### PR TITLE
Add reusable line endings check workflow

### DIFF
--- a/.github/workflows/check-line-endings.yml
+++ b/.github/workflows/check-line-endings.yml
@@ -1,0 +1,14 @@
+name: Check Line Endings
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  check-line-endings:
+    uses: microsoft/go-infra/.github/workflows/check-line-endings.yml@944d1d054c1265bf35b6632d42682217330907c4 # main

--- a/.github/workflows/check-line-endings.yml
+++ b/.github/workflows/check-line-endings.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   check-line-endings:
-    uses: microsoft/go-infra/.github/workflows/check-line-endings.yml@944d1d054c1265bf35b6632d42682217330907c4 # main
+    uses: microsoft/go-infra/.github/workflows/check-line-endings.yml@944d1d054c1265bf35b6632d42682217330907c4


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to the repository to check for line ending consistency on pushes and pull requests targeting the `main` branch.

* Continuous Integration:
  * Added `.github/workflows/check-line-endings.yml` workflow to automatically check line endings using a reusable workflow from `microsoft/go-infra`. This helps ensure consistent line endings in the codebase.

- https://github.com/microsoft/go-lab/issues/297