### PR TITLE
Fix size calculation in codedIndexSize

### DIFF
--- a/layout.go
+++ b/layout.go
@@ -7,7 +7,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"math/bits"
 
 	"github.com/microsoft/go-winmd/flags"
 	"github.com/microsoft/go-winmd/internal/ecma335"
@@ -87,14 +86,7 @@ func codedIndexSize(e coded, tableRowCounts [tableMax]uint32) uint8 {
 		}
 	}
 
-	var logn byte
-	if len(tables) > 0 {
-		// bits.Len is effectively calculating log2(n)+1.
-		// We need log2(n), so subtract 1.
-		n := uint(len(tables))
-		logn = byte(bits.Len(n)) - 1
-	}
-	if maxRowCount < 1<<(16-logn) {
+	if maxRowCount <= 1<<(16-codedTagBits(e)) {
 		return 2
 	}
 	return 4


### PR DESCRIPTION
`codedIndexSize` uses a wrong size calculation, which can cause the `Constants` table to have a wrong size, and ruin the parsing of all subsequent tables.

Reference implementation - 
https://github.com/malwarefrank/dnfile/blob/master/src/dnfile/base.py#L512C46-L512C46

For example, when parsing the attached file - 
[Microsoft.CodeAnalysis.zip](https://github.com/microsoft/go-winmd/files/13799016/Microsoft.CodeAnalysis.zip)
The `width` of the `Constants` table should be 10, but shows up as 8
