### PR TITLE
Fix package doc comment: no separating newline

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -8,5 +8,4 @@ which can be located at https://www.ecma-international.org/wp-content/uploads/EC
 
 Documentation and comments referencing an ECMA-335 section are prefixed with the symbol §.
 */
-
 package winmd


### PR DESCRIPTION
With the newline, `go doc .` doesn't include this comment. The comment needs to be adjacent to `package winmd` to show up.