### PR TITLE
Add idiomatic mkwinsyscall projection

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,14 +5,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.25.x, 1.26.x]
+        go-version: [1.26, 1.27]
         venv: [windows-2022, windows-2025, windows-11-arm]
     runs-on: ${{ matrix.venv }}
     steps:
-    - name: Install Go
-      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+    - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
         go-version: ${{ matrix.go-version }}
+        go-download-base-url: 'https://aka.ms/golang/release/latest'
     - name: Checkout code
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Run Test - Build

--- a/cmd/gowinmd/README.md
+++ b/cmd/gowinmd/README.md
@@ -8,12 +8,13 @@ See [go-winmd#8](https://github.com/microsoft/go-winmd/issues/8)
 ## Usage
 
 ```
-gowinmd -source <path/to/Windows.Win32.winmd> -format mkwinsyscall [-output <output.go>] <input.go ...>
+gowinmd -source <path/to/Windows.Win32.winmd> -format mkwinsyscall [-projection raw|idiomatic] [-output <output.go>] <input.go ...>
 ```
 ### Flags
 
 - `-source` — Path to the win32metadata (winmd) file to parse (required).
 - `-format` — Output format (required). Supported values: `mkwinsyscall`.
+- `-projection` — Signature projection. `raw` (the default) preserves literal ABI parameters. `idiomatic` uses metadata-backed slices, normal Go string element pointers, and the mkwinsyscall NTSTATUS error convention.
 - `-output` — Output file name. Prints to stdout if omitted.
 
 Input Go files are scanned for `//winmd:func` directives that specify which APIs to generate. The package name for the generated output is inferred from the input files.
@@ -40,6 +41,31 @@ This directive supports the following optional flags:
   
         //winmd:func kernel32.CreateFileW -name CreateFile
 
+The requested `-name` is emitted exactly, including its capitalization. Both exported and
+unexported valid Go identifiers are supported.
+
 ## Output
 
 `gowinmd` generates a complete Go source file with auto-detected imports and type aliases based on the generated content. The package name is inferred from the input Go files.
+
+Module references in directives use their WinMD names, which commonly include `.dll`:
+
+```go
+//winmd:func bcrypt.dll.BCryptGetProperty
+```
+
+The mkwinsyscall target omits that suffix because mkwinsyscall adds it while loading the DLL:
+
+```go
+//sys BCryptGetProperty(hObject BCRYPT_HANDLE, pszProperty *uint16, pbOutput []byte, pcbResult *uint32, dwFlags uint32) (ntstatus error) = bcrypt.BCryptGetProperty
+```
+
+In `idiomatic` projection, a pointer and its immediately following length are coalesced only when
+`NativeArrayInfoAttribute` or `MemorySizeAttribute` explicitly associates them. This preserves the
+native argument order while letting mkwinsyscall expand a slice back to pointer and length arguments.
+Input, output, optional, and nullable buffers all use this convention. An empty or nil slice passes
+a nil pointer and zero length. APIs that require a non-nil pointer for zero-length input still need a
+handwritten wrapper and can use `-projection raw` as the escape hatch.
+
+Only `NTSTATUS` returns become `(ntstatus error)`. mkwinsyscall preserves a nonzero status as
+`windows.NTStatus` and returns nil on success; other numeric return typedefs remain unchanged.

--- a/cmd/gowinmd/internal/gowinmd/gowinmd.go
+++ b/cmd/gowinmd/internal/gowinmd/gowinmd.go
@@ -79,6 +79,11 @@ type Context struct {
 	// unresolvableTypeRefs is a set of TypeRefs that were discovered but unable to be resolved
 	// inside the current module.
 	unresolvableTypeRefs map[typeNameKey]winmd.TypeRef
+	// projectedTypeDefs contains native typedefs replaced with their underlying Go pointer type.
+	projectedTypeDefs map[winmd.Index]bool
+	// requiredTypeDefs contains projected typedefs that are also referenced by generated declarations.
+	requiredTypeDefs map[winmd.Index]bool
+	projectingType   bool
 
 	// The maps below index commonly used winmd table relationships to allow fast access when
 	// interpreting the metadata and writing the Go source code. This helps with (e.g.) traversing
@@ -94,10 +99,27 @@ type Context struct {
 	typeDefSupportedArch map[winmd.Index]Arch
 	// methodDefSupportedArch maps MethodDef -> the Value of the SupportedArchitectureAttribute on that method.
 	methodDefSupportedArch map[winmd.Index]Arch
+	// paramSizeIndex maps Param -> the zero-based parameter index that supplies its element or byte count.
+	paramSizeIndex map[winmd.Index]uint16
 	// fieldOffset maps Field -> the Value of the FieldIndexAttribute on that field.
 	fieldOffset map[winmd.Index]uint32
 	// nestedTypeDefChildren maps TypeDef -> all of its child (nested) TypeDefs.
 	nestedTypeDefChildren map[winmd.Index][]winmd.Index
+}
+
+// Projection controls whether signatures preserve the literal WinMD ABI types or use
+// mkwinsyscall conventions that provide more idiomatic Go wrappers.
+type Projection uint8
+
+const (
+	ProjectionRaw Projection = iota
+	ProjectionIdiomatic
+)
+
+// MethodOptions controls how WriteMethodWithOptions formats a method.
+type MethodOptions struct {
+	GoName     string
+	Projection Projection
 }
 
 // NewContext creates a Context. Reads some tables in their entirety to fill in internal index maps
@@ -108,12 +130,15 @@ func NewContext(f *winmd.Metadata) (*Context, error) {
 		typeDefCache:         *newTypeDefCache(),
 		resolvedDefsByIndex:  make(map[winmd.Index]*resolvedDef),
 		unresolvableTypeRefs: make(map[typeNameKey]winmd.TypeRef),
+		projectedTypeDefs:    make(map[winmd.Index]bool),
+		requiredTypeDefs:     make(map[winmd.Index]bool),
 
 		methodDefImplMap:              make(map[winmd.Index]winmd.ImplMap),
 		fieldConstant:                 make(map[winmd.Index]winmd.Constant),
 		typeDefNativeTypedefAttribute: make(map[winmd.Index]winmd.CustomAttribute),
 		typeDefSupportedArch:          make(map[winmd.Index]Arch),
 		methodDefSupportedArch:        make(map[winmd.Index]Arch),
+		paramSizeIndex:                make(map[winmd.Index]uint16),
 		fieldOffset:                   make(map[winmd.Index]uint32),
 		nestedTypeDefChildren:         make(map[winmd.Index][]winmd.Index),
 	}
@@ -189,6 +214,21 @@ func NewContext(f *winmd.Metadata) (*Context, error) {
 		switch c.Namespace.String() {
 		case "Windows.Win32.Foundation.Metadata", "Windows.Win32.Interop": // The former is legacy
 			switch c.Name.String() {
+			case "NativeArrayInfoAttribute", "MemorySizeAttribute":
+				if a.Parent.Tag != winmd.HasCustomAttribute_Param {
+					break
+				}
+				fieldName := "CountParamIndex"
+				if c.Name.String() == "MemorySizeAttribute" {
+					fieldName = "BytesParamIndex"
+				}
+				index, ok, err := decodeInt16AttributeField(a.Value, fieldName)
+				if err != nil {
+					return nil, fmt.Errorf("decode %s on parameter %v: %w", c.Name, a.Parent.Index, err)
+				}
+				if ok && index >= 0 {
+					l.paramSizeIndex[a.Parent.Index] = uint16(index)
+				}
 			case "NativeTypedefAttribute":
 				if a.Parent.Tag != winmd.HasCustomAttribute_TypeDef {
 					break
@@ -250,6 +290,78 @@ func NewContext(f *winmd.Metadata) (*Context, error) {
 	return l, nil
 }
 
+func decodeInt16AttributeField(value []byte, wanted string) (int16, bool, error) {
+	if len(value) < 4 || value[0] != 1 || value[1] != 0 {
+		return 0, false, errors.New("invalid custom attribute prolog")
+	}
+	namedCount := int(binary.LittleEndian.Uint16(value[2:4]))
+	value = value[4:]
+	for range namedCount {
+		if len(value) < 2 || (value[0] != 0x53 && value[0] != 0x54) {
+			return 0, false, errors.New("unsupported custom attribute named argument")
+		}
+		fieldType := winmd.ElementType(value[1])
+		value = value[2:]
+		name, rest, err := decodeAttributeString(value)
+		if err != nil {
+			return 0, false, errors.New("invalid custom attribute field name")
+		}
+		value = rest
+		if name == wanted {
+			if fieldType != winmd.ElementType_I2 || len(value) < 2 {
+				return 0, false, fmt.Errorf("field %s is not an int16", wanted)
+			}
+			return int16(binary.LittleEndian.Uint16(value[:2])), true, nil
+		}
+		var size int
+		switch fieldType {
+		case winmd.ElementType_BOOLEAN, winmd.ElementType_I1, winmd.ElementType_U1:
+			size = 1
+		case winmd.ElementType_CHAR, winmd.ElementType_I2, winmd.ElementType_U2:
+			size = 2
+		case winmd.ElementType_I4, winmd.ElementType_U4, winmd.ElementType_R4:
+			size = 4
+		case winmd.ElementType_I8, winmd.ElementType_U8, winmd.ElementType_R8:
+			size = 8
+		case winmd.ElementType_STRING:
+			_, value, err = decodeAttributeString(value)
+			if err != nil {
+				return 0, false, err
+			}
+			continue
+		default:
+			return 0, false, fmt.Errorf("unsupported custom attribute field type %v", fieldType)
+		}
+		if len(value) < size {
+			return 0, false, errors.New("truncated custom attribute field value")
+		}
+		value = value[size:]
+	}
+	return 0, false, nil
+}
+
+func decodeAttributeString(value []byte) (string, []byte, error) {
+	if len(value) == 0 || value[0] == 0xff {
+		return "", nil, errors.New("null or truncated custom attribute string")
+	}
+	var length, prefix int
+	switch {
+	case value[0]&0x80 == 0:
+		length, prefix = int(value[0]), 1
+	case value[0]&0xc0 == 0x80 && len(value) >= 2:
+		length, prefix = int(value[0]&0x3f)<<8|int(value[1]), 2
+	case value[0]&0xe0 == 0xc0 && len(value) >= 4:
+		length = int(value[0]&0x1f)<<24 | int(value[1])<<16 | int(value[2])<<8 | int(value[3])
+		prefix = 4
+	default:
+		return "", nil, errors.New("invalid custom attribute string length")
+	}
+	if len(value) < prefix+length {
+		return "", nil, errors.New("truncated custom attribute string")
+	}
+	return string(value[prefix : prefix+length]), value[prefix+length:], nil
+}
+
 // MethodDefSupportedArch returns the set of architectures that the given method is supported on.
 func (c *Context) MethodDefSupportedArch(idx winmd.Index) Arch {
 	v, ok := c.methodDefSupportedArch[idx]
@@ -303,13 +415,23 @@ func (c *Context) TypeDefSupportedArch(idx winmd.Index) Arch {
 //
 // goNameOverride, if non-empty, replaces the default Go function name.
 func (c *Context) WriteMethod(w io.StringWriter, methodIndex winmd.Index, method winmd.MethodDef, arch Arch, goNameOverride string) error {
+	return c.WriteMethodWithOptions(w, methodIndex, method, arch, MethodOptions{GoName: goNameOverride})
+}
+
+// WriteMethodWithOptions writes a signature with the requested projection options.
+func (c *Context) WriteMethodWithOptions(w io.StringWriter, methodIndex winmd.Index, method winmd.MethodDef, arch Arch, options MethodOptions) error {
 	goName := method.Name.String()
-	if goNameOverride != "" {
-		goName = goNameOverride
+	if options.GoName != "" {
+		goName = options.GoName
+		if !token.IsIdentifier(goName) {
+			return fmt.Errorf("invalid Go function name %q", goName)
+		}
+	} else if !token.IsIdentifier(goName) {
+		goName = escapedUpper(goName)
 	}
 
 	w.WriteString("//sys\t")
-	w.WriteString(escapedUpper(goName))
+	w.WriteString(goName)
 	w.WriteString("(")
 
 	sig, err := c.Metadata.MethodDefSignature(method.Signature)
@@ -317,6 +439,8 @@ func (c *Context) WriteMethod(w io.StringWriter, methodIndex winmd.Index, method
 		return err
 	}
 
+	params := make([]winmd.Param, len(sig.Param))
+	paramRows := make([]winmd.Index, len(sig.Param))
 	for paramRowIndex := range method.ParamList.All() {
 		param, err := c.Metadata.Tables.Param.At(paramRowIndex)
 		if err != nil {
@@ -340,16 +464,41 @@ func (c *Context) WriteMethod(w io.StringWriter, methodIndex winmd.Index, method
 		// Note: this assumes there are no gaps in Sequence values, but technically gaps are
 		// possible per §II.22.33 information point 5. See https://github.com/microsoft/go-winmd/issues/10
 		i := param.Sequence - 1
-		if i > 0 {
-			w.WriteString(", ")
-		}
-		w.WriteString(escapeParam(param.Name.String()))
-		w.WriteString(" ")
-
 		if int(i) >= len(sig.Param) {
 			return fmt.Errorf("param record Sequence value %v is out of range of parsed signature params, length %v", i, len(sig.Param))
 		}
-		if err := c.writeType(w, &sig.Param[i].Type, arch); err != nil {
+		params[i] = param
+		paramRows[i] = paramRowIndex
+	}
+
+	wroteParam := false
+	for i, param := range params {
+		if options.Projection == ProjectionIdiomatic && i > 0 {
+			if sizeIndex, ok := c.paramSizeIndex[paramRows[i-1]]; ok && int(sizeIndex) == i {
+				continue
+			}
+		}
+		if wroteParam {
+			w.WriteString(", ")
+		}
+		wroteParam = true
+		w.WriteString(escapeParam(param.Name.String()))
+		w.WriteString(" ")
+
+		projectSlice := false
+		if options.Projection == ProjectionIdiomatic && i+1 < len(params) {
+			sizeIndex, ok := c.paramSizeIndex[paramRows[i]]
+			projectSlice = ok && int(sizeIndex) == i+1
+		}
+		var err error
+		if projectSlice {
+			err = c.writeSliceType(w, &sig.Param[i].Type, arch)
+		} else if options.Projection == ProjectionIdiomatic {
+			err = c.writeProjectedType(w, &sig.Param[i].Type, arch)
+		} else {
+			err = c.writeType(w, &sig.Param[i].Type, arch)
+		}
+		if err != nil {
 			return fmt.Errorf("failed to interpret type of param %v of method %v: %w", i, method.Name, err)
 		}
 	}
@@ -366,7 +515,7 @@ func (c *Context) WriteMethod(w io.StringWriter, methodIndex winmd.Index, method
 		if err != nil {
 			return err
 		}
-		moduleName = strings.ToLower(mr.Name.String())
+		moduleName = mkwinsyscallModuleName(mr.Name.String())
 		if moduleName == "kernel32" {
 			moduleName = ""
 		}
@@ -376,11 +525,17 @@ func (c *Context) WriteMethod(w io.StringWriter, methodIndex winmd.Index, method
 	if value := sig.RetType.Kind != winmd.SigRetTypeKind_Void; value || lastErr {
 		w.WriteString(" (")
 		if value {
+			if options.Projection == ProjectionIdiomatic && c.isTypeNamed(&sig.RetType.Type, arch, "NTSTATUS") {
+				w.WriteString("ntstatus error")
+				value = false
+			}
 			// General return value name, because mkwinsyscall needs one.
 			// Generated returns in general could be better. See https://github.com/microsoft/go-winmd/issues/12
-			w.WriteString("r ")
-			if err := c.writeType(w, &sig.RetType.Type, arch); err != nil {
-				return err
+			if value {
+				w.WriteString("r ")
+				if err := c.writeType(w, &sig.RetType.Type, arch); err != nil {
+					return err
+				}
 			}
 			if lastErr {
 				w.WriteString(", ")
@@ -402,6 +557,71 @@ func (c *Context) WriteMethod(w io.StringWriter, methodIndex winmd.Index, method
 		w.WriteString(method.Name.String())
 	}
 	return nil
+}
+
+func mkwinsyscallModuleName(moduleName string) string {
+	return strings.TrimSuffix(strings.ToLower(moduleName), ".dll")
+}
+
+func (c *Context) writeProjectedType(w io.StringWriter, p *winmd.SigType, arch Arch) error {
+	var rendered strings.Builder
+	c.projectingType = true
+	err := c.writeType(&rendered, p, arch)
+	c.projectingType = false
+	if err != nil {
+		return err
+	}
+	typeName := rendered.String()
+	if strings.HasPrefix(typeName, "*") && strings.HasSuffix(typeName, "Element") {
+		for _, def := range c.resolvedDefsByIndex {
+			if def.NativePointer && typeName == "*"+def.GoName {
+				c.projectedTypeDefs[def.Index] = true
+				var native strings.Builder
+				if err := c.writeTypeDefNativeUnderlying(&native, def, arch); err != nil {
+					return err
+				}
+				w.WriteString("*")
+				w.WriteString(native.String())
+				return nil
+			}
+		}
+	}
+	w.WriteString(typeName)
+	return nil
+}
+
+func (c *Context) writeSliceType(w io.StringWriter, p *winmd.SigType, arch Arch) error {
+	var rendered strings.Builder
+	if err := c.writeProjectedType(&rendered, p, arch); err != nil {
+		return err
+	}
+	typeName := rendered.String()
+	if !strings.HasPrefix(typeName, "*") {
+		return fmt.Errorf("array metadata applied to non-pointer type %s", typeName)
+	}
+	w.WriteString("[]")
+	elementType := strings.TrimPrefix(typeName, "*")
+	if elementType == "uint8" {
+		elementType = "byte"
+	}
+	w.WriteString(elementType)
+	return nil
+}
+
+func (c *Context) isTypeNamed(p *winmd.SigType, _ Arch, name string) bool {
+	v, ok := p.Value.(winmd.CodedIndex[winmd.TypeDefOrRefOrSpec])
+	if !ok {
+		return false
+	}
+	switch v.Tag {
+	case winmd.TypeDefOrRefOrSpec_TypeDef:
+		def, err := c.Metadata.Tables.TypeDef.At(v.Index)
+		return err == nil && def.Name.String() == name
+	case winmd.TypeDefOrRefOrSpec_TypeRef:
+		ref, err := c.Metadata.Tables.TypeRef.At(v.Index)
+		return err == nil && ref.Name.String() == name
+	}
+	return false
 }
 
 func (c *Context) writeType(w io.StringWriter, p *winmd.SigType, arch Arch) error {
@@ -484,6 +704,9 @@ func (c *Context) writeType(w io.StringWriter, p *winmd.SigType, arch Arch) erro
 					if def.NeedsPointerWhenUsed() {
 						w.WriteString("*")
 					}
+					if !c.projectingType {
+						c.requiredTypeDefs[def.Index] = true
+					}
 					w.WriteString(def.GoName)
 				case winmd.TypeDefOrRefOrSpec_TypeRef:
 					def, err := c.resolveTypeRef(v.Index, arch)
@@ -500,6 +723,9 @@ func (c *Context) writeType(w io.StringWriter, p *winmd.SigType, arch Arch) erro
 					} else {
 						if def.NeedsPointerWhenUsed() {
 							w.WriteString("*")
+						}
+						if !c.projectingType {
+							c.requiredTypeDefs[def.Index] = true
 						}
 						w.WriteString(def.GoName)
 					}
@@ -839,6 +1065,14 @@ func (c *Context) writeTypeDefNative(w io.StringWriter, r *resolvedDef, arch Arc
 	w.WriteString("type ")
 	w.WriteString(r.GoName)
 	w.WriteString(" ")
+	if err := c.writeTypeDefNativeUnderlying(w, r, arch); err != nil {
+		return err
+	}
+	w.WriteString("\n")
+	return nil
+}
+
+func (c *Context) writeTypeDefNativeUnderlying(w io.StringWriter, r *resolvedDef, arch Arch) error {
 	if r.def.FieldList.Start+1 != r.def.FieldList.End {
 		return fmt.Errorf("expected exactly one field for native typedef %v", r.def.Name)
 	}
@@ -858,7 +1092,6 @@ func (c *Context) writeTypeDefNative(w io.StringWriter, r *resolvedDef, arch Arc
 	if err := c.writeType(w, &signature.Type, arch); err != nil {
 		return err
 	}
-	w.WriteString("\n")
 	return nil
 }
 
@@ -946,6 +1179,9 @@ func (c *Context) WriteUsedTypeDefs(b map[Arch]*strings.Builder) error {
 	written := make(map[*resolvedDef]struct{})
 	for {
 		usedTypeDefs := c.typeDefCache.collect(func(r *resolvedDef) bool {
+			if c.projectedTypeDefs[r.Index] && !c.requiredTypeDefs[r.Index] {
+				return false
+			}
 			if _, ok := written[r]; !ok {
 				written[r] = struct{}{}
 				return true

--- a/cmd/gowinmd/internal/gowinmd/gowinmd_test.go
+++ b/cmd/gowinmd/internal/gowinmd/gowinmd_test.go
@@ -4,11 +4,41 @@
 package gowinmd
 
 import (
+	"encoding/binary"
 	"strings"
 	"testing"
 
 	"github.com/microsoft/go-winmd/winmd"
 )
+
+func TestDecodeInt16AttributeField(t *testing.T) {
+	value := []byte{1, 0, 1, 0, 0x53, byte(winmd.ElementType_I2), 15}
+	value = append(value, "CountParamIndex"...)
+	value = binary.LittleEndian.AppendUint16(value, 3)
+
+	got, ok, err := decodeInt16AttributeField(value, "CountParamIndex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || got != 3 {
+		t.Fatalf("decodeInt16AttributeField() = %v, %v; want 3, true", got, ok)
+	}
+}
+
+func TestMkwinsyscallModuleName(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		want string
+	}{
+		{"bcrypt.dll", "bcrypt"},
+		{"BCRYPT.DLL", "bcrypt"},
+		{"bcrypt", "bcrypt"},
+	} {
+		if got := mkwinsyscallModuleName(test.name); got != test.want {
+			t.Errorf("mkwinsyscallModuleName(%q) = %q; want %q", test.name, got, test.want)
+		}
+	}
+}
 
 func TestContext_writeType_cycle(t *testing.T) {
 	t.Skip("cycles can't be built with SigType rather than *SigType, and this code only supports SigType")

--- a/cmd/gowinmd/main.go
+++ b/cmd/gowinmd/main.go
@@ -30,6 +30,7 @@ func Run() error {
 	source := flag.String("source", "", "The win32metadata file to parse and generate signatures for.")
 	output := flag.String("output", "", "Output file name (prints to stdout if omitted).")
 	formatFlag := flag.String("format", "", "Output format. Required. Supported values: mkwinsyscall.")
+	projectionFlag := flag.String("projection", "raw", "Signature projection. Supported values: raw, idiomatic.")
 
 	flag.Parse()
 
@@ -38,6 +39,15 @@ func Run() error {
 	}
 	if *formatFlag != "mkwinsyscall" {
 		return fmt.Errorf("format is required: pass -format mkwinsyscall (got %q)", *formatFlag)
+	}
+	var projection gowinmd.Projection
+	switch *projectionFlag {
+	case "raw":
+		projection = gowinmd.ProjectionRaw
+	case "idiomatic":
+		projection = gowinmd.ProjectionIdiomatic
+	default:
+		return fmt.Errorf("unsupported projection %q: use raw or idiomatic", *projectionFlag)
 	}
 
 	inputFiles := flag.Args()
@@ -66,7 +76,7 @@ func Run() error {
 		gowinmd.ArchNone:  {},
 	}
 
-	if err := writePrototypes(b, f, filter); err != nil {
+	if err := writePrototypesWithProjection(b, f, filter, projection); err != nil {
 		return err
 	}
 
@@ -189,6 +199,10 @@ func parseDirective(s string) (ref, goName string) {
 type methodFilter map[string]string
 
 func writePrototypes(b map[gowinmd.Arch]*strings.Builder, f *winmd.Metadata, filter methodFilter) error {
+	return writePrototypesWithProjection(b, f, filter, gowinmd.ProjectionRaw)
+}
+
+func writePrototypesWithProjection(b map[gowinmd.Arch]*strings.Builder, f *winmd.Metadata, filter methodFilter, projection gowinmd.Projection) error {
 	context, err := gowinmd.NewContext(f)
 	if err != nil {
 		return err
@@ -239,7 +253,8 @@ func writePrototypes(b map[gowinmd.Arch]*strings.Builder, f *winmd.Metadata, fil
 				}
 				w.WriteString("\n")
 
-				if err := context.WriteMethod(w, j, md, arch, override); err != nil {
+				options := gowinmd.MethodOptions{GoName: override, Projection: projection}
+				if err := context.WriteMethodWithOptions(w, j, md, arch, options); err != nil {
 					// Include context in the error for diag purposes.
 					// writeSys may have partially written into b. This is actually convenient for diag.
 					lines := strings.Split(w.String(), "\n")

--- a/cmd/gowinmd/main_test.go
+++ b/cmd/gowinmd/main_test.go
@@ -13,18 +13,22 @@ import (
 	"github.com/microsoft/go-winmd/winmd"
 )
 
-func TestWriteMethod(t *testing.T) {
-	f, err := openTestWinmd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	b := map[gowinmd.Arch]*strings.Builder{
+func newArchBuilders() map[gowinmd.Arch]*strings.Builder {
+	return map[gowinmd.Arch]*strings.Builder{
 		gowinmd.Arch386:   {},
 		gowinmd.ArchAMD64: {},
 		gowinmd.ArchARM64: {},
 		gowinmd.ArchAll:   {},
 		gowinmd.ArchNone:  {},
 	}
+}
+
+func TestWriteMethod(t *testing.T) {
+	f, err := openTestWinmd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	b := newArchBuilders()
 	filter, err := buildNamespaceFilter(f,
 		"Windows.Win32.Storage.FileSystem",
 		"Windows.Win32.Security.Cryptography",
@@ -53,18 +57,68 @@ func TestWriteMethod(t *testing.T) {
 	}
 }
 
+func TestWriteProjectedBCryptMethods(t *testing.T) {
+	f, err := openTestWinmd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	b := newArchBuilders()
+	filter := methodFilter{}
+	for _, name := range []string{
+		"BCryptGetFipsAlgorithmMode", "BCryptGetProperty", "BCryptSetProperty",
+		"BCryptOpenAlgorithmProvider", "BCryptCreateHash", "BCryptHashData",
+		"BCryptEncrypt", "BCryptDecrypt", "BCryptGenerateSymmetricKey",
+		"BCryptSignHash", "BCryptDeriveKey",
+	} {
+		filter[strings.ToLower("bcrypt.dll."+name)] = ""
+	}
+	filter["bcrypt.dll.bcrypthashdata"] = "rawEncrypt"
+
+	if err := writePrototypesWithProjection(b, f, filter, gowinmd.ProjectionIdiomatic); err != nil {
+		t.Fatal(err)
+	}
+	got := b[gowinmd.ArchAll].String()
+	wants := []string{
+		"//sys\tBCryptGetProperty(hObject BCRYPT_HANDLE, pszProperty *uint16, pbOutput []byte, pcbResult *uint32, dwFlags uint32) (ntstatus error) = bcrypt.BCryptGetProperty",
+		"//sys\tBCryptSetProperty(hObject BCRYPT_HANDLE, pszProperty *uint16, pbInput []byte, dwFlags uint32) (ntstatus error) = bcrypt.BCryptSetProperty",
+		"//sys\trawEncrypt(hHash BCRYPT_HASH_HANDLE, pbInput []byte, dwFlags uint32) (ntstatus error) = bcrypt.BCryptHashData",
+	}
+	for _, want := range wants {
+		if !strings.Contains(got, want) {
+			t.Errorf("projected output does not contain %q\noutput:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, ".dll.") || strings.Contains(got, "PWSTRElement") {
+		t.Errorf("projected output contains an unnormalized DLL or synthetic string element type:\n%s", got)
+	}
+	if !strings.Contains(got, "BCRYPT_BLOCK_PADDING BCRYPT_FLAGS = 0x1") ||
+		!strings.Contains(got, "BCRYPT_PAD_NONE BCRYPT_FLAGS = 0x1") {
+		t.Errorf("projected output did not preserve duplicate constant values:\n%s", got)
+	}
+}
+
+func TestIdiomaticProjectionDoesNotProjectHRESULT(t *testing.T) {
+	f, err := openTestWinmd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	b := newArchBuilders()
+	filter := methodFilter{"ncrypt.dll.ncryptgetproperty": ""}
+	if err := writePrototypesWithProjection(b, f, filter, gowinmd.ProjectionIdiomatic); err != nil {
+		t.Fatal(err)
+	}
+	got := b[gowinmd.ArchAll].String()
+	if !strings.Contains(got, "(r HRESULT) = ncrypt.NCryptGetProperty") {
+		t.Fatalf("HRESULT return was unexpectedly projected:\n%s", got)
+	}
+}
+
 func TestFullFile(t *testing.T) {
 	f, err := openTestWinmd()
 	if err != nil {
 		t.Fatal(err)
 	}
-	b := map[gowinmd.Arch]*strings.Builder{
-		gowinmd.Arch386:   {},
-		gowinmd.ArchAMD64: {},
-		gowinmd.ArchARM64: {},
-		gowinmd.ArchAll:   {},
-		gowinmd.ArchNone:  {},
-	}
+	b := newArchBuilders()
 	if err := writePrototypes(b, f, nil); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/gowinmd/testdata/prototypes.golden.go
+++ b/cmd/gowinmd/testdata/prototypes.golden.go
@@ -1,1181 +1,1181 @@
 
 
 // APIs for Windows.Win32.Security.Cryptography
-//sys	SystemPrng(pbRandomData *uint8, cbRandomData uintptr) (r BOOL) = bcryptprimitives.dll.SystemPrng
-//sys	ProcessPrng(pbData *uint8, cbData uintptr) (r BOOL) = bcryptprimitives.dll.ProcessPrng
-//sys	CryptAcquireContextA(phProv *uintptr, szContainer *PSTRElement, szProvider *PSTRElement, dwProvType uint32, dwFlags uint32) (r BOOL, err error) = advapi32.dll.CryptAcquireContextA
-//sys	CryptAcquireContextW(phProv *uintptr, szContainer *PWSTRElement, szProvider *PWSTRElement, dwProvType uint32, dwFlags uint32) (r BOOL, err error) = advapi32.dll.CryptAcquireContextW
-//sys	CryptReleaseContext(hProv uintptr, dwFlags uint32) (r BOOL, err error) = advapi32.dll.CryptReleaseContext
-//sys	CryptGenKey(hProv uintptr, Algid ALG_ID, dwFlags CRYPT_KEY_FLAGS, phKey *uintptr) (r BOOL, err error) = advapi32.dll.CryptGenKey
-//sys	CryptDeriveKey(hProv uintptr, Algid ALG_ID, hBaseData uintptr, dwFlags uint32, phKey *uintptr) (r BOOL, err error) = advapi32.dll.CryptDeriveKey
-//sys	CryptDestroyKey(hKey uintptr) (r BOOL, err error) = advapi32.dll.CryptDestroyKey
-//sys	CryptSetKeyParam(hKey uintptr, dwParam CRYPT_KEY_PARAM_ID, pbData *uint8, dwFlags uint32) (r BOOL, err error) = advapi32.dll.CryptSetKeyParam
-//sys	CryptGetKeyParam(hKey uintptr, dwParam CRYPT_KEY_PARAM_ID, pbData *uint8, pdwDataLen *uint32, dwFlags uint32) (r BOOL, err error) = advapi32.dll.CryptGetKeyParam
-//sys	CryptSetHashParam(hHash uintptr, dwParam CRYPT_SET_HASH_PARAM, pbData *uint8, dwFlags uint32) (r BOOL, err error) = advapi32.dll.CryptSetHashParam
-//sys	CryptGetHashParam(hHash uintptr, dwParam uint32, pbData *uint8, pdwDataLen *uint32, dwFlags uint32) (r BOOL, err error) = advapi32.dll.CryptGetHashParam
-//sys	CryptSetProvParam(hProv uintptr, dwParam CRYPT_SET_PROV_PARAM_ID, pbData *uint8, dwFlags uint32) (r BOOL, err error) = advapi32.dll.CryptSetProvParam
-//sys	CryptGetProvParam(hProv uintptr, dwParam uint32, pbData *uint8, pdwDataLen *uint32, dwFlags uint32) (r BOOL, err error) = advapi32.dll.CryptGetProvParam
-//sys	CryptGenRandom(hProv uintptr, dwLen uint32, pbBuffer *uint8) (r BOOL, err error) = advapi32.dll.CryptGenRandom
-//sys	CryptGetUserKey(hProv uintptr, dwKeySpec uint32, phUserKey *uintptr) (r BOOL, err error) = advapi32.dll.CryptGetUserKey
-//sys	CryptExportKey(hKey uintptr, hExpKey uintptr, dwBlobType uint32, dwFlags CRYPT_KEY_FLAGS, pbData *uint8, pdwDataLen *uint32) (r BOOL, err error) = advapi32.dll.CryptExportKey
-//sys	CryptImportKey(hProv uintptr, pbData *uint8, dwDataLen uint32, hPubKey uintptr, dwFlags CRYPT_KEY_FLAGS, phKey *uintptr) (r BOOL, err error) = advapi32.dll.CryptImportKey
-//sys	CryptEncrypt(hKey uintptr, hHash uintptr, Final BOOL, dwFlags uint32, pbData *uint8, pdwDataLen *uint32, dwBufLen uint32) (r BOOL, err error) = advapi32.dll.CryptEncrypt
-//sys	CryptDecrypt(hKey uintptr, hHash uintptr, Final BOOL, dwFlags uint32, pbData *uint8, pdwDataLen *uint32) (r BOOL, err error) = advapi32.dll.CryptDecrypt
-//sys	CryptCreateHash(hProv uintptr, Algid ALG_ID, hKey uintptr, dwFlags uint32, phHash *uintptr) (r BOOL, err error) = advapi32.dll.CryptCreateHash
-//sys	CryptHashData(hHash uintptr, pbData *uint8, dwDataLen uint32, dwFlags uint32) (r BOOL, err error) = advapi32.dll.CryptHashData
-//sys	CryptHashSessionKey(hHash uintptr, hKey uintptr, dwFlags uint32) (r BOOL, err error) = advapi32.dll.CryptHashSessionKey
-//sys	CryptDestroyHash(hHash uintptr) (r BOOL, err error) = advapi32.dll.CryptDestroyHash
-//sys	CryptSignHashA(hHash uintptr, dwKeySpec uint32, szDescription *PSTRElement, dwFlags uint32, pbSignature *uint8, pdwSigLen *uint32) (r BOOL, err error) = advapi32.dll.CryptSignHashA
-//sys	CryptSignHashW(hHash uintptr, dwKeySpec uint32, szDescription *PWSTRElement, dwFlags uint32, pbSignature *uint8, pdwSigLen *uint32) (r BOOL, err error) = advapi32.dll.CryptSignHashW
-//sys	CryptVerifySignatureA(hHash uintptr, pbSignature *uint8, dwSigLen uint32, hPubKey uintptr, szDescription *PSTRElement, dwFlags uint32) (r BOOL, err error) = advapi32.dll.CryptVerifySignatureA
-//sys	CryptVerifySignatureW(hHash uintptr, pbSignature *uint8, dwSigLen uint32, hPubKey uintptr, szDescription *PWSTRElement, dwFlags uint32) (r BOOL, err error) = advapi32.dll.CryptVerifySignatureW
-//sys	CryptSetProviderA(pszProvName *PSTRElement, dwProvType uint32) (r BOOL, err error) = advapi32.dll.CryptSetProviderA
-//sys	CryptSetProviderW(pszProvName *PWSTRElement, dwProvType uint32) (r BOOL, err error) = advapi32.dll.CryptSetProviderW
-//sys	CryptSetProviderExA(pszProvName *PSTRElement, dwProvType uint32, pdwReserved *uint32, dwFlags uint32) (r BOOL, err error) = advapi32.dll.CryptSetProviderExA
-//sys	CryptSetProviderExW(pszProvName *PWSTRElement, dwProvType uint32, pdwReserved *uint32, dwFlags uint32) (r BOOL, err error) = advapi32.dll.CryptSetProviderExW
-//sys	CryptGetDefaultProviderA(dwProvType uint32, pdwReserved *uint32, dwFlags uint32, pszProvName *PSTRElement, pcbProvName *uint32) (r BOOL, err error) = advapi32.dll.CryptGetDefaultProviderA
-//sys	CryptGetDefaultProviderW(dwProvType uint32, pdwReserved *uint32, dwFlags uint32, pszProvName *PWSTRElement, pcbProvName *uint32) (r BOOL, err error) = advapi32.dll.CryptGetDefaultProviderW
-//sys	CryptEnumProviderTypesA(dwIndex uint32, pdwReserved *uint32, dwFlags uint32, pdwProvType *uint32, szTypeName *PSTRElement, pcbTypeName *uint32) (r BOOL, err error) = advapi32.dll.CryptEnumProviderTypesA
-//sys	CryptEnumProviderTypesW(dwIndex uint32, pdwReserved *uint32, dwFlags uint32, pdwProvType *uint32, szTypeName *PWSTRElement, pcbTypeName *uint32) (r BOOL, err error) = advapi32.dll.CryptEnumProviderTypesW
-//sys	CryptEnumProvidersA(dwIndex uint32, pdwReserved *uint32, dwFlags uint32, pdwProvType *uint32, szProvName *PSTRElement, pcbProvName *uint32) (r BOOL, err error) = advapi32.dll.CryptEnumProvidersA
-//sys	CryptEnumProvidersW(dwIndex uint32, pdwReserved *uint32, dwFlags uint32, pdwProvType *uint32, szProvName *PWSTRElement, pcbProvName *uint32) (r BOOL, err error) = advapi32.dll.CryptEnumProvidersW
-//sys	CryptContextAddRef(hProv uintptr, pdwReserved *uint32, dwFlags uint32) (r BOOL, err error) = advapi32.dll.CryptContextAddRef
-//sys	CryptDuplicateKey(hKey uintptr, pdwReserved *uint32, dwFlags uint32, phKey *uintptr) (r BOOL, err error) = advapi32.dll.CryptDuplicateKey
-//sys	CryptDuplicateHash(hHash uintptr, pdwReserved *uint32, dwFlags uint32, phHash *uintptr) (r BOOL, err error) = advapi32.dll.CryptDuplicateHash
-//sys	BCryptOpenAlgorithmProvider(phAlgorithm *BCRYPT_ALG_HANDLE, pszAlgId *PWSTRElement, pszImplementation *PWSTRElement, dwFlags BCRYPT_OPEN_ALGORITHM_PROVIDER_FLAGS) (r NTSTATUS) = bcrypt.dll.BCryptOpenAlgorithmProvider
-//sys	BCryptEnumAlgorithms(dwAlgOperations BCRYPT_OPERATION, pAlgCount *uint32, ppAlgList **BCRYPT_ALGORITHM_IDENTIFIER, dwFlags uint32) (r NTSTATUS) = bcrypt.dll.BCryptEnumAlgorithms
-//sys	BCryptEnumProviders(pszAlgId *PWSTRElement, pImplCount *uint32, ppImplList **BCRYPT_PROVIDER_NAME, dwFlags uint32) (r NTSTATUS) = bcrypt.dll.BCryptEnumProviders
-//sys	BCryptGetProperty(hObject BCRYPT_HANDLE, pszProperty *PWSTRElement, pbOutput *uint8, cbOutput uint32, pcbResult *uint32, dwFlags uint32) (r NTSTATUS) = bcrypt.dll.BCryptGetProperty
-//sys	BCryptSetProperty(hObject BCRYPT_HANDLE, pszProperty *PWSTRElement, pbInput *uint8, cbInput uint32, dwFlags uint32) (r NTSTATUS) = bcrypt.dll.BCryptSetProperty
-//sys	BCryptCloseAlgorithmProvider(hAlgorithm BCRYPT_ALG_HANDLE, dwFlags uint32) (r NTSTATUS) = bcrypt.dll.BCryptCloseAlgorithmProvider
-//sys	BCryptFreeBuffer(pvBuffer unsafe.Pointer) = bcrypt.dll.BCryptFreeBuffer
-//sys	BCryptGenerateSymmetricKey(hAlgorithm BCRYPT_ALG_HANDLE, phKey *BCRYPT_KEY_HANDLE, pbKeyObject *uint8, cbKeyObject uint32, pbSecret *uint8, cbSecret uint32, dwFlags uint32) (r NTSTATUS) = bcrypt.dll.BCryptGenerateSymmetricKey
-//sys	BCryptGenerateKeyPair(hAlgorithm BCRYPT_ALG_HANDLE, phKey *BCRYPT_KEY_HANDLE, dwLength uint32, dwFlags uint32) (r NTSTATUS) = bcrypt.dll.BCryptGenerateKeyPair
-//sys	BCryptEncrypt(hKey BCRYPT_KEY_HANDLE, pbInput *uint8, cbInput uint32, pPaddingInfo unsafe.Pointer, pbIV *uint8, cbIV uint32, pbOutput *uint8, cbOutput uint32, pcbResult *uint32, dwFlags BCRYPT_FLAGS) (r NTSTATUS) = bcrypt.dll.BCryptEncrypt
-//sys	BCryptDecrypt(hKey BCRYPT_KEY_HANDLE, pbInput *uint8, cbInput uint32, pPaddingInfo unsafe.Pointer, pbIV *uint8, cbIV uint32, pbOutput *uint8, cbOutput uint32, pcbResult *uint32, dwFlags BCRYPT_FLAGS) (r NTSTATUS) = bcrypt.dll.BCryptDecrypt
-//sys	BCryptExportKey(hKey BCRYPT_KEY_HANDLE, hExportKey BCRYPT_KEY_HANDLE, pszBlobType *PWSTRElement, pbOutput *uint8, cbOutput uint32, pcbResult *uint32, dwFlags uint32) (r NTSTATUS) = bcrypt.dll.BCryptExportKey
-//sys	BCryptImportKey(hAlgorithm BCRYPT_ALG_HANDLE, hImportKey BCRYPT_KEY_HANDLE, pszBlobType *PWSTRElement, phKey *BCRYPT_KEY_HANDLE, pbKeyObject *uint8, cbKeyObject uint32, pbInput *uint8, cbInput uint32, dwFlags uint32) (r NTSTATUS) = bcrypt.dll.BCryptImportKey
-//sys	BCryptImportKeyPair(hAlgorithm BCRYPT_ALG_HANDLE, hImportKey BCRYPT_KEY_HANDLE, pszBlobType *PWSTRElement, phKey *BCRYPT_KEY_HANDLE, pbInput *uint8, cbInput uint32, dwFlags uint32) (r NTSTATUS) = bcrypt.dll.BCryptImportKeyPair
-//sys	BCryptDuplicateKey(hKey BCRYPT_KEY_HANDLE, phNewKey *BCRYPT_KEY_HANDLE, pbKeyObject *uint8, cbKeyObject uint32, dwFlags uint32) (r NTSTATUS) = bcrypt.dll.BCryptDuplicateKey
-//sys	BCryptFinalizeKeyPair(hKey BCRYPT_KEY_HANDLE, dwFlags uint32) (r NTSTATUS) = bcrypt.dll.BCryptFinalizeKeyPair
-//sys	BCryptDestroyKey(hKey BCRYPT_KEY_HANDLE) (r NTSTATUS) = bcrypt.dll.BCryptDestroyKey
-//sys	BCryptDestroySecret(hSecret BCRYPT_SECRET_HANDLE) (r NTSTATUS) = bcrypt.dll.BCryptDestroySecret
-//sys	BCryptSignHash(hKey BCRYPT_KEY_HANDLE, pPaddingInfo unsafe.Pointer, pbInput *uint8, cbInput uint32, pbOutput *uint8, cbOutput uint32, pcbResult *uint32, dwFlags BCRYPT_FLAGS) (r NTSTATUS) = bcrypt.dll.BCryptSignHash
-//sys	BCryptVerifySignature(hKey BCRYPT_KEY_HANDLE, pPaddingInfo unsafe.Pointer, pbHash *uint8, cbHash uint32, pbSignature *uint8, cbSignature uint32, dwFlags BCRYPT_FLAGS) (r NTSTATUS) = bcrypt.dll.BCryptVerifySignature
-//sys	BCryptSecretAgreement(hPrivKey BCRYPT_KEY_HANDLE, hPubKey BCRYPT_KEY_HANDLE, phAgreedSecret *BCRYPT_SECRET_HANDLE, dwFlags uint32) (r NTSTATUS) = bcrypt.dll.BCryptSecretAgreement
-//sys	BCryptDeriveKey(hSharedSecret BCRYPT_SECRET_HANDLE, pwszKDF *PWSTRElement, pParameterList *BCryptBufferDesc, pbDerivedKey *uint8, cbDerivedKey uint32, pcbResult *uint32, dwFlags uint32) (r NTSTATUS) = bcrypt.dll.BCryptDeriveKey
-//sys	BCryptKeyDerivation(hKey BCRYPT_KEY_HANDLE, pParameterList *BCryptBufferDesc, pbDerivedKey *uint8, cbDerivedKey uint32, pcbResult *uint32, dwFlags uint32) (r NTSTATUS) = bcrypt.dll.BCryptKeyDerivation
-//sys	BCryptCreateHash(hAlgorithm BCRYPT_ALG_HANDLE, phHash *BCRYPT_HASH_HANDLE, pbHashObject *uint8, cbHashObject uint32, pbSecret *uint8, cbSecret uint32, dwFlags uint32) (r NTSTATUS) = bcrypt.dll.BCryptCreateHash
-//sys	BCryptHashData(hHash BCRYPT_HASH_HANDLE, pbInput *uint8, cbInput uint32, dwFlags uint32) (r NTSTATUS) = bcrypt.dll.BCryptHashData
-//sys	BCryptFinishHash(hHash BCRYPT_HASH_HANDLE, pbOutput *uint8, cbOutput uint32, dwFlags uint32) (r NTSTATUS) = bcrypt.dll.BCryptFinishHash
-//sys	BCryptCreateMultiHash(hAlgorithm BCRYPT_ALG_HANDLE, phHash *BCRYPT_HASH_HANDLE, nHashes uint32, pbHashObject *uint8, cbHashObject uint32, pbSecret *uint8, cbSecret uint32, dwFlags uint32) (r NTSTATUS) = bcrypt.dll.BCryptCreateMultiHash
-//sys	BCryptProcessMultiOperations(hObject BCRYPT_HANDLE, operationType BCRYPT_MULTI_OPERATION_TYPE, pOperations unsafe.Pointer, cbOperations uint32, dwFlags uint32) (r NTSTATUS) = bcrypt.dll.BCryptProcessMultiOperations
-//sys	BCryptDuplicateHash(hHash BCRYPT_HASH_HANDLE, phNewHash *BCRYPT_HASH_HANDLE, pbHashObject *uint8, cbHashObject uint32, dwFlags uint32) (r NTSTATUS) = bcrypt.dll.BCryptDuplicateHash
-//sys	BCryptDestroyHash(hHash BCRYPT_HASH_HANDLE) (r NTSTATUS) = bcrypt.dll.BCryptDestroyHash
-//sys	BCryptHash(hAlgorithm BCRYPT_ALG_HANDLE, pbSecret *uint8, cbSecret uint32, pbInput *uint8, cbInput uint32, pbOutput *uint8, cbOutput uint32) (r NTSTATUS) = bcrypt.dll.BCryptHash
-//sys	BCryptGenRandom(hAlgorithm BCRYPT_ALG_HANDLE, pbBuffer *uint8, cbBuffer uint32, dwFlags BCRYPTGENRANDOM_FLAGS) (r NTSTATUS) = bcrypt.dll.BCryptGenRandom
-//sys	BCryptDeriveKeyCapi(hHash BCRYPT_HASH_HANDLE, hTargetAlg BCRYPT_ALG_HANDLE, pbDerivedKey *uint8, cbDerivedKey uint32, dwFlags uint32) (r NTSTATUS) = bcrypt.dll.BCryptDeriveKeyCapi
-//sys	BCryptDeriveKeyPBKDF2(hPrf BCRYPT_ALG_HANDLE, pbPassword *uint8, cbPassword uint32, pbSalt *uint8, cbSalt uint32, cIterations uint64, pbDerivedKey *uint8, cbDerivedKey uint32, dwFlags uint32) (r NTSTATUS) = bcrypt.dll.BCryptDeriveKeyPBKDF2
-//sys	BCryptEncapsulate(hKey BCRYPT_KEY_HANDLE, pbSecretKey *uint8, cbSecretKey uint32, pcbSecretKey *uint32, pbCipherText *uint8, cbCipherText uint32, pcbCipherText *uint32, dwFlags uint32) (r NTSTATUS) = bcrypt.dll.BCryptEncapsulate
-//sys	BCryptDecapsulate(hKey BCRYPT_KEY_HANDLE, pbCipherText *uint8, cbCipherText uint32, pbSecretKey *uint8, cbSecretKey uint32, pcbSecretKey *uint32, dwFlags uint32) (r NTSTATUS) = bcrypt.dll.BCryptDecapsulate
-//sys	BCryptQueryProviderRegistration(pszProvider *PWSTRElement, dwMode BCRYPT_QUERY_PROVIDER_MODE, dwInterface BCRYPT_INTERFACE, pcbBuffer *uint32, ppBuffer **CRYPT_PROVIDER_REG) (r NTSTATUS) = bcrypt.dll.BCryptQueryProviderRegistration
-//sys	BCryptEnumRegisteredProviders(pcbBuffer *uint32, ppBuffer **CRYPT_PROVIDERS) (r NTSTATUS) = bcrypt.dll.BCryptEnumRegisteredProviders
-//sys	BCryptCreateContext(dwTable BCRYPT_TABLE, pszContext *PWSTRElement, pConfig *CRYPT_CONTEXT_CONFIG) (r NTSTATUS) = bcrypt.dll.BCryptCreateContext
-//sys	BCryptDeleteContext(dwTable BCRYPT_TABLE, pszContext *PWSTRElement) (r NTSTATUS) = bcrypt.dll.BCryptDeleteContext
-//sys	BCryptEnumContexts(dwTable BCRYPT_TABLE, pcbBuffer *uint32, ppBuffer **CRYPT_CONTEXTS) (r NTSTATUS) = bcrypt.dll.BCryptEnumContexts
-//sys	BCryptConfigureContext(dwTable BCRYPT_TABLE, pszContext *PWSTRElement, pConfig *CRYPT_CONTEXT_CONFIG) (r NTSTATUS) = bcrypt.dll.BCryptConfigureContext
-//sys	BCryptQueryContextConfiguration(dwTable BCRYPT_TABLE, pszContext *PWSTRElement, pcbBuffer *uint32, ppBuffer **CRYPT_CONTEXT_CONFIG) (r NTSTATUS) = bcrypt.dll.BCryptQueryContextConfiguration
-//sys	BCryptAddContextFunction(dwTable BCRYPT_TABLE, pszContext *PWSTRElement, dwInterface BCRYPT_INTERFACE, pszFunction *PWSTRElement, dwPosition uint32) (r NTSTATUS) = bcrypt.dll.BCryptAddContextFunction
-//sys	BCryptRemoveContextFunction(dwTable BCRYPT_TABLE, pszContext *PWSTRElement, dwInterface BCRYPT_INTERFACE, pszFunction *PWSTRElement) (r NTSTATUS) = bcrypt.dll.BCryptRemoveContextFunction
-//sys	BCryptEnumContextFunctions(dwTable BCRYPT_TABLE, pszContext *PWSTRElement, dwInterface BCRYPT_INTERFACE, pcbBuffer *uint32, ppBuffer **CRYPT_CONTEXT_FUNCTIONS) (r NTSTATUS) = bcrypt.dll.BCryptEnumContextFunctions
-//sys	BCryptConfigureContextFunction(dwTable BCRYPT_TABLE, pszContext *PWSTRElement, dwInterface BCRYPT_INTERFACE, pszFunction *PWSTRElement, pConfig *CRYPT_CONTEXT_FUNCTION_CONFIG) (r NTSTATUS) = bcrypt.dll.BCryptConfigureContextFunction
-//sys	BCryptQueryContextFunctionConfiguration(dwTable BCRYPT_TABLE, pszContext *PWSTRElement, dwInterface BCRYPT_INTERFACE, pszFunction *PWSTRElement, pcbBuffer *uint32, ppBuffer **CRYPT_CONTEXT_FUNCTION_CONFIG) (r NTSTATUS) = bcrypt.dll.BCryptQueryContextFunctionConfiguration
-//sys	BCryptEnumContextFunctionProviders(dwTable BCRYPT_TABLE, pszContext *PWSTRElement, dwInterface BCRYPT_INTERFACE, pszFunction *PWSTRElement, pcbBuffer *uint32, ppBuffer **CRYPT_CONTEXT_FUNCTION_PROVIDERS) (r NTSTATUS) = bcrypt.dll.BCryptEnumContextFunctionProviders
-//sys	BCryptSetContextFunctionProperty(dwTable BCRYPT_TABLE, pszContext *PWSTRElement, dwInterface BCRYPT_INTERFACE, pszFunction *PWSTRElement, pszProperty *PWSTRElement, cbValue uint32, pbValue *uint8) (r NTSTATUS) = bcrypt.dll.BCryptSetContextFunctionProperty
-//sys	BCryptQueryContextFunctionProperty(dwTable BCRYPT_TABLE, pszContext *PWSTRElement, dwInterface BCRYPT_INTERFACE, pszFunction *PWSTRElement, pszProperty *PWSTRElement, pcbValue *uint32, ppbValue **uint8) (r NTSTATUS) = bcrypt.dll.BCryptQueryContextFunctionProperty
-//sys	BCryptRegisterConfigChangeNotify(phEvent *HANDLE) (r NTSTATUS) = bcrypt.dll.BCryptRegisterConfigChangeNotify
-//sys	BCryptUnregisterConfigChangeNotify(hEvent HANDLE) (r NTSTATUS) = bcrypt.dll.BCryptUnregisterConfigChangeNotify
-//sys	BCryptResolveProviders(pszContext *PWSTRElement, dwInterface uint32, pszFunction *PWSTRElement, pszProvider *PWSTRElement, dwMode BCRYPT_QUERY_PROVIDER_MODE, dwFlags BCRYPT_RESOLVE_PROVIDERS_FLAGS, pcbBuffer *uint32, ppBuffer **CRYPT_PROVIDER_REFS) (r NTSTATUS) = bcrypt.dll.BCryptResolveProviders
-//sys	BCryptGetFipsAlgorithmMode(pfEnabled *uint8) (r NTSTATUS) = bcrypt.dll.BCryptGetFipsAlgorithmMode
-//sys	NCryptOpenStorageProvider(phProvider *NCRYPT_PROV_HANDLE, pszProviderName *PWSTRElement, dwFlags uint32) (r HRESULT) = ncrypt.dll.NCryptOpenStorageProvider
-//sys	NCryptEnumAlgorithms(hProvider NCRYPT_PROV_HANDLE, dwAlgOperations NCRYPT_OPERATION, pdwAlgCount *uint32, ppAlgList **NCryptAlgorithmName, dwFlags uint32) (r HRESULT) = ncrypt.dll.NCryptEnumAlgorithms
-//sys	NCryptIsAlgSupported(hProvider NCRYPT_PROV_HANDLE, pszAlgId *PWSTRElement, dwFlags uint32) (r HRESULT) = ncrypt.dll.NCryptIsAlgSupported
-//sys	NCryptEnumKeys(hProvider NCRYPT_PROV_HANDLE, pszScope *PWSTRElement, ppKeyName **NCryptKeyName, ppEnumState *unsafe.Pointer, dwFlags NCRYPT_FLAGS) (r HRESULT) = ncrypt.dll.NCryptEnumKeys
-//sys	NCryptEnumStorageProviders(pdwProviderCount *uint32, ppProviderList **NCryptProviderName, dwFlags uint32) (r HRESULT) = ncrypt.dll.NCryptEnumStorageProviders
-//sys	NCryptFreeBuffer(pvInput unsafe.Pointer) (r HRESULT) = ncrypt.dll.NCryptFreeBuffer
-//sys	NCryptOpenKey(hProvider NCRYPT_PROV_HANDLE, phKey *NCRYPT_KEY_HANDLE, pszKeyName *PWSTRElement, dwLegacyKeySpec CERT_KEY_SPEC, dwFlags NCRYPT_FLAGS) (r HRESULT) = ncrypt.dll.NCryptOpenKey
-//sys	NCryptCreatePersistedKey(hProvider NCRYPT_PROV_HANDLE, phKey *NCRYPT_KEY_HANDLE, pszAlgId *PWSTRElement, pszKeyName *PWSTRElement, dwLegacyKeySpec CERT_KEY_SPEC, dwFlags NCRYPT_FLAGS) (r HRESULT) = ncrypt.dll.NCryptCreatePersistedKey
-//sys	NCryptGetProperty(hObject NCRYPT_HANDLE, pszProperty *PWSTRElement, pbOutput *uint8, cbOutput uint32, pcbResult *uint32, dwFlags OBJECT_SECURITY_INFORMATION) (r HRESULT) = ncrypt.dll.NCryptGetProperty
-//sys	NCryptSetProperty(hObject NCRYPT_HANDLE, pszProperty *PWSTRElement, pbInput *uint8, cbInput uint32, dwFlags NCRYPT_FLAGS) (r HRESULT) = ncrypt.dll.NCryptSetProperty
-//sys	NCryptFinalizeKey(hKey NCRYPT_KEY_HANDLE, dwFlags NCRYPT_FLAGS) (r HRESULT) = ncrypt.dll.NCryptFinalizeKey
-//sys	NCryptEncrypt(hKey NCRYPT_KEY_HANDLE, pbInput *uint8, cbInput uint32, pPaddingInfo unsafe.Pointer, pbOutput *uint8, cbOutput uint32, pcbResult *uint32, dwFlags NCRYPT_FLAGS) (r HRESULT) = ncrypt.dll.NCryptEncrypt
-//sys	NCryptDecrypt(hKey NCRYPT_KEY_HANDLE, pbInput *uint8, cbInput uint32, pPaddingInfo unsafe.Pointer, pbOutput *uint8, cbOutput uint32, pcbResult *uint32, dwFlags NCRYPT_FLAGS) (r HRESULT) = ncrypt.dll.NCryptDecrypt
-//sys	NCryptEncapsulate(hKey NCRYPT_KEY_HANDLE, pbSecretKey *uint8, cbSecretKey uint32, pcbSecretKey *uint32, pbCipherText *uint8, cbCipherText uint32, pcbCipherText *uint32, dwFlags uint32) (r HRESULT) = ncrypt.dll.NCryptEncapsulate
-//sys	NCryptDecapsulate(hKey NCRYPT_KEY_HANDLE, pbCipherText *uint8, cbCipherText uint32, pbSecretKey *uint8, cbSecretKey uint32, pcbSecretKey *uint32, dwFlags uint32) (r HRESULT) = ncrypt.dll.NCryptDecapsulate
-//sys	NCryptImportKey(hProvider NCRYPT_PROV_HANDLE, hImportKey NCRYPT_KEY_HANDLE, pszBlobType *PWSTRElement, pParameterList *BCryptBufferDesc, phKey *NCRYPT_KEY_HANDLE, pbData *uint8, cbData uint32, dwFlags NCRYPT_FLAGS) (r HRESULT) = ncrypt.dll.NCryptImportKey
-//sys	NCryptExportKey(hKey NCRYPT_KEY_HANDLE, hExportKey NCRYPT_KEY_HANDLE, pszBlobType *PWSTRElement, pParameterList *BCryptBufferDesc, pbOutput *uint8, cbOutput uint32, pcbResult *uint32, dwFlags NCRYPT_FLAGS) (r HRESULT) = ncrypt.dll.NCryptExportKey
-//sys	NCryptSignHash(hKey NCRYPT_KEY_HANDLE, pPaddingInfo unsafe.Pointer, pbHashValue *uint8, cbHashValue uint32, pbSignature *uint8, cbSignature uint32, pcbResult *uint32, dwFlags NCRYPT_FLAGS) (r HRESULT) = ncrypt.dll.NCryptSignHash
-//sys	NCryptVerifySignature(hKey NCRYPT_KEY_HANDLE, pPaddingInfo unsafe.Pointer, pbHashValue *uint8, cbHashValue uint32, pbSignature *uint8, cbSignature uint32, dwFlags NCRYPT_FLAGS) (r HRESULT) = ncrypt.dll.NCryptVerifySignature
-//sys	NCryptDeleteKey(hKey NCRYPT_KEY_HANDLE, dwFlags uint32) (r HRESULT) = ncrypt.dll.NCryptDeleteKey
-//sys	NCryptFreeObject(hObject NCRYPT_HANDLE) (r HRESULT) = ncrypt.dll.NCryptFreeObject
-//sys	NCryptIsKeyHandle(hKey NCRYPT_KEY_HANDLE) (r BOOL) = ncrypt.dll.NCryptIsKeyHandle
-//sys	NCryptTranslateHandle(phProvider *NCRYPT_PROV_HANDLE, phKey *NCRYPT_KEY_HANDLE, hLegacyProv uintptr, hLegacyKey uintptr, dwLegacyKeySpec CERT_KEY_SPEC, dwFlags uint32) (r HRESULT) = ncrypt.dll.NCryptTranslateHandle
-//sys	NCryptNotifyChangeKey(hProvider NCRYPT_PROV_HANDLE, phEvent *HANDLE, dwFlags NCRYPT_FLAGS) (r HRESULT) = ncrypt.dll.NCryptNotifyChangeKey
-//sys	NCryptSecretAgreement(hPrivKey NCRYPT_KEY_HANDLE, hPubKey NCRYPT_KEY_HANDLE, phAgreedSecret *NCRYPT_SECRET_HANDLE, dwFlags NCRYPT_FLAGS) (r HRESULT) = ncrypt.dll.NCryptSecretAgreement
-//sys	NCryptDeriveKey(hSharedSecret NCRYPT_SECRET_HANDLE, pwszKDF *PWSTRElement, pParameterList *BCryptBufferDesc, pbDerivedKey *uint8, cbDerivedKey uint32, pcbResult *uint32, dwFlags uint32) (r HRESULT) = ncrypt.dll.NCryptDeriveKey
-//sys	NCryptKeyDerivation(hKey NCRYPT_KEY_HANDLE, pParameterList *BCryptBufferDesc, pbDerivedKey *uint8, cbDerivedKey uint32, pcbResult *uint32, dwFlags uint32) (r HRESULT) = ncrypt.dll.NCryptKeyDerivation
-//sys	NCryptCreateClaim(hSubjectKey NCRYPT_KEY_HANDLE, hAuthorityKey NCRYPT_KEY_HANDLE, dwClaimType uint32, pParameterList *BCryptBufferDesc, pbClaimBlob *uint8, cbClaimBlob uint32, pcbResult *uint32, dwFlags uint32) (r HRESULT) = ncrypt.dll.NCryptCreateClaim
-//sys	NCryptVerifyClaim(hSubjectKey NCRYPT_KEY_HANDLE, hAuthorityKey NCRYPT_KEY_HANDLE, dwClaimType uint32, pParameterList *BCryptBufferDesc, pbClaimBlob *uint8, cbClaimBlob uint32, pOutput *BCryptBufferDesc, dwFlags uint32) (r HRESULT) = ncrypt.dll.NCryptVerifyClaim
-//sys	CryptFormatObject(dwCertEncodingType CERT_QUERY_ENCODING_TYPE, dwFormatType uint32, dwFormatStrType uint32, pFormatStruct unsafe.Pointer, lpszStructType *PSTRElement, pbEncoded *uint8, cbEncoded uint32, pbFormat unsafe.Pointer, pcbFormat *uint32) (r BOOL, err error) = crypt32.dll.CryptFormatObject
-//sys	CryptEncodeObjectEx(dwCertEncodingType CERT_QUERY_ENCODING_TYPE, lpszStructType *PSTRElement, pvStructInfo unsafe.Pointer, dwFlags CRYPT_ENCODE_OBJECT_FLAGS, pEncodePara *CRYPT_ENCODE_PARA, pvEncoded unsafe.Pointer, pcbEncoded *uint32) (r BOOL, err error) = crypt32.dll.CryptEncodeObjectEx
-//sys	CryptEncodeObject(dwCertEncodingType CERT_QUERY_ENCODING_TYPE, lpszStructType *PSTRElement, pvStructInfo unsafe.Pointer, pbEncoded *uint8, pcbEncoded *uint32) (r BOOL, err error) = crypt32.dll.CryptEncodeObject
-//sys	CryptDecodeObjectEx(dwCertEncodingType CERT_QUERY_ENCODING_TYPE, lpszStructType *PSTRElement, pbEncoded *uint8, cbEncoded uint32, dwFlags uint32, pDecodePara *CRYPT_DECODE_PARA, pvStructInfo unsafe.Pointer, pcbStructInfo *uint32) (r BOOL, err error) = crypt32.dll.CryptDecodeObjectEx
-//sys	CryptDecodeObject(dwCertEncodingType CERT_QUERY_ENCODING_TYPE, lpszStructType *PSTRElement, pbEncoded *uint8, cbEncoded uint32, dwFlags uint32, pvStructInfo unsafe.Pointer, pcbStructInfo *uint32) (r BOOL, err error) = crypt32.dll.CryptDecodeObject
-//sys	CryptInstallOIDFunctionAddress(hModule HMODULE, dwEncodingType uint32, pszFuncName *PSTRElement, cFuncEntry uint32, rgFuncEntry *CRYPT_OID_FUNC_ENTRY, dwFlags uint32) (r BOOL) = crypt32.dll.CryptInstallOIDFunctionAddress
-//sys	CryptInitOIDFunctionSet(pszFuncName *PSTRElement, dwFlags uint32) (r unsafe.Pointer) = crypt32.dll.CryptInitOIDFunctionSet
-//sys	CryptGetOIDFunctionAddress(hFuncSet unsafe.Pointer, dwEncodingType uint32, pszOID *PSTRElement, dwFlags uint32, ppvFuncAddr *unsafe.Pointer, phFuncAddr *unsafe.Pointer) (r BOOL, err error) = crypt32.dll.CryptGetOIDFunctionAddress
-//sys	CryptGetDefaultOIDDllList(hFuncSet unsafe.Pointer, dwEncodingType uint32, pwszDllList *PWSTRElement, pcchDllList *uint32) (r BOOL, err error) = crypt32.dll.CryptGetDefaultOIDDllList
-//sys	CryptGetDefaultOIDFunctionAddress(hFuncSet unsafe.Pointer, dwEncodingType uint32, pwszDll *PWSTRElement, dwFlags uint32, ppvFuncAddr *unsafe.Pointer, phFuncAddr *unsafe.Pointer) (r BOOL) = crypt32.dll.CryptGetDefaultOIDFunctionAddress
-//sys	CryptFreeOIDFunctionAddress(hFuncAddr unsafe.Pointer, dwFlags uint32) (r BOOL) = crypt32.dll.CryptFreeOIDFunctionAddress
-//sys	CryptRegisterOIDFunction(dwEncodingType uint32, pszFuncName *PSTRElement, pszOID *PSTRElement, pwszDll *PWSTRElement, pszOverrideFuncName *PSTRElement) (r BOOL) = crypt32.dll.CryptRegisterOIDFunction
-//sys	CryptUnregisterOIDFunction(dwEncodingType uint32, pszFuncName *PSTRElement, pszOID *PSTRElement) (r BOOL) = crypt32.dll.CryptUnregisterOIDFunction
-//sys	CryptRegisterDefaultOIDFunction(dwEncodingType uint32, pszFuncName *PSTRElement, dwIndex uint32, pwszDll *PWSTRElement) (r BOOL) = crypt32.dll.CryptRegisterDefaultOIDFunction
-//sys	CryptUnregisterDefaultOIDFunction(dwEncodingType uint32, pszFuncName *PSTRElement, pwszDll *PWSTRElement) (r BOOL) = crypt32.dll.CryptUnregisterDefaultOIDFunction
-//sys	CryptSetOIDFunctionValue(dwEncodingType uint32, pszFuncName *PSTRElement, pszOID *PSTRElement, pwszValueName *PWSTRElement, dwValueType REG_VALUE_TYPE, pbValueData *uint8, cbValueData uint32) (r BOOL) = crypt32.dll.CryptSetOIDFunctionValue
-//sys	CryptGetOIDFunctionValue(dwEncodingType uint32, pszFuncName *PSTRElement, pszOID *PSTRElement, pwszValueName *PWSTRElement, pdwValueType *uint32, pbValueData *uint8, pcbValueData *uint32) (r BOOL, err error) = crypt32.dll.CryptGetOIDFunctionValue
-//sys	CryptEnumOIDFunction(dwEncodingType uint32, pszFuncName *PSTRElement, pszOID *PSTRElement, dwFlags uint32, pvArg unsafe.Pointer, pfnEnumOIDFunc PFN_CRYPT_ENUM_OID_FUNC) (r BOOL, err error) = crypt32.dll.CryptEnumOIDFunction
-//sys	CryptFindOIDInfo(dwKeyType uint32, pvKey unsafe.Pointer, dwGroupId uint32) (r *CRYPT_OID_INFO) = crypt32.dll.CryptFindOIDInfo
-//sys	CryptRegisterOIDInfo(pInfo *CRYPT_OID_INFO, dwFlags uint32) (r BOOL) = crypt32.dll.CryptRegisterOIDInfo
-//sys	CryptUnregisterOIDInfo(pInfo *CRYPT_OID_INFO) (r BOOL) = crypt32.dll.CryptUnregisterOIDInfo
-//sys	CryptEnumOIDInfo(dwGroupId uint32, dwFlags uint32, pvArg unsafe.Pointer, pfnEnumOIDInfo PFN_CRYPT_ENUM_OID_INFO) (r BOOL) = crypt32.dll.CryptEnumOIDInfo
-//sys	CryptFindLocalizedName(pwszCryptName *PWSTRElement) (r *PWSTRElement) = crypt32.dll.CryptFindLocalizedName
-//sys	CryptMsgOpenToEncode(dwMsgEncodingType uint32, dwFlags uint32, dwMsgType CRYPT_MSG_TYPE, pvMsgEncodeInfo unsafe.Pointer, pszInnerContentObjID *PSTRElement, pStreamInfo *CMSG_STREAM_INFO) (r unsafe.Pointer, err error) = crypt32.dll.CryptMsgOpenToEncode
-//sys	CryptMsgCalculateEncodedLength(dwMsgEncodingType uint32, dwFlags uint32, dwMsgType uint32, pvMsgEncodeInfo unsafe.Pointer, pszInnerContentObjID *PSTRElement, cbData uint32) (r uint32, err error) = crypt32.dll.CryptMsgCalculateEncodedLength
-//sys	CryptMsgOpenToDecode(dwMsgEncodingType uint32, dwFlags uint32, dwMsgType uint32, hCryptProv HCRYPTPROV_LEGACY, pRecipientInfo *CERT_INFO, pStreamInfo *CMSG_STREAM_INFO) (r unsafe.Pointer, err error) = crypt32.dll.CryptMsgOpenToDecode
-//sys	CryptMsgDuplicate(hCryptMsg unsafe.Pointer) (r unsafe.Pointer) = crypt32.dll.CryptMsgDuplicate
-//sys	CryptMsgClose(hCryptMsg unsafe.Pointer) (r BOOL, err error) = crypt32.dll.CryptMsgClose
-//sys	CryptMsgUpdate(hCryptMsg unsafe.Pointer, pbData *uint8, cbData uint32, fFinal BOOL) (r BOOL, err error) = crypt32.dll.CryptMsgUpdate
-//sys	CryptMsgGetParam(hCryptMsg unsafe.Pointer, dwParamType uint32, dwIndex uint32, pvData unsafe.Pointer, pcbData *uint32) (r BOOL, err error) = crypt32.dll.CryptMsgGetParam
-//sys	CryptMsgControl(hCryptMsg unsafe.Pointer, dwFlags uint32, dwCtrlType uint32, pvCtrlPara unsafe.Pointer) (r BOOL, err error) = crypt32.dll.CryptMsgControl
-//sys	CryptMsgVerifyCountersignatureEncoded(hCryptProv HCRYPTPROV_LEGACY, dwEncodingType uint32, pbSignerInfo *uint8, cbSignerInfo uint32, pbSignerInfoCountersignature *uint8, cbSignerInfoCountersignature uint32, pciCountersigner *CERT_INFO) (r BOOL, err error) = crypt32.dll.CryptMsgVerifyCountersignatureEncoded
-//sys	CryptMsgVerifyCountersignatureEncodedEx(hCryptProv HCRYPTPROV_LEGACY, dwEncodingType uint32, pbSignerInfo *uint8, cbSignerInfo uint32, pbSignerInfoCountersignature *uint8, cbSignerInfoCountersignature uint32, dwSignerType uint32, pvSigner unsafe.Pointer, dwFlags uint32, pvExtra unsafe.Pointer) (r BOOL, err error) = crypt32.dll.CryptMsgVerifyCountersignatureEncodedEx
-//sys	CryptMsgCountersign(hCryptMsg unsafe.Pointer, dwIndex uint32, cCountersigners uint32, rgCountersigners *CMSG_SIGNER_ENCODE_INFO) (r BOOL, err error) = crypt32.dll.CryptMsgCountersign
-//sys	CryptMsgCountersignEncoded(dwEncodingType uint32, pbSignerInfo *uint8, cbSignerInfo uint32, cCountersigners uint32, rgCountersigners *CMSG_SIGNER_ENCODE_INFO, pbCountersignature *uint8, pcbCountersignature *uint32) (r BOOL, err error) = crypt32.dll.CryptMsgCountersignEncoded
-//sys	CertOpenStore(lpszStoreProvider *PSTRElement, dwEncodingType CERT_QUERY_ENCODING_TYPE, hCryptProv HCRYPTPROV_LEGACY, dwFlags CERT_OPEN_STORE_FLAGS, pvPara unsafe.Pointer) (r HCERTSTORE, err error) = crypt32.dll.CertOpenStore
-//sys	CertDuplicateStore(hCertStore HCERTSTORE) (r HCERTSTORE) = crypt32.dll.CertDuplicateStore
-//sys	CertSaveStore(hCertStore HCERTSTORE, dwEncodingType CERT_QUERY_ENCODING_TYPE, dwSaveAs CERT_STORE_SAVE_AS, dwSaveTo CERT_STORE_SAVE_TO, pvSaveToPara unsafe.Pointer, dwFlags uint32) (r BOOL, err error) = crypt32.dll.CertSaveStore
-//sys	CertCloseStore(hCertStore HCERTSTORE, dwFlags uint32) (r BOOL, err error) = crypt32.dll.CertCloseStore
-//sys	CertGetSubjectCertificateFromStore(hCertStore HCERTSTORE, dwCertEncodingType CERT_QUERY_ENCODING_TYPE, pCertId *CERT_INFO) (r *CERT_CONTEXT, err error) = crypt32.dll.CertGetSubjectCertificateFromStore
-//sys	CertEnumCertificatesInStore(hCertStore HCERTSTORE, pPrevCertContext *CERT_CONTEXT) (r *CERT_CONTEXT, err error) = crypt32.dll.CertEnumCertificatesInStore
-//sys	CertFindCertificateInStore(hCertStore HCERTSTORE, dwCertEncodingType CERT_QUERY_ENCODING_TYPE, dwFindFlags uint32, dwFindType CERT_FIND_FLAGS, pvFindPara unsafe.Pointer, pPrevCertContext *CERT_CONTEXT) (r *CERT_CONTEXT, err error) = crypt32.dll.CertFindCertificateInStore
-//sys	CertGetIssuerCertificateFromStore(hCertStore HCERTSTORE, pSubjectContext *CERT_CONTEXT, pPrevIssuerContext *CERT_CONTEXT, pdwFlags *uint32) (r *CERT_CONTEXT, err error) = crypt32.dll.CertGetIssuerCertificateFromStore
-//sys	CertVerifySubjectCertificateContext(pSubject *CERT_CONTEXT, pIssuer *CERT_CONTEXT, pdwFlags *uint32) (r BOOL, err error) = crypt32.dll.CertVerifySubjectCertificateContext
-//sys	CertDuplicateCertificateContext(pCertContext *CERT_CONTEXT) (r *CERT_CONTEXT) = crypt32.dll.CertDuplicateCertificateContext
-//sys	CertCreateCertificateContext(dwCertEncodingType CERT_QUERY_ENCODING_TYPE, pbCertEncoded *uint8, cbCertEncoded uint32) (r *CERT_CONTEXT, err error) = crypt32.dll.CertCreateCertificateContext
-//sys	CertFreeCertificateContext(pCertContext *CERT_CONTEXT) (r BOOL) = crypt32.dll.CertFreeCertificateContext
-//sys	CertSetCertificateContextProperty(pCertContext *CERT_CONTEXT, dwPropId uint32, dwFlags uint32, pvData unsafe.Pointer) (r BOOL, err error) = crypt32.dll.CertSetCertificateContextProperty
-//sys	CertGetCertificateContextProperty(pCertContext *CERT_CONTEXT, dwPropId uint32, pvData unsafe.Pointer, pcbData *uint32) (r BOOL, err error) = crypt32.dll.CertGetCertificateContextProperty
-//sys	CertEnumCertificateContextProperties(pCertContext *CERT_CONTEXT, dwPropId uint32) (r uint32) = crypt32.dll.CertEnumCertificateContextProperties
-//sys	CertCreateCTLEntryFromCertificateContextProperties(pCertContext *CERT_CONTEXT, cOptAttr uint32, rgOptAttr *CRYPT_ATTRIBUTE, dwFlags uint32, pvReserved unsafe.Pointer, pCtlEntry *CTL_ENTRY, pcbCtlEntry *uint32) (r BOOL, err error) = crypt32.dll.CertCreateCTLEntryFromCertificateContextProperties
-//sys	CertSetCertificateContextPropertiesFromCTLEntry(pCertContext *CERT_CONTEXT, pCtlEntry *CTL_ENTRY, dwFlags uint32) (r BOOL, err error) = crypt32.dll.CertSetCertificateContextPropertiesFromCTLEntry
-//sys	CertGetCRLFromStore(hCertStore HCERTSTORE, pIssuerContext *CERT_CONTEXT, pPrevCrlContext *CRL_CONTEXT, pdwFlags *uint32) (r *CRL_CONTEXT, err error) = crypt32.dll.CertGetCRLFromStore
-//sys	CertEnumCRLsInStore(hCertStore HCERTSTORE, pPrevCrlContext *CRL_CONTEXT) (r *CRL_CONTEXT, err error) = crypt32.dll.CertEnumCRLsInStore
-//sys	CertFindCRLInStore(hCertStore HCERTSTORE, dwCertEncodingType CERT_QUERY_ENCODING_TYPE, dwFindFlags uint32, dwFindType uint32, pvFindPara unsafe.Pointer, pPrevCrlContext *CRL_CONTEXT) (r *CRL_CONTEXT, err error) = crypt32.dll.CertFindCRLInStore
-//sys	CertDuplicateCRLContext(pCrlContext *CRL_CONTEXT) (r *CRL_CONTEXT) = crypt32.dll.CertDuplicateCRLContext
-//sys	CertCreateCRLContext(dwCertEncodingType CERT_QUERY_ENCODING_TYPE, pbCrlEncoded *uint8, cbCrlEncoded uint32) (r *CRL_CONTEXT, err error) = crypt32.dll.CertCreateCRLContext
-//sys	CertFreeCRLContext(pCrlContext *CRL_CONTEXT) (r BOOL) = crypt32.dll.CertFreeCRLContext
-//sys	CertSetCRLContextProperty(pCrlContext *CRL_CONTEXT, dwPropId uint32, dwFlags uint32, pvData unsafe.Pointer) (r BOOL, err error) = crypt32.dll.CertSetCRLContextProperty
-//sys	CertGetCRLContextProperty(pCrlContext *CRL_CONTEXT, dwPropId uint32, pvData unsafe.Pointer, pcbData *uint32) (r BOOL, err error) = crypt32.dll.CertGetCRLContextProperty
-//sys	CertEnumCRLContextProperties(pCrlContext *CRL_CONTEXT, dwPropId uint32) (r uint32) = crypt32.dll.CertEnumCRLContextProperties
-//sys	CertFindCertificateInCRL(pCert *CERT_CONTEXT, pCrlContext *CRL_CONTEXT, dwFlags uint32, pvReserved unsafe.Pointer, ppCrlEntry **CRL_ENTRY) (r BOOL) = crypt32.dll.CertFindCertificateInCRL
-//sys	CertIsValidCRLForCertificate(pCert *CERT_CONTEXT, pCrl *CRL_CONTEXT, dwFlags uint32, pvReserved unsafe.Pointer) (r BOOL) = crypt32.dll.CertIsValidCRLForCertificate
-//sys	CertAddEncodedCertificateToStore(hCertStore HCERTSTORE, dwCertEncodingType CERT_QUERY_ENCODING_TYPE, pbCertEncoded *uint8, cbCertEncoded uint32, dwAddDisposition uint32, ppCertContext **CERT_CONTEXT) (r BOOL, err error) = crypt32.dll.CertAddEncodedCertificateToStore
-//sys	CertAddCertificateContextToStore(hCertStore HCERTSTORE, pCertContext *CERT_CONTEXT, dwAddDisposition uint32, ppStoreContext **CERT_CONTEXT) (r BOOL, err error) = crypt32.dll.CertAddCertificateContextToStore
-//sys	CertAddSerializedElementToStore(hCertStore HCERTSTORE, pbElement *uint8, cbElement uint32, dwAddDisposition uint32, dwFlags uint32, dwContextTypeFlags uint32, pdwContextType *uint32, ppvContext *unsafe.Pointer) (r BOOL, err error) = crypt32.dll.CertAddSerializedElementToStore
-//sys	CertDeleteCertificateFromStore(pCertContext *CERT_CONTEXT) (r BOOL, err error) = crypt32.dll.CertDeleteCertificateFromStore
-//sys	CertAddEncodedCRLToStore(hCertStore HCERTSTORE, dwCertEncodingType CERT_QUERY_ENCODING_TYPE, pbCrlEncoded *uint8, cbCrlEncoded uint32, dwAddDisposition uint32, ppCrlContext **CRL_CONTEXT) (r BOOL, err error) = crypt32.dll.CertAddEncodedCRLToStore
-//sys	CertAddCRLContextToStore(hCertStore HCERTSTORE, pCrlContext *CRL_CONTEXT, dwAddDisposition uint32, ppStoreContext **CRL_CONTEXT) (r BOOL, err error) = crypt32.dll.CertAddCRLContextToStore
-//sys	CertDeleteCRLFromStore(pCrlContext *CRL_CONTEXT) (r BOOL, err error) = crypt32.dll.CertDeleteCRLFromStore
-//sys	CertSerializeCertificateStoreElement(pCertContext *CERT_CONTEXT, dwFlags uint32, pbElement *uint8, pcbElement *uint32) (r BOOL, err error) = crypt32.dll.CertSerializeCertificateStoreElement
-//sys	CertSerializeCRLStoreElement(pCrlContext *CRL_CONTEXT, dwFlags uint32, pbElement *uint8, pcbElement *uint32) (r BOOL, err error) = crypt32.dll.CertSerializeCRLStoreElement
-//sys	CertDuplicateCTLContext(pCtlContext *CTL_CONTEXT) (r *CTL_CONTEXT) = crypt32.dll.CertDuplicateCTLContext
-//sys	CertCreateCTLContext(dwMsgAndCertEncodingType uint32, pbCtlEncoded *uint8, cbCtlEncoded uint32) (r *CTL_CONTEXT, err error) = crypt32.dll.CertCreateCTLContext
-//sys	CertFreeCTLContext(pCtlContext *CTL_CONTEXT) (r BOOL) = crypt32.dll.CertFreeCTLContext
-//sys	CertSetCTLContextProperty(pCtlContext *CTL_CONTEXT, dwPropId uint32, dwFlags uint32, pvData unsafe.Pointer) (r BOOL, err error) = crypt32.dll.CertSetCTLContextProperty
-//sys	CertGetCTLContextProperty(pCtlContext *CTL_CONTEXT, dwPropId uint32, pvData unsafe.Pointer, pcbData *uint32) (r BOOL, err error) = crypt32.dll.CertGetCTLContextProperty
-//sys	CertEnumCTLContextProperties(pCtlContext *CTL_CONTEXT, dwPropId uint32) (r uint32) = crypt32.dll.CertEnumCTLContextProperties
-//sys	CertEnumCTLsInStore(hCertStore HCERTSTORE, pPrevCtlContext *CTL_CONTEXT) (r *CTL_CONTEXT, err error) = crypt32.dll.CertEnumCTLsInStore
-//sys	CertFindSubjectInCTL(dwEncodingType uint32, dwSubjectType uint32, pvSubject unsafe.Pointer, pCtlContext *CTL_CONTEXT, dwFlags uint32) (r *CTL_ENTRY, err error) = crypt32.dll.CertFindSubjectInCTL
-//sys	CertFindCTLInStore(hCertStore HCERTSTORE, dwMsgAndCertEncodingType uint32, dwFindFlags uint32, dwFindType CERT_FIND_TYPE, pvFindPara unsafe.Pointer, pPrevCtlContext *CTL_CONTEXT) (r *CTL_CONTEXT, err error) = crypt32.dll.CertFindCTLInStore
-//sys	CertAddEncodedCTLToStore(hCertStore HCERTSTORE, dwMsgAndCertEncodingType CERT_QUERY_ENCODING_TYPE, pbCtlEncoded *uint8, cbCtlEncoded uint32, dwAddDisposition uint32, ppCtlContext **CTL_CONTEXT) (r BOOL, err error) = crypt32.dll.CertAddEncodedCTLToStore
-//sys	CertAddCTLContextToStore(hCertStore HCERTSTORE, pCtlContext *CTL_CONTEXT, dwAddDisposition uint32, ppStoreContext **CTL_CONTEXT) (r BOOL, err error) = crypt32.dll.CertAddCTLContextToStore
-//sys	CertSerializeCTLStoreElement(pCtlContext *CTL_CONTEXT, dwFlags uint32, pbElement *uint8, pcbElement *uint32) (r BOOL, err error) = crypt32.dll.CertSerializeCTLStoreElement
-//sys	CertDeleteCTLFromStore(pCtlContext *CTL_CONTEXT) (r BOOL, err error) = crypt32.dll.CertDeleteCTLFromStore
-//sys	CertAddCertificateLinkToStore(hCertStore HCERTSTORE, pCertContext *CERT_CONTEXT, dwAddDisposition uint32, ppStoreContext **CERT_CONTEXT) (r BOOL, err error) = crypt32.dll.CertAddCertificateLinkToStore
-//sys	CertAddCRLLinkToStore(hCertStore HCERTSTORE, pCrlContext *CRL_CONTEXT, dwAddDisposition uint32, ppStoreContext **CRL_CONTEXT) (r BOOL, err error) = crypt32.dll.CertAddCRLLinkToStore
-//sys	CertAddCTLLinkToStore(hCertStore HCERTSTORE, pCtlContext *CTL_CONTEXT, dwAddDisposition uint32, ppStoreContext **CTL_CONTEXT) (r BOOL, err error) = crypt32.dll.CertAddCTLLinkToStore
-//sys	CertAddStoreToCollection(hCollectionStore HCERTSTORE, hSiblingStore HCERTSTORE, dwUpdateFlags uint32, dwPriority uint32) (r BOOL) = crypt32.dll.CertAddStoreToCollection
-//sys	CertRemoveStoreFromCollection(hCollectionStore HCERTSTORE, hSiblingStore HCERTSTORE) = crypt32.dll.CertRemoveStoreFromCollection
-//sys	CertControlStore(hCertStore HCERTSTORE, dwFlags CERT_CONTROL_STORE_FLAGS, dwCtrlType uint32, pvCtrlPara unsafe.Pointer) (r BOOL, err error) = crypt32.dll.CertControlStore
-//sys	CertSetStoreProperty(hCertStore HCERTSTORE, dwPropId uint32, dwFlags uint32, pvData unsafe.Pointer) (r BOOL) = crypt32.dll.CertSetStoreProperty
-//sys	CertGetStoreProperty(hCertStore HCERTSTORE, dwPropId uint32, pvData unsafe.Pointer, pcbData *uint32) (r BOOL, err error) = crypt32.dll.CertGetStoreProperty
-//sys	CertCreateContext(dwContextType uint32, dwEncodingType uint32, pbEncoded *uint8, cbEncoded uint32, dwFlags uint32, pCreatePara *CERT_CREATE_CONTEXT_PARA) (r unsafe.Pointer, err error) = crypt32.dll.CertCreateContext
-//sys	CertRegisterSystemStore(pvSystemStore unsafe.Pointer, dwFlags uint32, pStoreInfo *CERT_SYSTEM_STORE_INFO, pvReserved unsafe.Pointer) (r BOOL) = crypt32.dll.CertRegisterSystemStore
-//sys	CertRegisterPhysicalStore(pvSystemStore unsafe.Pointer, dwFlags uint32, pwszStoreName *PWSTRElement, pStoreInfo *CERT_PHYSICAL_STORE_INFO, pvReserved unsafe.Pointer) (r BOOL) = crypt32.dll.CertRegisterPhysicalStore
-//sys	CertUnregisterSystemStore(pvSystemStore unsafe.Pointer, dwFlags uint32) (r BOOL) = crypt32.dll.CertUnregisterSystemStore
-//sys	CertUnregisterPhysicalStore(pvSystemStore unsafe.Pointer, dwFlags uint32, pwszStoreName *PWSTRElement) (r BOOL) = crypt32.dll.CertUnregisterPhysicalStore
-//sys	CertEnumSystemStoreLocation(dwFlags uint32, pvArg unsafe.Pointer, pfnEnum PFN_CERT_ENUM_SYSTEM_STORE_LOCATION) (r BOOL) = crypt32.dll.CertEnumSystemStoreLocation
-//sys	CertEnumSystemStore(dwFlags uint32, pvSystemStoreLocationPara unsafe.Pointer, pvArg unsafe.Pointer, pfnEnum PFN_CERT_ENUM_SYSTEM_STORE) (r BOOL) = crypt32.dll.CertEnumSystemStore
-//sys	CertEnumPhysicalStore(pvSystemStore unsafe.Pointer, dwFlags uint32, pvArg unsafe.Pointer, pfnEnum PFN_CERT_ENUM_PHYSICAL_STORE) (r BOOL, err error) = crypt32.dll.CertEnumPhysicalStore
-//sys	CertGetEnhancedKeyUsage(pCertContext *CERT_CONTEXT, dwFlags uint32, pUsage *CTL_USAGE, pcbUsage *uint32) (r BOOL, err error) = crypt32.dll.CertGetEnhancedKeyUsage
-//sys	CertSetEnhancedKeyUsage(pCertContext *CERT_CONTEXT, pUsage *CTL_USAGE) (r BOOL, err error) = crypt32.dll.CertSetEnhancedKeyUsage
-//sys	CertAddEnhancedKeyUsageIdentifier(pCertContext *CERT_CONTEXT, pszUsageIdentifier *PSTRElement) (r BOOL, err error) = crypt32.dll.CertAddEnhancedKeyUsageIdentifier
-//sys	CertRemoveEnhancedKeyUsageIdentifier(pCertContext *CERT_CONTEXT, pszUsageIdentifier *PSTRElement) (r BOOL, err error) = crypt32.dll.CertRemoveEnhancedKeyUsageIdentifier
-//sys	CertGetValidUsages(cCerts uint32, rghCerts **CERT_CONTEXT, cNumOIDs *int32, rghOIDs **PSTRElement, pcbOIDs *uint32) (r BOOL, err error) = crypt32.dll.CertGetValidUsages
-//sys	CryptMsgGetAndVerifySigner(hCryptMsg unsafe.Pointer, cSignerStore uint32, rghSignerStore *HCERTSTORE, dwFlags uint32, ppSigner **CERT_CONTEXT, pdwSignerIndex *uint32) (r BOOL, err error) = crypt32.dll.CryptMsgGetAndVerifySigner
-//sys	CryptMsgSignCTL(dwMsgEncodingType uint32, pbCtlContent *uint8, cbCtlContent uint32, pSignInfo *CMSG_SIGNED_ENCODE_INFO, dwFlags uint32, pbEncoded *uint8, pcbEncoded *uint32) (r BOOL, err error) = crypt32.dll.CryptMsgSignCTL
-//sys	CryptMsgEncodeAndSignCTL(dwMsgEncodingType uint32, pCtlInfo *CTL_INFO, pSignInfo *CMSG_SIGNED_ENCODE_INFO, dwFlags uint32, pbEncoded *uint8, pcbEncoded *uint32) (r BOOL, err error) = crypt32.dll.CryptMsgEncodeAndSignCTL
-//sys	CertFindSubjectInSortedCTL(pSubjectIdentifier *CRYPT_INTEGER_BLOB, pCtlContext *CTL_CONTEXT, dwFlags uint32, pvReserved unsafe.Pointer, pEncodedAttributes *CRYPT_INTEGER_BLOB) (r BOOL) = crypt32.dll.CertFindSubjectInSortedCTL
-//sys	CertEnumSubjectInSortedCTL(pCtlContext *CTL_CONTEXT, ppvNextSubject *unsafe.Pointer, pSubjectIdentifier *CRYPT_INTEGER_BLOB, pEncodedAttributes *CRYPT_INTEGER_BLOB) (r BOOL) = crypt32.dll.CertEnumSubjectInSortedCTL
-//sys	CertVerifyCTLUsage(dwEncodingType uint32, dwSubjectType uint32, pvSubject unsafe.Pointer, pSubjectUsage *CTL_USAGE, dwFlags uint32, pVerifyUsagePara *CTL_VERIFY_USAGE_PARA, pVerifyUsageStatus *CTL_VERIFY_USAGE_STATUS) (r BOOL, err error) = crypt32.dll.CertVerifyCTLUsage
-//sys	CertVerifyRevocation(dwEncodingType uint32, dwRevType uint32, cContext uint32, rgpvContext *unsafe.Pointer, dwFlags uint32, pRevPara *CERT_REVOCATION_PARA, pRevStatus *CERT_REVOCATION_STATUS) (r BOOL, err error) = crypt32.dll.CertVerifyRevocation
-//sys	CertCompareIntegerBlob(pInt1 *CRYPT_INTEGER_BLOB, pInt2 *CRYPT_INTEGER_BLOB) (r BOOL, err error) = crypt32.dll.CertCompareIntegerBlob
-//sys	CertCompareCertificate(dwCertEncodingType CERT_QUERY_ENCODING_TYPE, pCertId1 *CERT_INFO, pCertId2 *CERT_INFO) (r BOOL) = crypt32.dll.CertCompareCertificate
-//sys	CertCompareCertificateName(dwCertEncodingType CERT_QUERY_ENCODING_TYPE, pCertName1 *CRYPT_INTEGER_BLOB, pCertName2 *CRYPT_INTEGER_BLOB) (r BOOL) = crypt32.dll.CertCompareCertificateName
-//sys	CertIsRDNAttrsInCertificateName(dwCertEncodingType CERT_QUERY_ENCODING_TYPE, dwFlags uint32, pCertName *CRYPT_INTEGER_BLOB, pRDN *CERT_RDN) (r BOOL, err error) = crypt32.dll.CertIsRDNAttrsInCertificateName
-//sys	CertComparePublicKeyInfo(dwCertEncodingType CERT_QUERY_ENCODING_TYPE, pPublicKey1 *CERT_PUBLIC_KEY_INFO, pPublicKey2 *CERT_PUBLIC_KEY_INFO) (r BOOL) = crypt32.dll.CertComparePublicKeyInfo
-//sys	CertGetPublicKeyLength(dwCertEncodingType CERT_QUERY_ENCODING_TYPE, pPublicKey *CERT_PUBLIC_KEY_INFO) (r uint32, err error) = crypt32.dll.CertGetPublicKeyLength
-//sys	CryptVerifyCertificateSignature(hCryptProv HCRYPTPROV_LEGACY, dwCertEncodingType CERT_QUERY_ENCODING_TYPE, pbEncoded *uint8, cbEncoded uint32, pPublicKey *CERT_PUBLIC_KEY_INFO) (r BOOL, err error) = crypt32.dll.CryptVerifyCertificateSignature
-//sys	CryptVerifyCertificateSignatureEx(hCryptProv HCRYPTPROV_LEGACY, dwCertEncodingType CERT_QUERY_ENCODING_TYPE, dwSubjectType uint32, pvSubject unsafe.Pointer, dwIssuerType uint32, pvIssuer unsafe.Pointer, dwFlags CRYPT_VERIFY_CERT_FLAGS, pvExtra unsafe.Pointer) (r BOOL, err error) = crypt32.dll.CryptVerifyCertificateSignatureEx
-//sys	CertIsStrongHashToSign(pStrongSignPara *CERT_STRONG_SIGN_PARA, pwszCNGHashAlgid *PWSTRElement, pSigningCert *CERT_CONTEXT) (r BOOL, err error) = crypt32.dll.CertIsStrongHashToSign
-//sys	CryptHashToBeSigned(hCryptProv HCRYPTPROV_LEGACY, dwCertEncodingType CERT_QUERY_ENCODING_TYPE, pbEncoded *uint8, cbEncoded uint32, pbComputedHash *uint8, pcbComputedHash *uint32) (r BOOL, err error) = crypt32.dll.CryptHashToBeSigned
-//sys	CryptHashCertificate(hCryptProv HCRYPTPROV_LEGACY, Algid ALG_ID, dwFlags uint32, pbEncoded *uint8, cbEncoded uint32, pbComputedHash *uint8, pcbComputedHash *uint32) (r BOOL, err error) = crypt32.dll.CryptHashCertificate
-//sys	CryptHashCertificate2(pwszCNGHashAlgid *PWSTRElement, dwFlags uint32, pvReserved unsafe.Pointer, pbEncoded *uint8, cbEncoded uint32, pbComputedHash *uint8, pcbComputedHash *uint32) (r BOOL, err error) = crypt32.dll.CryptHashCertificate2
-//sys	CryptSignCertificate(hCryptProvOrNCryptKey HCRYPTPROV_OR_NCRYPT_KEY_HANDLE, dwKeySpec uint32, dwCertEncodingType CERT_QUERY_ENCODING_TYPE, pbEncodedToBeSigned *uint8, cbEncodedToBeSigned uint32, pSignatureAlgorithm *CRYPT_ALGORITHM_IDENTIFIER, pvHashAuxInfo unsafe.Pointer, pbSignature *uint8, pcbSignature *uint32) (r BOOL, err error) = crypt32.dll.CryptSignCertificate
-//sys	CryptSignAndEncodeCertificate(hCryptProvOrNCryptKey HCRYPTPROV_OR_NCRYPT_KEY_HANDLE, dwKeySpec CERT_KEY_SPEC, dwCertEncodingType CERT_QUERY_ENCODING_TYPE, lpszStructType *PSTRElement, pvStructInfo unsafe.Pointer, pSignatureAlgorithm *CRYPT_ALGORITHM_IDENTIFIER, pvHashAuxInfo unsafe.Pointer, pbEncoded *uint8, pcbEncoded *uint32) (r BOOL, err error) = crypt32.dll.CryptSignAndEncodeCertificate
-//sys	CertVerifyTimeValidity(pTimeToVerify *FILETIME, pCertInfo *CERT_INFO) (r int32) = crypt32.dll.CertVerifyTimeValidity
-//sys	CertVerifyCRLTimeValidity(pTimeToVerify *FILETIME, pCrlInfo *CRL_INFO) (r int32) = crypt32.dll.CertVerifyCRLTimeValidity
-//sys	CertVerifyValidityNesting(pSubjectInfo *CERT_INFO, pIssuerInfo *CERT_INFO) (r BOOL) = crypt32.dll.CertVerifyValidityNesting
-//sys	CertVerifyCRLRevocation(dwCertEncodingType CERT_QUERY_ENCODING_TYPE, pCertId *CERT_INFO, cCrlInfo uint32, rgpCrlInfo **CRL_INFO) (r BOOL) = crypt32.dll.CertVerifyCRLRevocation
-//sys	CertAlgIdToOID(dwAlgId uint32) (r *PSTRElement) = crypt32.dll.CertAlgIdToOID
-//sys	CertOIDToAlgId(pszObjId *PSTRElement) (r uint32) = crypt32.dll.CertOIDToAlgId
-//sys	CertFindExtension(pszObjId *PSTRElement, cExtensions uint32, rgExtensions *CERT_EXTENSION) (r *CERT_EXTENSION) = crypt32.dll.CertFindExtension
-//sys	CertFindAttribute(pszObjId *PSTRElement, cAttr uint32, rgAttr *CRYPT_ATTRIBUTE) (r *CRYPT_ATTRIBUTE) = crypt32.dll.CertFindAttribute
-//sys	CertFindRDNAttr(pszObjId *PSTRElement, pName *CERT_NAME_INFO) (r *CERT_RDN_ATTR) = crypt32.dll.CertFindRDNAttr
-//sys	CertGetIntendedKeyUsage(dwCertEncodingType CERT_QUERY_ENCODING_TYPE, pCertInfo *CERT_INFO, pbKeyUsage *uint8, cbKeyUsage uint32) (r BOOL, err error) = crypt32.dll.CertGetIntendedKeyUsage
-//sys	CryptInstallDefaultContext(hCryptProv uintptr, dwDefaultType CRYPT_DEFAULT_CONTEXT_TYPE, pvDefaultPara unsafe.Pointer, dwFlags CRYPT_DEFAULT_CONTEXT_FLAGS, pvReserved unsafe.Pointer, phDefaultContext *unsafe.Pointer) (r BOOL, err error) = crypt32.dll.CryptInstallDefaultContext
-//sys	CryptUninstallDefaultContext(hDefaultContext unsafe.Pointer, dwFlags uint32, pvReserved unsafe.Pointer) (r BOOL, err error) = crypt32.dll.CryptUninstallDefaultContext
-//sys	CryptExportPublicKeyInfo(hCryptProvOrNCryptKey HCRYPTPROV_OR_NCRYPT_KEY_HANDLE, dwKeySpec uint32, dwCertEncodingType CERT_QUERY_ENCODING_TYPE, pInfo *CERT_PUBLIC_KEY_INFO, pcbInfo *uint32) (r BOOL, err error) = crypt32.dll.CryptExportPublicKeyInfo
-//sys	CryptExportPublicKeyInfoEx(hCryptProvOrNCryptKey HCRYPTPROV_OR_NCRYPT_KEY_HANDLE, dwKeySpec uint32, dwCertEncodingType CERT_QUERY_ENCODING_TYPE, pszPublicKeyObjId *PSTRElement, dwFlags uint32, pvAuxInfo unsafe.Pointer, pInfo *CERT_PUBLIC_KEY_INFO, pcbInfo *uint32) (r BOOL, err error) = crypt32.dll.CryptExportPublicKeyInfoEx
-//sys	CryptExportPublicKeyInfoFromBCryptKeyHandle(hBCryptKey BCRYPT_KEY_HANDLE, dwCertEncodingType CERT_QUERY_ENCODING_TYPE, pszPublicKeyObjId *PSTRElement, dwFlags uint32, pvAuxInfo unsafe.Pointer, pInfo *CERT_PUBLIC_KEY_INFO, pcbInfo *uint32) (r BOOL) = crypt32.dll.CryptExportPublicKeyInfoFromBCryptKeyHandle
-//sys	CryptImportPublicKeyInfo(hCryptProv uintptr, dwCertEncodingType CERT_QUERY_ENCODING_TYPE, pInfo *CERT_PUBLIC_KEY_INFO, phKey *uintptr) (r BOOL, err error) = crypt32.dll.CryptImportPublicKeyInfo
-//sys	CryptImportPublicKeyInfoEx(hCryptProv uintptr, dwCertEncodingType CERT_QUERY_ENCODING_TYPE, pInfo *CERT_PUBLIC_KEY_INFO, aiKeyAlg ALG_ID, dwFlags uint32, pvAuxInfo unsafe.Pointer, phKey *uintptr) (r BOOL, err error) = crypt32.dll.CryptImportPublicKeyInfoEx
-//sys	CryptImportPublicKeyInfoEx2(dwCertEncodingType CERT_QUERY_ENCODING_TYPE, pInfo *CERT_PUBLIC_KEY_INFO, dwFlags CRYPT_IMPORT_PUBLIC_KEY_FLAGS, pvAuxInfo unsafe.Pointer, phKey *BCRYPT_KEY_HANDLE) (r BOOL, err error) = crypt32.dll.CryptImportPublicKeyInfoEx2
-//sys	CryptAcquireCertificatePrivateKey(pCert *CERT_CONTEXT, dwFlags CRYPT_ACQUIRE_FLAGS, pvParameters unsafe.Pointer, phCryptProvOrNCryptKey *HCRYPTPROV_OR_NCRYPT_KEY_HANDLE, pdwKeySpec *CERT_KEY_SPEC, pfCallerFreeProvOrNCryptKey *BOOL) (r BOOL, err error) = crypt32.dll.CryptAcquireCertificatePrivateKey
-//sys	CryptFindCertificateKeyProvInfo(pCert *CERT_CONTEXT, dwFlags CRYPT_FIND_FLAGS, pvReserved unsafe.Pointer) (r BOOL, err error) = crypt32.dll.CryptFindCertificateKeyProvInfo
-//sys	CryptImportPKCS8(sPrivateKeyAndParams CRYPT_PKCS8_IMPORT_PARAMS, dwFlags CRYPT_KEY_FLAGS, phCryptProv *uintptr, pvAuxInfo unsafe.Pointer) (r BOOL, err error) = crypt32.dll.CryptImportPKCS8
-//sys	CryptExportPKCS8(hCryptProv uintptr, dwKeySpec uint32, pszPrivateKeyObjId *PSTRElement, dwFlags uint32, pvAuxInfo unsafe.Pointer, pbPrivateKeyBlob *uint8, pcbPrivateKeyBlob *uint32) (r BOOL, err error) = crypt32.dll.CryptExportPKCS8
-//sys	CryptHashPublicKeyInfo(hCryptProv HCRYPTPROV_LEGACY, Algid ALG_ID, dwFlags uint32, dwCertEncodingType CERT_QUERY_ENCODING_TYPE, pInfo *CERT_PUBLIC_KEY_INFO, pbComputedHash *uint8, pcbComputedHash *uint32) (r BOOL, err error) = crypt32.dll.CryptHashPublicKeyInfo
-//sys	CertRDNValueToStrA(dwValueType uint32, pValue *CRYPT_INTEGER_BLOB, psz *PSTRElement, csz uint32) (r uint32) = crypt32.dll.CertRDNValueToStrA
-//sys	CertRDNValueToStrW(dwValueType uint32, pValue *CRYPT_INTEGER_BLOB, psz *PWSTRElement, csz uint32) (r uint32) = crypt32.dll.CertRDNValueToStrW
-//sys	CertNameToStrA(dwCertEncodingType CERT_QUERY_ENCODING_TYPE, pName *CRYPT_INTEGER_BLOB, dwStrType CERT_STRING_TYPE, psz *PSTRElement, csz uint32) (r uint32) = crypt32.dll.CertNameToStrA
-//sys	CertNameToStrW(dwCertEncodingType CERT_QUERY_ENCODING_TYPE, pName *CRYPT_INTEGER_BLOB, dwStrType CERT_STRING_TYPE, psz *PWSTRElement, csz uint32) (r uint32) = crypt32.dll.CertNameToStrW
-//sys	CertStrToNameA(dwCertEncodingType CERT_QUERY_ENCODING_TYPE, pszX500 *PSTRElement, dwStrType CERT_STRING_TYPE, pvReserved unsafe.Pointer, pbEncoded *uint8, pcbEncoded *uint32, ppszError **PSTRElement) (r BOOL, err error) = crypt32.dll.CertStrToNameA
-//sys	CertStrToNameW(dwCertEncodingType CERT_QUERY_ENCODING_TYPE, pszX500 *PWSTRElement, dwStrType CERT_STRING_TYPE, pvReserved unsafe.Pointer, pbEncoded *uint8, pcbEncoded *uint32, ppszError **PWSTRElement) (r BOOL, err error) = crypt32.dll.CertStrToNameW
-//sys	CertGetNameStringA(pCertContext *CERT_CONTEXT, dwType uint32, dwFlags uint32, pvTypePara unsafe.Pointer, pszNameString *PSTRElement, cchNameString uint32) (r uint32) = crypt32.dll.CertGetNameStringA
-//sys	CertGetNameStringW(pCertContext *CERT_CONTEXT, dwType uint32, dwFlags uint32, pvTypePara unsafe.Pointer, pszNameString *PWSTRElement, cchNameString uint32) (r uint32) = crypt32.dll.CertGetNameStringW
-//sys	CryptSignMessage(pSignPara *CRYPT_SIGN_MESSAGE_PARA, fDetachedSignature BOOL, cToBeSigned uint32, rgpbToBeSigned **uint8, rgcbToBeSigned *uint32, pbSignedBlob *uint8, pcbSignedBlob *uint32) (r BOOL, err error) = crypt32.dll.CryptSignMessage
-//sys	CryptVerifyMessageSignature(pVerifyPara *CRYPT_VERIFY_MESSAGE_PARA, dwSignerIndex uint32, pbSignedBlob *uint8, cbSignedBlob uint32, pbDecoded *uint8, pcbDecoded *uint32, ppSignerCert **CERT_CONTEXT) (r BOOL, err error) = crypt32.dll.CryptVerifyMessageSignature
-//sys	CryptGetMessageSignerCount(dwMsgEncodingType uint32, pbSignedBlob *uint8, cbSignedBlob uint32) (r int32, err error) = crypt32.dll.CryptGetMessageSignerCount
-//sys	CryptGetMessageCertificates(dwMsgAndCertEncodingType uint32, hCryptProv HCRYPTPROV_LEGACY, dwFlags uint32, pbSignedBlob *uint8, cbSignedBlob uint32) (r HCERTSTORE, err error) = crypt32.dll.CryptGetMessageCertificates
-//sys	CryptVerifyDetachedMessageSignature(pVerifyPara *CRYPT_VERIFY_MESSAGE_PARA, dwSignerIndex uint32, pbDetachedSignBlob *uint8, cbDetachedSignBlob uint32, cToBeSigned uint32, rgpbToBeSigned **uint8, rgcbToBeSigned *uint32, ppSignerCert **CERT_CONTEXT) (r BOOL, err error) = crypt32.dll.CryptVerifyDetachedMessageSignature
-//sys	CryptEncryptMessage(pEncryptPara *CRYPT_ENCRYPT_MESSAGE_PARA, cRecipientCert uint32, rgpRecipientCert **CERT_CONTEXT, pbToBeEncrypted *uint8, cbToBeEncrypted uint32, pbEncryptedBlob *uint8, pcbEncryptedBlob *uint32) (r BOOL, err error) = crypt32.dll.CryptEncryptMessage
-//sys	CryptDecryptMessage(pDecryptPara *CRYPT_DECRYPT_MESSAGE_PARA, pbEncryptedBlob *uint8, cbEncryptedBlob uint32, pbDecrypted *uint8, pcbDecrypted *uint32, ppXchgCert **CERT_CONTEXT) (r BOOL, err error) = crypt32.dll.CryptDecryptMessage
-//sys	CryptSignAndEncryptMessage(pSignPara *CRYPT_SIGN_MESSAGE_PARA, pEncryptPara *CRYPT_ENCRYPT_MESSAGE_PARA, cRecipientCert uint32, rgpRecipientCert **CERT_CONTEXT, pbToBeSignedAndEncrypted *uint8, cbToBeSignedAndEncrypted uint32, pbSignedAndEncryptedBlob *uint8, pcbSignedAndEncryptedBlob *uint32) (r BOOL, err error) = crypt32.dll.CryptSignAndEncryptMessage
-//sys	CryptDecryptAndVerifyMessageSignature(pDecryptPara *CRYPT_DECRYPT_MESSAGE_PARA, pVerifyPara *CRYPT_VERIFY_MESSAGE_PARA, dwSignerIndex uint32, pbEncryptedBlob *uint8, cbEncryptedBlob uint32, pbDecrypted *uint8, pcbDecrypted *uint32, ppXchgCert **CERT_CONTEXT, ppSignerCert **CERT_CONTEXT) (r BOOL, err error) = crypt32.dll.CryptDecryptAndVerifyMessageSignature
-//sys	CryptDecodeMessage(dwMsgTypeFlags uint32, pDecryptPara *CRYPT_DECRYPT_MESSAGE_PARA, pVerifyPara *CRYPT_VERIFY_MESSAGE_PARA, dwSignerIndex uint32, pbEncodedBlob *uint8, cbEncodedBlob uint32, dwPrevInnerContentType uint32, pdwMsgType *uint32, pdwInnerContentType *uint32, pbDecoded *uint8, pcbDecoded *uint32, ppXchgCert **CERT_CONTEXT, ppSignerCert **CERT_CONTEXT) (r BOOL, err error) = crypt32.dll.CryptDecodeMessage
-//sys	CryptHashMessage(pHashPara *CRYPT_HASH_MESSAGE_PARA, fDetachedHash BOOL, cToBeHashed uint32, rgpbToBeHashed **uint8, rgcbToBeHashed *uint32, pbHashedBlob *uint8, pcbHashedBlob *uint32, pbComputedHash *uint8, pcbComputedHash *uint32) (r BOOL, err error) = crypt32.dll.CryptHashMessage
-//sys	CryptVerifyMessageHash(pHashPara *CRYPT_HASH_MESSAGE_PARA, pbHashedBlob *uint8, cbHashedBlob uint32, pbToBeHashed *uint8, pcbToBeHashed *uint32, pbComputedHash *uint8, pcbComputedHash *uint32) (r BOOL, err error) = crypt32.dll.CryptVerifyMessageHash
-//sys	CryptVerifyDetachedMessageHash(pHashPara *CRYPT_HASH_MESSAGE_PARA, pbDetachedHashBlob *uint8, cbDetachedHashBlob uint32, cToBeHashed uint32, rgpbToBeHashed **uint8, rgcbToBeHashed *uint32, pbComputedHash *uint8, pcbComputedHash *uint32) (r BOOL, err error) = crypt32.dll.CryptVerifyDetachedMessageHash
-//sys	CryptSignMessageWithKey(pSignPara *CRYPT_KEY_SIGN_MESSAGE_PARA, pbToBeSigned *uint8, cbToBeSigned uint32, pbSignedBlob *uint8, pcbSignedBlob *uint32) (r BOOL, err error) = crypt32.dll.CryptSignMessageWithKey
-//sys	CryptVerifyMessageSignatureWithKey(pVerifyPara *CRYPT_KEY_VERIFY_MESSAGE_PARA, pPublicKeyInfo *CERT_PUBLIC_KEY_INFO, pbSignedBlob *uint8, cbSignedBlob uint32, pbDecoded *uint8, pcbDecoded *uint32) (r BOOL, err error) = crypt32.dll.CryptVerifyMessageSignatureWithKey
-//sys	CertOpenSystemStoreA(hProv HCRYPTPROV_LEGACY, szSubsystemProtocol *PSTRElement) (r HCERTSTORE, err error) = crypt32.dll.CertOpenSystemStoreA
-//sys	CertOpenSystemStoreW(hProv HCRYPTPROV_LEGACY, szSubsystemProtocol *PWSTRElement) (r HCERTSTORE, err error) = crypt32.dll.CertOpenSystemStoreW
-//sys	CertAddEncodedCertificateToSystemStoreA(szCertStoreName *PSTRElement, pbCertEncoded *uint8, cbCertEncoded uint32) (r BOOL, err error) = crypt32.dll.CertAddEncodedCertificateToSystemStoreA
-//sys	CertAddEncodedCertificateToSystemStoreW(szCertStoreName *PWSTRElement, pbCertEncoded *uint8, cbCertEncoded uint32) (r BOOL, err error) = crypt32.dll.CertAddEncodedCertificateToSystemStoreW
-//sys	FindCertsByIssuer(pCertChains *CERT_CHAIN, pcbCertChains *uint32, pcCertChains *uint32, pbEncodedIssuerName *uint8, cbEncodedIssuerName uint32, pwszPurpose *PWSTRElement, dwKeySpec uint32) (r HRESULT) = wintrust.dll.FindCertsByIssuer
-//sys	CryptQueryObject(dwObjectType CERT_QUERY_OBJECT_TYPE, pvObject unsafe.Pointer, dwExpectedContentTypeFlags CERT_QUERY_CONTENT_TYPE_FLAGS, dwExpectedFormatTypeFlags CERT_QUERY_FORMAT_TYPE_FLAGS, dwFlags uint32, pdwMsgAndCertEncodingType *CERT_QUERY_ENCODING_TYPE, pdwContentType *CERT_QUERY_CONTENT_TYPE, pdwFormatType *CERT_QUERY_FORMAT_TYPE, phCertStore *HCERTSTORE, phMsg *unsafe.Pointer, ppvContext *unsafe.Pointer) (r BOOL, err error) = crypt32.dll.CryptQueryObject
-//sys	CryptMemAlloc(cbSize uint32) (r unsafe.Pointer) = crypt32.dll.CryptMemAlloc
-//sys	CryptMemRealloc(pv unsafe.Pointer, cbSize uint32) (r unsafe.Pointer) = crypt32.dll.CryptMemRealloc
-//sys	CryptMemFree(pv unsafe.Pointer) = crypt32.dll.CryptMemFree
-//sys	CryptCreateAsyncHandle(dwFlags uint32, phAsync *HCRYPTASYNC) (r BOOL) = crypt32.dll.CryptCreateAsyncHandle
-//sys	CryptSetAsyncParam(hAsync HCRYPTASYNC, pszParamOid *PSTRElement, pvParam unsafe.Pointer, pfnFree PFN_CRYPT_ASYNC_PARAM_FREE_FUNC) (r BOOL) = crypt32.dll.CryptSetAsyncParam
-//sys	CryptGetAsyncParam(hAsync HCRYPTASYNC, pszParamOid *PSTRElement, ppvParam *unsafe.Pointer, ppfnFree *PFN_CRYPT_ASYNC_PARAM_FREE_FUNC) (r BOOL) = crypt32.dll.CryptGetAsyncParam
-//sys	CryptCloseAsyncHandle(hAsync HCRYPTASYNC) (r BOOL) = crypt32.dll.CryptCloseAsyncHandle
-//sys	CryptRetrieveObjectByUrlA(pszUrl *PSTRElement, pszObjectOid *PSTRElement, dwRetrievalFlags uint32, dwTimeout uint32, ppvObject *unsafe.Pointer, hAsyncRetrieve HCRYPTASYNC, pCredentials *CRYPT_CREDENTIALS, pvVerify unsafe.Pointer, pAuxInfo *CRYPT_RETRIEVE_AUX_INFO) (r BOOL) = cryptnet.dll.CryptRetrieveObjectByUrlA
-//sys	CryptRetrieveObjectByUrlW(pszUrl *PWSTRElement, pszObjectOid *PSTRElement, dwRetrievalFlags uint32, dwTimeout uint32, ppvObject *unsafe.Pointer, hAsyncRetrieve HCRYPTASYNC, pCredentials *CRYPT_CREDENTIALS, pvVerify unsafe.Pointer, pAuxInfo *CRYPT_RETRIEVE_AUX_INFO) (r BOOL) = cryptnet.dll.CryptRetrieveObjectByUrlW
-//sys	CryptInstallCancelRetrieval(pfnCancel PFN_CRYPT_CANCEL_RETRIEVAL, pvArg unsafe.Pointer, dwFlags uint32, pvReserved unsafe.Pointer) (r BOOL) = cryptnet.dll.CryptInstallCancelRetrieval
-//sys	CryptUninstallCancelRetrieval(dwFlags uint32, pvReserved unsafe.Pointer) (r BOOL) = cryptnet.dll.CryptUninstallCancelRetrieval
-//sys	CryptGetObjectUrl(pszUrlOid *PSTRElement, pvPara unsafe.Pointer, dwFlags CRYPT_GET_URL_FLAGS, pUrlArray *CRYPT_URL_ARRAY, pcbUrlArray *uint32, pUrlInfo *CRYPT_URL_INFO, pcbUrlInfo *uint32, pvReserved unsafe.Pointer) (r BOOL, err error) = cryptnet.dll.CryptGetObjectUrl
-//sys	CertCreateSelfSignCertificate(hCryptProvOrNCryptKey HCRYPTPROV_OR_NCRYPT_KEY_HANDLE, pSubjectIssuerBlob *CRYPT_INTEGER_BLOB, dwFlags CERT_CREATE_SELFSIGN_FLAGS, pKeyProvInfo *CRYPT_KEY_PROV_INFO, pSignatureAlgorithm *CRYPT_ALGORITHM_IDENTIFIER, pStartTime *SYSTEMTIME, pEndTime *SYSTEMTIME, pExtensions *CERT_EXTENSIONS) (r *CERT_CONTEXT, err error) = crypt32.dll.CertCreateSelfSignCertificate
-//sys	CryptGetKeyIdentifierProperty(pKeyIdentifier *CRYPT_INTEGER_BLOB, dwPropId uint32, dwFlags uint32, pwszComputerName *PWSTRElement, pvReserved unsafe.Pointer, pvData unsafe.Pointer, pcbData *uint32) (r BOOL, err error) = crypt32.dll.CryptGetKeyIdentifierProperty
-//sys	CryptSetKeyIdentifierProperty(pKeyIdentifier *CRYPT_INTEGER_BLOB, dwPropId uint32, dwFlags uint32, pwszComputerName *PWSTRElement, pvReserved unsafe.Pointer, pvData unsafe.Pointer) (r BOOL, err error) = crypt32.dll.CryptSetKeyIdentifierProperty
-//sys	CryptEnumKeyIdentifierProperties(pKeyIdentifier *CRYPT_INTEGER_BLOB, dwPropId uint32, dwFlags uint32, pwszComputerName *PWSTRElement, pvReserved unsafe.Pointer, pvArg unsafe.Pointer, pfnEnum PFN_CRYPT_ENUM_KEYID_PROP) (r BOOL, err error) = crypt32.dll.CryptEnumKeyIdentifierProperties
-//sys	CryptCreateKeyIdentifierFromCSP(dwCertEncodingType CERT_QUERY_ENCODING_TYPE, pszPubKeyOID *PSTRElement, pPubKeyStruc *PUBLICKEYSTRUC, cbPubKeyStruc uint32, dwFlags uint32, pvReserved unsafe.Pointer, pbHash *uint8, pcbHash *uint32) (r BOOL, err error) = crypt32.dll.CryptCreateKeyIdentifierFromCSP
-//sys	CertCreateCertificateChainEngine(pConfig *CERT_CHAIN_ENGINE_CONFIG, phChainEngine *HCERTCHAINENGINE) (r BOOL, err error) = crypt32.dll.CertCreateCertificateChainEngine
-//sys	CertFreeCertificateChainEngine(hChainEngine HCERTCHAINENGINE) = crypt32.dll.CertFreeCertificateChainEngine
-//sys	CertResyncCertificateChainEngine(hChainEngine HCERTCHAINENGINE) (r BOOL, err error) = crypt32.dll.CertResyncCertificateChainEngine
-//sys	CertGetCertificateChain(hChainEngine HCERTCHAINENGINE, pCertContext *CERT_CONTEXT, pTime *FILETIME, hAdditionalStore HCERTSTORE, pChainPara *CERT_CHAIN_PARA, dwFlags uint32, pvReserved unsafe.Pointer, ppChainContext **CERT_CHAIN_CONTEXT) (r BOOL, err error) = crypt32.dll.CertGetCertificateChain
-//sys	CertFreeCertificateChain(pChainContext *CERT_CHAIN_CONTEXT) = crypt32.dll.CertFreeCertificateChain
-//sys	CertDuplicateCertificateChain(pChainContext *CERT_CHAIN_CONTEXT) (r *CERT_CHAIN_CONTEXT) = crypt32.dll.CertDuplicateCertificateChain
-//sys	CertFindChainInStore(hCertStore HCERTSTORE, dwCertEncodingType CERT_QUERY_ENCODING_TYPE, dwFindFlags CERT_FIND_CHAIN_IN_STORE_FLAGS, dwFindType uint32, pvFindPara unsafe.Pointer, pPrevChainContext *CERT_CHAIN_CONTEXT) (r *CERT_CHAIN_CONTEXT) = crypt32.dll.CertFindChainInStore
-//sys	CertVerifyCertificateChainPolicy(pszPolicyOID *PSTRElement, pChainContext *CERT_CHAIN_CONTEXT, pPolicyPara *CERT_CHAIN_POLICY_PARA, pPolicyStatus *CERT_CHAIN_POLICY_STATUS) (r BOOL) = crypt32.dll.CertVerifyCertificateChainPolicy
-//sys	CryptStringToBinaryA(pszString *PSTRElement, cchString uint32, dwFlags CRYPT_STRING, pbBinary *uint8, pcbBinary *uint32, pdwSkip *uint32, pdwFlags *uint32) (r BOOL, err error) = crypt32.dll.CryptStringToBinaryA
-//sys	CryptStringToBinaryW(pszString *PWSTRElement, cchString uint32, dwFlags CRYPT_STRING, pbBinary *uint8, pcbBinary *uint32, pdwSkip *uint32, pdwFlags *uint32) (r BOOL, err error) = crypt32.dll.CryptStringToBinaryW
-//sys	CryptBinaryToStringA(pbBinary *uint8, cbBinary uint32, dwFlags CRYPT_STRING, pszString *PSTRElement, pcchString *uint32) (r BOOL) = crypt32.dll.CryptBinaryToStringA
-//sys	CryptBinaryToStringW(pbBinary *uint8, cbBinary uint32, dwFlags CRYPT_STRING, pszString *PWSTRElement, pcchString *uint32) (r BOOL) = crypt32.dll.CryptBinaryToStringW
-//sys	PFXImportCertStore(pPFX *CRYPT_INTEGER_BLOB, szPassword *PWSTRElement, dwFlags CRYPT_KEY_FLAGS) (r HCERTSTORE, err error) = crypt32.dll.PFXImportCertStore
-//sys	PFXIsPFXBlob(pPFX *CRYPT_INTEGER_BLOB) (r BOOL) = crypt32.dll.PFXIsPFXBlob
-//sys	PFXVerifyPassword(pPFX *CRYPT_INTEGER_BLOB, szPassword *PWSTRElement, dwFlags uint32) (r BOOL) = crypt32.dll.PFXVerifyPassword
-//sys	PFXExportCertStoreEx(hStore HCERTSTORE, pPFX *CRYPT_INTEGER_BLOB, szPassword *PWSTRElement, pvPara unsafe.Pointer, dwFlags uint32) (r BOOL, err error) = crypt32.dll.PFXExportCertStoreEx
-//sys	PFXExportCertStore(hStore HCERTSTORE, pPFX *CRYPT_INTEGER_BLOB, szPassword *PWSTRElement, dwFlags uint32) (r BOOL, err error) = crypt32.dll.PFXExportCertStore
-//sys	CertOpenServerOcspResponse(pChainContext *CERT_CHAIN_CONTEXT, dwFlags uint32, pOpenPara *CERT_SERVER_OCSP_RESPONSE_OPEN_PARA) (r unsafe.Pointer, err error) = crypt32.dll.CertOpenServerOcspResponse
-//sys	CertAddRefServerOcspResponse(hServerOcspResponse unsafe.Pointer) = crypt32.dll.CertAddRefServerOcspResponse
-//sys	CertCloseServerOcspResponse(hServerOcspResponse unsafe.Pointer, dwFlags uint32) = crypt32.dll.CertCloseServerOcspResponse
-//sys	CertGetServerOcspResponseContext(hServerOcspResponse unsafe.Pointer, dwFlags uint32, pvReserved unsafe.Pointer) (r *CERT_SERVER_OCSP_RESPONSE_CONTEXT) = crypt32.dll.CertGetServerOcspResponseContext
-//sys	CertAddRefServerOcspResponseContext(pServerOcspResponseContext *CERT_SERVER_OCSP_RESPONSE_CONTEXT) = crypt32.dll.CertAddRefServerOcspResponseContext
-//sys	CertFreeServerOcspResponseContext(pServerOcspResponseContext *CERT_SERVER_OCSP_RESPONSE_CONTEXT) = crypt32.dll.CertFreeServerOcspResponseContext
-//sys	CertRetrieveLogoOrBiometricInfo(pCertContext *CERT_CONTEXT, lpszLogoOrBiometricType *PSTRElement, dwRetrievalFlags uint32, dwTimeout uint32, dwFlags uint32, pvReserved unsafe.Pointer, ppbData **uint8, pcbData *uint32, ppwszMimeType **PWSTRElement) (r BOOL, err error) = crypt32.dll.CertRetrieveLogoOrBiometricInfo
-//sys	CertSelectCertificateChains(pSelectionContext *Guid, dwFlags uint32, pChainParameters *CERT_SELECT_CHAIN_PARA, cCriteria uint32, rgpCriteria *CERT_SELECT_CRITERIA, hStore HCERTSTORE, pcSelection *uint32, pprgpSelection ***CERT_CHAIN_CONTEXT) (r BOOL, err error) = crypt32.dll.CertSelectCertificateChains
-//sys	CertFreeCertificateChainList(prgpSelection **CERT_CHAIN_CONTEXT) = crypt32.dll.CertFreeCertificateChainList
-//sys	CryptRetrieveTimeStamp(wszUrl *PWSTRElement, dwRetrievalFlags uint32, dwTimeout uint32, pszHashId *PSTRElement, pPara *CRYPT_TIMESTAMP_PARA, pbData *uint8, cbData uint32, ppTsContext **CRYPT_TIMESTAMP_CONTEXT, ppTsSigner **CERT_CONTEXT, phStore *HCERTSTORE) (r BOOL, err error) = crypt32.dll.CryptRetrieveTimeStamp
-//sys	CryptVerifyTimeStampSignature(pbTSContentInfo *uint8, cbTSContentInfo uint32, pbData *uint8, cbData uint32, hAdditionalStore HCERTSTORE, ppTsContext **CRYPT_TIMESTAMP_CONTEXT, ppTsSigner **CERT_CONTEXT, phStore *HCERTSTORE) (r BOOL, err error) = crypt32.dll.CryptVerifyTimeStampSignature
-//sys	CertIsWeakHash(dwHashUseType uint32, pwszCNGHashAlgid *PWSTRElement, dwChainFlags uint32, pSignerChainContext *CERT_CHAIN_CONTEXT, pTimeStamp *FILETIME, pwszFileName *PWSTRElement) (r BOOL) = crypt32.dll.CertIsWeakHash
-//sys	CryptProtectData(pDataIn *CRYPT_INTEGER_BLOB, szDataDescr *PWSTRElement, pOptionalEntropy *CRYPT_INTEGER_BLOB, pvReserved unsafe.Pointer, pPromptStruct *CRYPTPROTECT_PROMPTSTRUCT, dwFlags uint32, pDataOut *CRYPT_INTEGER_BLOB) (r BOOL, err error) = crypt32.dll.CryptProtectData
-//sys	CryptUnprotectData(pDataIn *CRYPT_INTEGER_BLOB, ppszDataDescr **PWSTRElement, pOptionalEntropy *CRYPT_INTEGER_BLOB, pvReserved unsafe.Pointer, pPromptStruct *CRYPTPROTECT_PROMPTSTRUCT, dwFlags uint32, pDataOut *CRYPT_INTEGER_BLOB) (r BOOL, err error) = crypt32.dll.CryptUnprotectData
-//sys	CryptUpdateProtectedState(pOldSid PSID, pwszOldPassword *PWSTRElement, dwFlags uint32, pdwSuccessCount *uint32, pdwFailureCount *uint32) (r BOOL, err error) = crypt32.dll.CryptUpdateProtectedState
-//sys	CryptProtectMemory(pDataIn unsafe.Pointer, cbDataIn uint32, dwFlags uint32) (r BOOL, err error) = crypt32.dll.CryptProtectMemory
-//sys	CryptUnprotectMemory(pDataIn unsafe.Pointer, cbDataIn uint32, dwFlags uint32) (r BOOL, err error) = crypt32.dll.CryptUnprotectMemory
-//sys	NCryptRegisterProtectionDescriptorName(pwszName *PWSTRElement, pwszDescriptorString *PWSTRElement, dwFlags uint32) (r HRESULT) = ncrypt.dll.NCryptRegisterProtectionDescriptorName
-//sys	NCryptQueryProtectionDescriptorName(pwszName *PWSTRElement, pwszDescriptorString *PWSTRElement, pcDescriptorString *uintptr, dwFlags uint32) (r HRESULT) = ncrypt.dll.NCryptQueryProtectionDescriptorName
-//sys	NCryptCreateProtectionDescriptor(pwszDescriptorString *PWSTRElement, dwFlags uint32, phDescriptor *NCRYPT_DESCRIPTOR_HANDLE) (r HRESULT) = ncrypt.dll.NCryptCreateProtectionDescriptor
-//sys	NCryptCloseProtectionDescriptor(hDescriptor NCRYPT_DESCRIPTOR_HANDLE) (r HRESULT) = ncrypt.dll.NCryptCloseProtectionDescriptor
-//sys	NCryptGetProtectionDescriptorInfo(hDescriptor NCRYPT_DESCRIPTOR_HANDLE, pMemPara *NCRYPT_ALLOC_PARA, dwInfoType uint32, ppvInfo *unsafe.Pointer) (r HRESULT) = ncrypt.dll.NCryptGetProtectionDescriptorInfo
-//sys	NCryptProtectSecret(hDescriptor NCRYPT_DESCRIPTOR_HANDLE, dwFlags uint32, pbData *uint8, cbData uint32, pMemPara *NCRYPT_ALLOC_PARA, hWnd HWND, ppbProtectedBlob **uint8, pcbProtectedBlob *uint32) (r HRESULT) = ncrypt.dll.NCryptProtectSecret
-//sys	NCryptUnprotectSecret(phDescriptor *NCRYPT_DESCRIPTOR_HANDLE, dwFlags NCRYPT_FLAGS, pbProtectedBlob *uint8, cbProtectedBlob uint32, pMemPara *NCRYPT_ALLOC_PARA, hWnd HWND, ppbData **uint8, pcbData *uint32) (r HRESULT) = ncrypt.dll.NCryptUnprotectSecret
-//sys	NCryptStreamOpenToProtect(hDescriptor NCRYPT_DESCRIPTOR_HANDLE, dwFlags uint32, hWnd HWND, pStreamInfo *NCRYPT_PROTECT_STREAM_INFO, phStream *NCRYPT_STREAM_HANDLE) (r HRESULT) = ncrypt.dll.NCryptStreamOpenToProtect
-//sys	NCryptStreamOpenToUnprotect(pStreamInfo *NCRYPT_PROTECT_STREAM_INFO, dwFlags uint32, hWnd HWND, phStream *NCRYPT_STREAM_HANDLE) (r HRESULT) = ncrypt.dll.NCryptStreamOpenToUnprotect
-//sys	NCryptStreamOpenToUnprotectEx(pStreamInfo *NCRYPT_PROTECT_STREAM_INFO_EX, dwFlags uint32, hWnd HWND, phStream *NCRYPT_STREAM_HANDLE) (r HRESULT) = ncrypt.dll.NCryptStreamOpenToUnprotectEx
-//sys	NCryptStreamUpdate(hStream NCRYPT_STREAM_HANDLE, pbData *uint8, cbData uintptr, fFinal BOOL) (r HRESULT) = ncrypt.dll.NCryptStreamUpdate
-//sys	NCryptStreamClose(hStream NCRYPT_STREAM_HANDLE) (r HRESULT) = ncrypt.dll.NCryptStreamClose
-//sys	SignError() (r HRESULT) = mssign32.dll.SignError
-//sys	SignerFreeSignerContext(pSignerContext *SIGNER_CONTEXT) (r HRESULT) = mssign32.dll.SignerFreeSignerContext
-//sys	SignerSign(pSubjectInfo *SIGNER_SUBJECT_INFO, pSignerCert *SIGNER_CERT, pSignatureInfo *SIGNER_SIGNATURE_INFO, pProviderInfo *SIGNER_PROVIDER_INFO, pwszHttpTimeStamp *PWSTRElement, psRequest *CRYPT_ATTRIBUTES, pSipData unsafe.Pointer) (r HRESULT) = mssign32.dll.SignerSign
-//sys	SignerSignEx(dwFlags SIGNER_SIGN_FLAGS, pSubjectInfo *SIGNER_SUBJECT_INFO, pSignerCert *SIGNER_CERT, pSignatureInfo *SIGNER_SIGNATURE_INFO, pProviderInfo *SIGNER_PROVIDER_INFO, pwszHttpTimeStamp *PWSTRElement, psRequest *CRYPT_ATTRIBUTES, pSipData unsafe.Pointer, ppSignerContext **SIGNER_CONTEXT) (r HRESULT) = mssign32.dll.SignerSignEx
-//sys	SignerSignEx2(dwFlags SIGNER_SIGN_FLAGS, pSubjectInfo *SIGNER_SUBJECT_INFO, pSignerCert *SIGNER_CERT, pSignatureInfo *SIGNER_SIGNATURE_INFO, pProviderInfo *SIGNER_PROVIDER_INFO, dwTimestampFlags SIGNER_TIMESTAMP_FLAGS, pszTimestampAlgorithmOid *PSTRElement, pwszHttpTimeStamp *PWSTRElement, psRequest *CRYPT_ATTRIBUTES, pSipData unsafe.Pointer, ppSignerContext **SIGNER_CONTEXT, pCryptoPolicy *CERT_STRONG_SIGN_PARA, pReserved unsafe.Pointer) (r HRESULT) = mssign32.dll.SignerSignEx2
-//sys	SignerSignEx3(dwFlags SIGNER_SIGN_FLAGS, pSubjectInfo *SIGNER_SUBJECT_INFO, pSignerCert *SIGNER_CERT, pSignatureInfo *SIGNER_SIGNATURE_INFO, pProviderInfo *SIGNER_PROVIDER_INFO, dwTimestampFlags SIGNER_TIMESTAMP_FLAGS, pszTimestampAlgorithmOid *PSTRElement, pwszHttpTimeStamp *PWSTRElement, psRequest *CRYPT_ATTRIBUTES, pSipData unsafe.Pointer, ppSignerContext **SIGNER_CONTEXT, pCryptoPolicy *CERT_STRONG_SIGN_PARA, pDigestSignInfo *SIGNER_DIGEST_SIGN_INFO, pReserved unsafe.Pointer) (r HRESULT) = mssign32.dll.SignerSignEx3
-//sys	SignerTimeStamp(pSubjectInfo *SIGNER_SUBJECT_INFO, pwszHttpTimeStamp *PWSTRElement, psRequest *CRYPT_ATTRIBUTES, pSipData unsafe.Pointer) (r HRESULT) = mssign32.dll.SignerTimeStamp
-//sys	SignerTimeStampEx(dwFlags uint32, pSubjectInfo *SIGNER_SUBJECT_INFO, pwszHttpTimeStamp *PWSTRElement, psRequest *CRYPT_ATTRIBUTES, pSipData unsafe.Pointer, ppSignerContext **SIGNER_CONTEXT) (r HRESULT) = mssign32.dll.SignerTimeStampEx
-//sys	SignerTimeStampEx2(dwFlags SIGNER_TIMESTAMP_FLAGS, pSubjectInfo *SIGNER_SUBJECT_INFO, pwszHttpTimeStamp *PWSTRElement, dwAlgId ALG_ID, psRequest *CRYPT_ATTRIBUTES, pSipData unsafe.Pointer, ppSignerContext **SIGNER_CONTEXT) (r HRESULT) = mssign32.dll.SignerTimeStampEx2
-//sys	SignerTimeStampEx3(dwFlags SIGNER_TIMESTAMP_FLAGS, dwIndex uint32, pSubjectInfo *SIGNER_SUBJECT_INFO, pwszHttpTimeStamp *PWSTRElement, pszAlgorithmOid *PWSTRElement, psRequest *CRYPT_ATTRIBUTES, pSipData unsafe.Pointer, ppSignerContext **SIGNER_CONTEXT, pCryptoPolicy *CERT_STRONG_SIGN_PARA, pReserved unsafe.Pointer) (r HRESULT) = mssign32.dll.SignerTimeStampEx3
-//sys	CryptXmlClose(hCryptXml unsafe.Pointer) (r HRESULT) = cryptxml.dll.CryptXmlClose
-//sys	CryptXmlGetTransforms(ppConfig **CRYPT_XML_TRANSFORM_CHAIN_CONFIG) (r HRESULT) = cryptxml.dll.CryptXmlGetTransforms
-//sys	CryptXmlOpenToEncode(pConfig *CRYPT_XML_TRANSFORM_CHAIN_CONFIG, dwFlags CRYPT_XML_FLAGS, wszId *PWSTRElement, rgProperty *CRYPT_XML_PROPERTY, cProperty uint32, pEncoded *CRYPT_XML_BLOB, phSignature *unsafe.Pointer) (r HRESULT) = cryptxml.dll.CryptXmlOpenToEncode
-//sys	CryptXmlOpenToDecode(pConfig *CRYPT_XML_TRANSFORM_CHAIN_CONFIG, dwFlags CRYPT_XML_FLAGS, rgProperty *CRYPT_XML_PROPERTY, cProperty uint32, pEncoded *CRYPT_XML_BLOB, phCryptXml *unsafe.Pointer) (r HRESULT) = cryptxml.dll.CryptXmlOpenToDecode
-//sys	CryptXmlAddObject(hSignatureOrObject unsafe.Pointer, dwFlags uint32, rgProperty *CRYPT_XML_PROPERTY, cProperty uint32, pEncoded *CRYPT_XML_BLOB, ppObject **CRYPT_XML_OBJECT) (r HRESULT) = cryptxml.dll.CryptXmlAddObject
-//sys	CryptXmlCreateReference(hCryptXml unsafe.Pointer, dwFlags uint32, wszId *PWSTRElement, wszURI *PWSTRElement, wszType *PWSTRElement, pDigestMethod *CRYPT_XML_ALGORITHM, cTransform uint32, rgTransform *CRYPT_XML_ALGORITHM, phReference *unsafe.Pointer) (r HRESULT) = cryptxml.dll.CryptXmlCreateReference
-//sys	CryptXmlDigestReference(hReference unsafe.Pointer, dwFlags uint32, pDataProviderIn *CRYPT_XML_DATA_PROVIDER) (r HRESULT) = cryptxml.dll.CryptXmlDigestReference
-//sys	CryptXmlSetHMACSecret(hSignature unsafe.Pointer, pbSecret *uint8, cbSecret uint32) (r HRESULT) = cryptxml.dll.CryptXmlSetHMACSecret
-//sys	CryptXmlSign(hSignature unsafe.Pointer, hKey HCRYPTPROV_OR_NCRYPT_KEY_HANDLE, dwKeySpec CERT_KEY_SPEC, dwFlags CRYPT_XML_FLAGS, dwKeyInfoSpec CRYPT_XML_KEYINFO_SPEC, pvKeyInfoSpec unsafe.Pointer, pSignatureMethod *CRYPT_XML_ALGORITHM, pCanonicalization *CRYPT_XML_ALGORITHM) (r HRESULT) = cryptxml.dll.CryptXmlSign
-//sys	CryptXmlImportPublicKey(dwFlags CRYPT_XML_FLAGS, pKeyValue *CRYPT_XML_KEY_VALUE, phKey *BCRYPT_KEY_HANDLE) (r HRESULT) = cryptxml.dll.CryptXmlImportPublicKey
-//sys	CryptXmlVerifySignature(hSignature unsafe.Pointer, hKey BCRYPT_KEY_HANDLE, dwFlags CRYPT_XML_FLAGS) (r HRESULT) = cryptxml.dll.CryptXmlVerifySignature
-//sys	CryptXmlGetDocContext(hCryptXml unsafe.Pointer, ppStruct **CRYPT_XML_DOC_CTXT) (r HRESULT) = cryptxml.dll.CryptXmlGetDocContext
-//sys	CryptXmlGetSignature(hCryptXml unsafe.Pointer, ppStruct **CRYPT_XML_SIGNATURE) (r HRESULT) = cryptxml.dll.CryptXmlGetSignature
-//sys	CryptXmlGetReference(hCryptXml unsafe.Pointer, ppStruct **CRYPT_XML_REFERENCE) (r HRESULT) = cryptxml.dll.CryptXmlGetReference
-//sys	CryptXmlGetStatus(hCryptXml unsafe.Pointer, pStatus *CRYPT_XML_STATUS) (r HRESULT) = cryptxml.dll.CryptXmlGetStatus
-//sys	CryptXmlEncode(hCryptXml unsafe.Pointer, dwCharset CRYPT_XML_CHARSET, rgProperty *CRYPT_XML_PROPERTY, cProperty uint32, pvCallbackState unsafe.Pointer, pfnWrite PFN_CRYPT_XML_WRITE_CALLBACK) (r HRESULT) = cryptxml.dll.CryptXmlEncode
-//sys	CryptXmlGetAlgorithmInfo(pXmlAlgorithm *CRYPT_XML_ALGORITHM, dwFlags CRYPT_XML_FLAGS, ppAlgInfo **CRYPT_XML_ALGORITHM_INFO) (r HRESULT) = cryptxml.dll.CryptXmlGetAlgorithmInfo
-//sys	CryptXmlFindAlgorithmInfo(dwFindByType uint32, pvFindBy unsafe.Pointer, dwGroupId uint32, dwFlags uint32) (r *CRYPT_XML_ALGORITHM_INFO) = cryptxml.dll.CryptXmlFindAlgorithmInfo
-//sys	CryptXmlEnumAlgorithmInfo(dwGroupId uint32, dwFlags uint32, pvArg unsafe.Pointer, pfnEnumAlgInfo PFN_CRYPT_XML_ENUM_ALG_INFO) (r HRESULT) = cryptxml.dll.CryptXmlEnumAlgorithmInfo
-//sys	GetToken(cPolicyChain uint32, pPolicyChain *POLICY_ELEMENT, securityToken **GENERIC_XML_TOKEN, phProofTokenCrypto **INFORMATIONCARD_CRYPTO_HANDLE) (r HRESULT) = infocardapi.dll.GetToken
-//sys	ManageCardSpace() (r HRESULT) = infocardapi.dll.ManageCardSpace
-//sys	ImportInformationCard(fileName *PWSTRElement) (r HRESULT) = infocardapi.dll.ImportInformationCard
-//sys	Encrypt(hCrypto *INFORMATIONCARD_CRYPTO_HANDLE, fOAEP BOOL, cbInData uint32, pInData *uint8, pcbOutData *uint32, ppOutData **uint8) (r HRESULT) = infocardapi.dll.Encrypt
-//sys	Decrypt(hCrypto *INFORMATIONCARD_CRYPTO_HANDLE, fOAEP BOOL, cbInData uint32, pInData *uint8, pcbOutData *uint32, ppOutData **uint8) (r HRESULT) = infocardapi.dll.Decrypt
-//sys	SignHash(hCrypto *INFORMATIONCARD_CRYPTO_HANDLE, cbHash uint32, pHash *uint8, hashAlgOid *PWSTRElement, pcbSig *uint32, ppSig **uint8) (r HRESULT) = infocardapi.dll.SignHash
-//sys	VerifyHash(hCrypto *INFORMATIONCARD_CRYPTO_HANDLE, cbHash uint32, pHash *uint8, hashAlgOid *PWSTRElement, cbSig uint32, pSig *uint8, pfVerified *BOOL) (r HRESULT) = infocardapi.dll.VerifyHash
-//sys	GetCryptoTransform(hSymmetricCrypto *INFORMATIONCARD_CRYPTO_HANDLE, mode uint32, padding PaddingMode, feedbackSize uint32, direction Direction, cbIV uint32, pIV *uint8, pphTransform **INFORMATIONCARD_CRYPTO_HANDLE) (r HRESULT) = infocardapi.dll.GetCryptoTransform
-//sys	GetKeyedHash(hSymmetricCrypto *INFORMATIONCARD_CRYPTO_HANDLE, pphHash **INFORMATIONCARD_CRYPTO_HANDLE) (r HRESULT) = infocardapi.dll.GetKeyedHash
-//sys	TransformBlock(hCrypto *INFORMATIONCARD_CRYPTO_HANDLE, cbInData uint32, pInData *uint8, pcbOutData *uint32, ppOutData **uint8) (r HRESULT) = infocardapi.dll.TransformBlock
-//sys	TransformFinalBlock(hCrypto *INFORMATIONCARD_CRYPTO_HANDLE, cbInData uint32, pInData *uint8, pcbOutData *uint32, ppOutData **uint8) (r HRESULT) = infocardapi.dll.TransformFinalBlock
-//sys	HashCore(hCrypto *INFORMATIONCARD_CRYPTO_HANDLE, cbInData uint32, pInData *uint8) (r HRESULT) = infocardapi.dll.HashCore
-//sys	HashFinal(hCrypto *INFORMATIONCARD_CRYPTO_HANDLE, cbInData uint32, pInData *uint8, pcbOutData *uint32, ppOutData **uint8) (r HRESULT) = infocardapi.dll.HashFinal
-//sys	FreeToken(pAllocMemory *GENERIC_XML_TOKEN) (r BOOL) = infocardapi.dll.FreeToken
-//sys	CloseCryptoHandle(hCrypto *INFORMATIONCARD_CRYPTO_HANDLE) (r HRESULT) = infocardapi.dll.CloseCryptoHandle
-//sys	GenerateDerivedKey(hCrypto *INFORMATIONCARD_CRYPTO_HANDLE, cbLabel uint32, pLabel *uint8, cbNonce uint32, pNonce *uint8, derivedKeyLength uint32, offset uint32, algId *PWSTRElement, pcbKey *uint32, ppKey **uint8) (r HRESULT) = infocardapi.dll.GenerateDerivedKey
-//sys	GetBrowserToken(dwParamType uint32, pParam unsafe.Pointer, pcbToken *uint32, ppToken **uint8) (r HRESULT) = infocardapi.dll.GetBrowserToken
-//sys	GetCipherInterface(pszProviderName *PWSTRElement, pszAlgId *PWSTRElement, ppFunctionTable **BCRYPT_CIPHER_FUNCTION_TABLE, dwFlags uint32) (r NTSTATUS) = bcryptprimitives.dll.GetCipherInterface
-//sys	GetHashInterface(pszProviderName *PWSTRElement, pszAlgId *PWSTRElement, ppFunctionTable **BCRYPT_HASH_FUNCTION_TABLE, dwFlags uint32) (r NTSTATUS) = bcryptprimitives.dll.GetHashInterface
-//sys	GetAsymmetricEncryptionInterface(pszProviderName *PWSTRElement, pszAlgId *PWSTRElement, ppFunctionTable **BCRYPT_ASYMMETRIC_ENCRYPTION_FUNCTION_TABLE, dwFlags uint32) (r NTSTATUS) = bcryptprimitives.dll.GetAsymmetricEncryptionInterface
-//sys	GetSecretAgreementInterface(pszProviderName *PWSTRElement, pszAlgId *PWSTRElement, ppFunctionTable **BCRYPT_SECRET_AGREEMENT_FUNCTION_TABLE, dwFlags uint32) (r NTSTATUS) = bcryptprimitives.dll.GetSecretAgreementInterface
-//sys	GetSignatureInterface(pszProviderName *PWSTRElement, pszAlgId *PWSTRElement, ppFunctionTable **BCRYPT_SIGNATURE_FUNCTION_TABLE, dwFlags uint32) (r NTSTATUS) = bcryptprimitives.dll.GetSignatureInterface
-//sys	GetRngInterface(pszProviderName *PWSTRElement, ppFunctionTable **BCRYPT_RNG_FUNCTION_TABLE, dwFlags uint32) (r NTSTATUS) = bcryptprimitives.dll.GetRngInterface
-//sys	GetKeyDerivationInterface(pszProviderName *PWSTRElement, pszAlgId *PWSTRElement, ppFunctionTable **BCRYPT_KEY_DERIVATION_FUNCTION_TABLE, dwFlags uint32) (r NTSTATUS) = bcryptprimitives.dll.GetKeyDerivationInterface
-//sys	BCryptRegisterProvider(pszProvider *PWSTRElement, dwFlags uint32, pReg *CRYPT_PROVIDER_REG) (r NTSTATUS) = bcrypt.dll.BCryptRegisterProvider
-//sys	BCryptUnregisterProvider(pszProvider *PWSTRElement) (r NTSTATUS) = bcrypt.dll.BCryptUnregisterProvider
-//sys	BCryptAddContextFunctionProvider(dwTable uint32, pszContext *PWSTRElement, dwInterface uint32, pszFunction *PWSTRElement, pszProvider *PWSTRElement, dwPosition uint32) (r NTSTATUS) = bcrypt.dll.BCryptAddContextFunctionProvider
-//sys	BCryptRemoveContextFunctionProvider(dwTable uint32, pszContext *PWSTRElement, dwInterface uint32, pszFunction *PWSTRElement, pszProvider *PWSTRElement) (r NTSTATUS) = bcrypt.dll.BCryptRemoveContextFunctionProvider
-//sys	GetKeyStorageInterface(pszProviderName *PWSTRElement, ppFunctionTable **NCRYPT_KEY_STORAGE_FUNCTION_TABLE, dwFlags uint32) (r NTSTATUS) = ncrypt.dll.GetKeyStorageInterface
-//sys	SslChangeNotify(hEvent HANDLE, dwFlags uint32) (r HRESULT) = ncrypt.dll.SslChangeNotify
-//sys	SslComputeClientAuthHash(hSslProvider NCRYPT_PROV_HANDLE, hMasterKey NCRYPT_KEY_HANDLE, hHandshakeHash NCRYPT_HASH_HANDLE, pszAlgId *PWSTRElement, pbOutput *uint8, cbOutput uint32, pcbResult *uint32, dwFlags uint32) (r HRESULT) = ncrypt.dll.SslComputeClientAuthHash
-//sys	SslComputeEapKeyBlock(hSslProvider NCRYPT_PROV_HANDLE, hMasterKey NCRYPT_KEY_HANDLE, pbRandoms *uint8, cbRandoms uint32, pbOutput *uint8, cbOutput uint32, pcbResult *uint32, dwFlags uint32) (r HRESULT) = ncrypt.dll.SslComputeEapKeyBlock
-//sys	SslComputeFinishedHash(hSslProvider NCRYPT_PROV_HANDLE, hMasterKey NCRYPT_KEY_HANDLE, hHandshakeHash NCRYPT_HASH_HANDLE, pbOutput *uint8, cbOutput uint32, dwFlags uint32) (r HRESULT) = ncrypt.dll.SslComputeFinishedHash
-//sys	SslCreateEphemeralKey(hSslProvider NCRYPT_PROV_HANDLE, phEphemeralKey *NCRYPT_KEY_HANDLE, dwProtocol uint32, dwCipherSuite uint32, dwKeyType uint32, dwKeyBitLen uint32, pbParams *uint8, cbParams uint32, dwFlags uint32) (r HRESULT) = ncrypt.dll.SslCreateEphemeralKey
-//sys	SslCreateHandshakeHash(hSslProvider NCRYPT_PROV_HANDLE, phHandshakeHash *NCRYPT_HASH_HANDLE, dwProtocol uint32, dwCipherSuite uint32, dwFlags uint32) (r HRESULT) = ncrypt.dll.SslCreateHandshakeHash
-//sys	SslDecryptPacket(hSslProvider NCRYPT_PROV_HANDLE, hKey NCRYPT_KEY_HANDLE, pbInput *uint8, cbInput uint32, pbOutput *uint8, cbOutput uint32, pcbResult *uint32, SequenceNumber uint64, dwFlags uint32) (r HRESULT) = ncrypt.dll.SslDecryptPacket
-//sys	SslEncryptPacket(hSslProvider NCRYPT_PROV_HANDLE, hKey NCRYPT_KEY_HANDLE, pbInput *uint8, cbInput uint32, pbOutput *uint8, cbOutput uint32, pcbResult *uint32, SequenceNumber uint64, dwContentType uint32, dwFlags uint32) (r HRESULT) = ncrypt.dll.SslEncryptPacket
-//sys	SslEnumCipherSuites(hSslProvider NCRYPT_PROV_HANDLE, hPrivateKey NCRYPT_KEY_HANDLE, ppCipherSuite **NCRYPT_SSL_CIPHER_SUITE, ppEnumState *unsafe.Pointer, dwFlags uint32) (r HRESULT) = ncrypt.dll.SslEnumCipherSuites
-//sys	SslEnumCipherSuitesEx(hSslProvider NCRYPT_PROV_HANDLE, hPrivateKey NCRYPT_KEY_HANDLE, ppCipherSuite **NCRYPT_SSL_CIPHER_SUITE_EX, ppEnumState *unsafe.Pointer, dwFlags uint32) (r HRESULT) = ncrypt.dll.SslEnumCipherSuitesEx
-//sys	SslEnumEccCurves(hSslProvider NCRYPT_PROV_HANDLE, pEccCurveCount *uint32, ppEccCurve **NCRYPT_SSL_ECC_CURVE, dwFlags uint32) (r HRESULT) = ncrypt.dll.SslEnumEccCurves
-//sys	SslEnumProtocolProviders(pdwProviderCount *uint32, ppProviderList **NCryptProviderName, dwFlags uint32) (r HRESULT) = ncrypt.dll.SslEnumProtocolProviders
-//sys	SslExportKey(hSslProvider NCRYPT_PROV_HANDLE, hKey NCRYPT_KEY_HANDLE, pszBlobType *PWSTRElement, pbOutput *uint8, cbOutput uint32, pcbResult *uint32, dwFlags uint32) (r HRESULT) = ncrypt.dll.SslExportKey
-//sys	SslFreeBuffer(pvInput unsafe.Pointer) (r HRESULT) = ncrypt.dll.SslFreeBuffer
-//sys	SslFreeObject(hObject NCRYPT_HANDLE, dwFlags uint32) (r HRESULT) = ncrypt.dll.SslFreeObject
-//sys	SslGenerateMasterKey(hSslProvider NCRYPT_PROV_HANDLE, hPrivateKey NCRYPT_KEY_HANDLE, hPublicKey NCRYPT_KEY_HANDLE, phMasterKey *NCRYPT_KEY_HANDLE, dwProtocol uint32, dwCipherSuite uint32, pParameterList *BCryptBufferDesc, pbOutput *uint8, cbOutput uint32, pcbResult *uint32, dwFlags uint32) (r HRESULT) = ncrypt.dll.SslGenerateMasterKey
-//sys	SslGenerateSessionKeys(hSslProvider NCRYPT_PROV_HANDLE, hMasterKey NCRYPT_KEY_HANDLE, phReadKey *NCRYPT_KEY_HANDLE, phWriteKey *NCRYPT_KEY_HANDLE, pParameterList *BCryptBufferDesc, dwFlags uint32) (r HRESULT) = ncrypt.dll.SslGenerateSessionKeys
-//sys	SslGetKeyProperty(hKey NCRYPT_KEY_HANDLE, pszProperty *PWSTRElement, ppbOutput **uint8, pcbOutput *uint32, dwFlags uint32) (r HRESULT) = ncrypt.dll.SslGetKeyProperty
-//sys	SslGetProviderProperty(hSslProvider NCRYPT_PROV_HANDLE, pszProperty *PWSTRElement, ppbOutput **uint8, pcbOutput *uint32, ppEnumState *unsafe.Pointer, dwFlags uint32) (r HRESULT) = ncrypt.dll.SslGetProviderProperty
-//sys	SslHashHandshake(hSslProvider NCRYPT_PROV_HANDLE, hHandshakeHash NCRYPT_HASH_HANDLE, pbInput *uint8, cbInput uint32, dwFlags uint32) (r HRESULT) = ncrypt.dll.SslHashHandshake
-//sys	SslImportKey(hSslProvider NCRYPT_PROV_HANDLE, phKey *NCRYPT_KEY_HANDLE, pszBlobType *PWSTRElement, pbKeyBlob *uint8, cbKeyBlob uint32, dwFlags uint32) (r HRESULT) = ncrypt.dll.SslImportKey
-//sys	SslImportMasterKey(hSslProvider NCRYPT_PROV_HANDLE, hPrivateKey NCRYPT_KEY_HANDLE, phMasterKey *NCRYPT_KEY_HANDLE, dwProtocol uint32, dwCipherSuite uint32, pParameterList *BCryptBufferDesc, pbEncryptedKey *uint8, cbEncryptedKey uint32, dwFlags uint32) (r HRESULT) = ncrypt.dll.SslImportMasterKey
-//sys	SslLookupCipherSuiteInfo(hSslProvider NCRYPT_PROV_HANDLE, dwProtocol uint32, dwCipherSuite uint32, dwKeyType uint32, pCipherSuite *NCRYPT_SSL_CIPHER_SUITE, dwFlags uint32) (r HRESULT) = ncrypt.dll.SslLookupCipherSuiteInfo
-//sys	SslOpenPrivateKey(hSslProvider NCRYPT_PROV_HANDLE, phPrivateKey *NCRYPT_KEY_HANDLE, pCertContext *CERT_CONTEXT, dwFlags uint32) (r HRESULT) = ncrypt.dll.SslOpenPrivateKey
-//sys	SslOpenProvider(phSslProvider *NCRYPT_PROV_HANDLE, pszProviderName *PWSTRElement, dwFlags uint32) (r HRESULT) = ncrypt.dll.SslOpenProvider
-//sys	SslSignHash(hSslProvider NCRYPT_PROV_HANDLE, hPrivateKey NCRYPT_KEY_HANDLE, pbHashValue *uint8, cbHashValue uint32, pbSignature *uint8, cbSignature uint32, pcbResult *uint32, dwFlags uint32) (r HRESULT) = ncrypt.dll.SslSignHash
-//sys	SslVerifySignature(hSslProvider NCRYPT_PROV_HANDLE, hPublicKey NCRYPT_KEY_HANDLE, pbHashValue *uint8, cbHashValue uint32, pbSignature *uint8, cbSignature uint32, dwFlags uint32) (r HRESULT) = ncrypt.dll.SslVerifySignature
-//sys	SslLookupCipherLengths(hSslProvider NCRYPT_PROV_HANDLE, dwProtocol uint32, dwCipherSuite uint32, dwKeyType uint32, pCipherLengths *NCRYPT_SSL_CIPHER_LENGTHS, cbCipherLengths uint32, dwFlags uint32) (r HRESULT) = ncrypt.dll.SslLookupCipherLengths
-//sys	SslCreateClientAuthHash(hSslProvider NCRYPT_PROV_HANDLE, phHandshakeHash *NCRYPT_HASH_HANDLE, dwProtocol uint32, dwCipherSuite uint32, pszHashAlgId *PWSTRElement, dwFlags uint32) (r HRESULT) = ncrypt.dll.SslCreateClientAuthHash
-//sys	SslGetCipherSuitePRFHashAlgorithm(hSslProvider NCRYPT_PROV_HANDLE, dwProtocol uint32, dwCipherSuite uint32, dwKeyType uint32, szPRFHash *PWSTRElement, dwFlags uint32) (r HRESULT) = ncrypt.dll.SslGetCipherSuitePRFHashAlgorithm
-//sys	SslComputeSessionHash(hSslProvider NCRYPT_PROV_HANDLE, hHandshakeHash NCRYPT_HASH_HANDLE, dwProtocol uint32, pbOutput *uint8, cbOutput uint32, pcbResult *uint32, dwFlags uint32) (r HRESULT) = ncrypt.dll.SslComputeSessionHash
-//sys	SslGeneratePreMasterKey(hSslProvider NCRYPT_PROV_HANDLE, hPublicKey NCRYPT_KEY_HANDLE, phPreMasterKey *NCRYPT_KEY_HANDLE, dwProtocol uint32, dwCipherSuite uint32, pParameterList *BCryptBufferDesc, pbOutput *uint8, cbOutput uint32, pcbResult *uint32, dwFlags uint32) (r HRESULT) = ncrypt.dll.SslGeneratePreMasterKey
-//sys	SslExportKeyingMaterial(hSslProvider NCRYPT_PROV_HANDLE, hMasterKey NCRYPT_KEY_HANDLE, sLabel *PSTRElement, pbRandoms *uint8, cbRandoms uint32, pbContextValue *uint8, cbContextValue uint16, pbOutput *uint8, cbOutput uint32, dwFlags uint32) (r HRESULT) = ncrypt.dll.SslExportKeyingMaterial
-//sys	SslExtractEarlyKey(hSslProvider NCRYPT_PROV_HANDLE, hPreSharedKey NCRYPT_KEY_HANDLE, phEarlyKey *NCRYPT_KEY_HANDLE, dwProtocol uint32, dwCipherSuite uint32, pParameterList *BCryptBufferDesc, dwFlags uint32) (r HRESULT) = ncrypt.dll.SslExtractEarlyKey
-//sys	SslExtractHandshakeKey(hSslProvider NCRYPT_PROV_HANDLE, hPrivateKey NCRYPT_KEY_HANDLE, hPublicKey NCRYPT_KEY_HANDLE, hEarlyKey NCRYPT_KEY_HANDLE, phHandshakeKey *NCRYPT_KEY_HANDLE, pParameterList *BCryptBufferDesc, dwFlags uint32) (r HRESULT) = ncrypt.dll.SslExtractHandshakeKey
-//sys	SslExtractMasterKey(hSslProvider NCRYPT_PROV_HANDLE, hHandshakeKey NCRYPT_KEY_HANDLE, phMasterKey *NCRYPT_KEY_HANDLE, pParameterList *BCryptBufferDesc, dwFlags uint32) (r HRESULT) = ncrypt.dll.SslExtractMasterKey
-//sys	SslExpandTrafficKeys(hSslProvider NCRYPT_PROV_HANDLE, hBaseKey NCRYPT_KEY_HANDLE, hHashValue NCRYPT_HASH_HANDLE, phClientTrafficKey *NCRYPT_KEY_HANDLE, phServerTrafficKey *NCRYPT_KEY_HANDLE, pParameterList *BCryptBufferDesc, dwFlags uint32) (r HRESULT) = ncrypt.dll.SslExpandTrafficKeys
-//sys	SslExpandWriteKey(hSslProvider NCRYPT_PROV_HANDLE, hBaseTrafficKey NCRYPT_KEY_HANDLE, phWriteKey *NCRYPT_KEY_HANDLE, pParameterList *BCryptBufferDesc, dwFlags uint32) (r HRESULT) = ncrypt.dll.SslExpandWriteKey
-//sys	SslExpandExporterMasterKey(hSslProvider NCRYPT_PROV_HANDLE, hBaseKey NCRYPT_KEY_HANDLE, hHashValue NCRYPT_HASH_HANDLE, phExporterMasterKey *NCRYPT_KEY_HANDLE, pParameterList *BCryptBufferDesc, dwFlags uint32) (r HRESULT) = ncrypt.dll.SslExpandExporterMasterKey
-//sys	SslExpandResumptionMasterKey(hSslProvider NCRYPT_PROV_HANDLE, hMasterKey NCRYPT_KEY_HANDLE, hHashValue NCRYPT_HASH_HANDLE, phResumptionMasterKey *NCRYPT_KEY_HANDLE, pParameterList *BCryptBufferDesc, dwFlags uint32) (r HRESULT) = ncrypt.dll.SslExpandResumptionMasterKey
-//sys	SslDuplicateTranscriptHash(hSslProvider NCRYPT_PROV_HANDLE, hTranscriptHash NCRYPT_HASH_HANDLE, phTranscriptHash *NCRYPT_HASH_HANDLE, dwFlags uint32) (r HRESULT) = ncrypt.dll.SslDuplicateTranscriptHash
-//sys	SslExpandBinderKey(hSslProvider NCRYPT_PROV_HANDLE, hEarlyKey NCRYPT_KEY_HANDLE, phBinderKey *NCRYPT_KEY_HANDLE, pParameterList *BCryptBufferDesc, dwFlags uint32) (r HRESULT) = ncrypt.dll.SslExpandBinderKey
-//sys	SslExpandPreSharedKey(hSslProvider NCRYPT_PROV_HANDLE, hResumptionMasterKey NCRYPT_KEY_HANDLE, pbTicketNonce *uint8, cbTicketNonce uint32, phPreSharedKey *NCRYPT_KEY_HANDLE, pParameterList *BCryptBufferDesc, dwFlags uint32) (r HRESULT) = ncrypt.dll.SslExpandPreSharedKey
-//sys	GetSChannelInterface(pszProviderName *PWSTRElement, ppFunctionTable **NCRYPT_SSL_FUNCTION_TABLE, dwFlags uint32) (r NTSTATUS) = ncrypt.dll.GetSChannelInterface
-//sys	SslIncrementProviderReferenceCount(hSslProvider NCRYPT_PROV_HANDLE) (r HRESULT) = ncrypt.dll.SslIncrementProviderReferenceCount
-//sys	SslDecrementProviderReferenceCount(hSslProvider NCRYPT_PROV_HANDLE) (r HRESULT) = ncrypt.dll.SslDecrementProviderReferenceCount
+//sys	SystemPrng(pbRandomData *uint8, cbRandomData uintptr) (r BOOL) = bcryptprimitives.SystemPrng
+//sys	ProcessPrng(pbData *uint8, cbData uintptr) (r BOOL) = bcryptprimitives.ProcessPrng
+//sys	CryptAcquireContextA(phProv *uintptr, szContainer *PSTRElement, szProvider *PSTRElement, dwProvType uint32, dwFlags uint32) (r BOOL, err error) = advapi32.CryptAcquireContextA
+//sys	CryptAcquireContextW(phProv *uintptr, szContainer *PWSTRElement, szProvider *PWSTRElement, dwProvType uint32, dwFlags uint32) (r BOOL, err error) = advapi32.CryptAcquireContextW
+//sys	CryptReleaseContext(hProv uintptr, dwFlags uint32) (r BOOL, err error) = advapi32.CryptReleaseContext
+//sys	CryptGenKey(hProv uintptr, Algid ALG_ID, dwFlags CRYPT_KEY_FLAGS, phKey *uintptr) (r BOOL, err error) = advapi32.CryptGenKey
+//sys	CryptDeriveKey(hProv uintptr, Algid ALG_ID, hBaseData uintptr, dwFlags uint32, phKey *uintptr) (r BOOL, err error) = advapi32.CryptDeriveKey
+//sys	CryptDestroyKey(hKey uintptr) (r BOOL, err error) = advapi32.CryptDestroyKey
+//sys	CryptSetKeyParam(hKey uintptr, dwParam CRYPT_KEY_PARAM_ID, pbData *uint8, dwFlags uint32) (r BOOL, err error) = advapi32.CryptSetKeyParam
+//sys	CryptGetKeyParam(hKey uintptr, dwParam CRYPT_KEY_PARAM_ID, pbData *uint8, pdwDataLen *uint32, dwFlags uint32) (r BOOL, err error) = advapi32.CryptGetKeyParam
+//sys	CryptSetHashParam(hHash uintptr, dwParam CRYPT_SET_HASH_PARAM, pbData *uint8, dwFlags uint32) (r BOOL, err error) = advapi32.CryptSetHashParam
+//sys	CryptGetHashParam(hHash uintptr, dwParam uint32, pbData *uint8, pdwDataLen *uint32, dwFlags uint32) (r BOOL, err error) = advapi32.CryptGetHashParam
+//sys	CryptSetProvParam(hProv uintptr, dwParam CRYPT_SET_PROV_PARAM_ID, pbData *uint8, dwFlags uint32) (r BOOL, err error) = advapi32.CryptSetProvParam
+//sys	CryptGetProvParam(hProv uintptr, dwParam uint32, pbData *uint8, pdwDataLen *uint32, dwFlags uint32) (r BOOL, err error) = advapi32.CryptGetProvParam
+//sys	CryptGenRandom(hProv uintptr, dwLen uint32, pbBuffer *uint8) (r BOOL, err error) = advapi32.CryptGenRandom
+//sys	CryptGetUserKey(hProv uintptr, dwKeySpec uint32, phUserKey *uintptr) (r BOOL, err error) = advapi32.CryptGetUserKey
+//sys	CryptExportKey(hKey uintptr, hExpKey uintptr, dwBlobType uint32, dwFlags CRYPT_KEY_FLAGS, pbData *uint8, pdwDataLen *uint32) (r BOOL, err error) = advapi32.CryptExportKey
+//sys	CryptImportKey(hProv uintptr, pbData *uint8, dwDataLen uint32, hPubKey uintptr, dwFlags CRYPT_KEY_FLAGS, phKey *uintptr) (r BOOL, err error) = advapi32.CryptImportKey
+//sys	CryptEncrypt(hKey uintptr, hHash uintptr, Final BOOL, dwFlags uint32, pbData *uint8, pdwDataLen *uint32, dwBufLen uint32) (r BOOL, err error) = advapi32.CryptEncrypt
+//sys	CryptDecrypt(hKey uintptr, hHash uintptr, Final BOOL, dwFlags uint32, pbData *uint8, pdwDataLen *uint32) (r BOOL, err error) = advapi32.CryptDecrypt
+//sys	CryptCreateHash(hProv uintptr, Algid ALG_ID, hKey uintptr, dwFlags uint32, phHash *uintptr) (r BOOL, err error) = advapi32.CryptCreateHash
+//sys	CryptHashData(hHash uintptr, pbData *uint8, dwDataLen uint32, dwFlags uint32) (r BOOL, err error) = advapi32.CryptHashData
+//sys	CryptHashSessionKey(hHash uintptr, hKey uintptr, dwFlags uint32) (r BOOL, err error) = advapi32.CryptHashSessionKey
+//sys	CryptDestroyHash(hHash uintptr) (r BOOL, err error) = advapi32.CryptDestroyHash
+//sys	CryptSignHashA(hHash uintptr, dwKeySpec uint32, szDescription *PSTRElement, dwFlags uint32, pbSignature *uint8, pdwSigLen *uint32) (r BOOL, err error) = advapi32.CryptSignHashA
+//sys	CryptSignHashW(hHash uintptr, dwKeySpec uint32, szDescription *PWSTRElement, dwFlags uint32, pbSignature *uint8, pdwSigLen *uint32) (r BOOL, err error) = advapi32.CryptSignHashW
+//sys	CryptVerifySignatureA(hHash uintptr, pbSignature *uint8, dwSigLen uint32, hPubKey uintptr, szDescription *PSTRElement, dwFlags uint32) (r BOOL, err error) = advapi32.CryptVerifySignatureA
+//sys	CryptVerifySignatureW(hHash uintptr, pbSignature *uint8, dwSigLen uint32, hPubKey uintptr, szDescription *PWSTRElement, dwFlags uint32) (r BOOL, err error) = advapi32.CryptVerifySignatureW
+//sys	CryptSetProviderA(pszProvName *PSTRElement, dwProvType uint32) (r BOOL, err error) = advapi32.CryptSetProviderA
+//sys	CryptSetProviderW(pszProvName *PWSTRElement, dwProvType uint32) (r BOOL, err error) = advapi32.CryptSetProviderW
+//sys	CryptSetProviderExA(pszProvName *PSTRElement, dwProvType uint32, pdwReserved *uint32, dwFlags uint32) (r BOOL, err error) = advapi32.CryptSetProviderExA
+//sys	CryptSetProviderExW(pszProvName *PWSTRElement, dwProvType uint32, pdwReserved *uint32, dwFlags uint32) (r BOOL, err error) = advapi32.CryptSetProviderExW
+//sys	CryptGetDefaultProviderA(dwProvType uint32, pdwReserved *uint32, dwFlags uint32, pszProvName *PSTRElement, pcbProvName *uint32) (r BOOL, err error) = advapi32.CryptGetDefaultProviderA
+//sys	CryptGetDefaultProviderW(dwProvType uint32, pdwReserved *uint32, dwFlags uint32, pszProvName *PWSTRElement, pcbProvName *uint32) (r BOOL, err error) = advapi32.CryptGetDefaultProviderW
+//sys	CryptEnumProviderTypesA(dwIndex uint32, pdwReserved *uint32, dwFlags uint32, pdwProvType *uint32, szTypeName *PSTRElement, pcbTypeName *uint32) (r BOOL, err error) = advapi32.CryptEnumProviderTypesA
+//sys	CryptEnumProviderTypesW(dwIndex uint32, pdwReserved *uint32, dwFlags uint32, pdwProvType *uint32, szTypeName *PWSTRElement, pcbTypeName *uint32) (r BOOL, err error) = advapi32.CryptEnumProviderTypesW
+//sys	CryptEnumProvidersA(dwIndex uint32, pdwReserved *uint32, dwFlags uint32, pdwProvType *uint32, szProvName *PSTRElement, pcbProvName *uint32) (r BOOL, err error) = advapi32.CryptEnumProvidersA
+//sys	CryptEnumProvidersW(dwIndex uint32, pdwReserved *uint32, dwFlags uint32, pdwProvType *uint32, szProvName *PWSTRElement, pcbProvName *uint32) (r BOOL, err error) = advapi32.CryptEnumProvidersW
+//sys	CryptContextAddRef(hProv uintptr, pdwReserved *uint32, dwFlags uint32) (r BOOL, err error) = advapi32.CryptContextAddRef
+//sys	CryptDuplicateKey(hKey uintptr, pdwReserved *uint32, dwFlags uint32, phKey *uintptr) (r BOOL, err error) = advapi32.CryptDuplicateKey
+//sys	CryptDuplicateHash(hHash uintptr, pdwReserved *uint32, dwFlags uint32, phHash *uintptr) (r BOOL, err error) = advapi32.CryptDuplicateHash
+//sys	BCryptOpenAlgorithmProvider(phAlgorithm *BCRYPT_ALG_HANDLE, pszAlgId *PWSTRElement, pszImplementation *PWSTRElement, dwFlags BCRYPT_OPEN_ALGORITHM_PROVIDER_FLAGS) (r NTSTATUS) = bcrypt.BCryptOpenAlgorithmProvider
+//sys	BCryptEnumAlgorithms(dwAlgOperations BCRYPT_OPERATION, pAlgCount *uint32, ppAlgList **BCRYPT_ALGORITHM_IDENTIFIER, dwFlags uint32) (r NTSTATUS) = bcrypt.BCryptEnumAlgorithms
+//sys	BCryptEnumProviders(pszAlgId *PWSTRElement, pImplCount *uint32, ppImplList **BCRYPT_PROVIDER_NAME, dwFlags uint32) (r NTSTATUS) = bcrypt.BCryptEnumProviders
+//sys	BCryptGetProperty(hObject BCRYPT_HANDLE, pszProperty *PWSTRElement, pbOutput *uint8, cbOutput uint32, pcbResult *uint32, dwFlags uint32) (r NTSTATUS) = bcrypt.BCryptGetProperty
+//sys	BCryptSetProperty(hObject BCRYPT_HANDLE, pszProperty *PWSTRElement, pbInput *uint8, cbInput uint32, dwFlags uint32) (r NTSTATUS) = bcrypt.BCryptSetProperty
+//sys	BCryptCloseAlgorithmProvider(hAlgorithm BCRYPT_ALG_HANDLE, dwFlags uint32) (r NTSTATUS) = bcrypt.BCryptCloseAlgorithmProvider
+//sys	BCryptFreeBuffer(pvBuffer unsafe.Pointer) = bcrypt.BCryptFreeBuffer
+//sys	BCryptGenerateSymmetricKey(hAlgorithm BCRYPT_ALG_HANDLE, phKey *BCRYPT_KEY_HANDLE, pbKeyObject *uint8, cbKeyObject uint32, pbSecret *uint8, cbSecret uint32, dwFlags uint32) (r NTSTATUS) = bcrypt.BCryptGenerateSymmetricKey
+//sys	BCryptGenerateKeyPair(hAlgorithm BCRYPT_ALG_HANDLE, phKey *BCRYPT_KEY_HANDLE, dwLength uint32, dwFlags uint32) (r NTSTATUS) = bcrypt.BCryptGenerateKeyPair
+//sys	BCryptEncrypt(hKey BCRYPT_KEY_HANDLE, pbInput *uint8, cbInput uint32, pPaddingInfo unsafe.Pointer, pbIV *uint8, cbIV uint32, pbOutput *uint8, cbOutput uint32, pcbResult *uint32, dwFlags BCRYPT_FLAGS) (r NTSTATUS) = bcrypt.BCryptEncrypt
+//sys	BCryptDecrypt(hKey BCRYPT_KEY_HANDLE, pbInput *uint8, cbInput uint32, pPaddingInfo unsafe.Pointer, pbIV *uint8, cbIV uint32, pbOutput *uint8, cbOutput uint32, pcbResult *uint32, dwFlags BCRYPT_FLAGS) (r NTSTATUS) = bcrypt.BCryptDecrypt
+//sys	BCryptExportKey(hKey BCRYPT_KEY_HANDLE, hExportKey BCRYPT_KEY_HANDLE, pszBlobType *PWSTRElement, pbOutput *uint8, cbOutput uint32, pcbResult *uint32, dwFlags uint32) (r NTSTATUS) = bcrypt.BCryptExportKey
+//sys	BCryptImportKey(hAlgorithm BCRYPT_ALG_HANDLE, hImportKey BCRYPT_KEY_HANDLE, pszBlobType *PWSTRElement, phKey *BCRYPT_KEY_HANDLE, pbKeyObject *uint8, cbKeyObject uint32, pbInput *uint8, cbInput uint32, dwFlags uint32) (r NTSTATUS) = bcrypt.BCryptImportKey
+//sys	BCryptImportKeyPair(hAlgorithm BCRYPT_ALG_HANDLE, hImportKey BCRYPT_KEY_HANDLE, pszBlobType *PWSTRElement, phKey *BCRYPT_KEY_HANDLE, pbInput *uint8, cbInput uint32, dwFlags uint32) (r NTSTATUS) = bcrypt.BCryptImportKeyPair
+//sys	BCryptDuplicateKey(hKey BCRYPT_KEY_HANDLE, phNewKey *BCRYPT_KEY_HANDLE, pbKeyObject *uint8, cbKeyObject uint32, dwFlags uint32) (r NTSTATUS) = bcrypt.BCryptDuplicateKey
+//sys	BCryptFinalizeKeyPair(hKey BCRYPT_KEY_HANDLE, dwFlags uint32) (r NTSTATUS) = bcrypt.BCryptFinalizeKeyPair
+//sys	BCryptDestroyKey(hKey BCRYPT_KEY_HANDLE) (r NTSTATUS) = bcrypt.BCryptDestroyKey
+//sys	BCryptDestroySecret(hSecret BCRYPT_SECRET_HANDLE) (r NTSTATUS) = bcrypt.BCryptDestroySecret
+//sys	BCryptSignHash(hKey BCRYPT_KEY_HANDLE, pPaddingInfo unsafe.Pointer, pbInput *uint8, cbInput uint32, pbOutput *uint8, cbOutput uint32, pcbResult *uint32, dwFlags BCRYPT_FLAGS) (r NTSTATUS) = bcrypt.BCryptSignHash
+//sys	BCryptVerifySignature(hKey BCRYPT_KEY_HANDLE, pPaddingInfo unsafe.Pointer, pbHash *uint8, cbHash uint32, pbSignature *uint8, cbSignature uint32, dwFlags BCRYPT_FLAGS) (r NTSTATUS) = bcrypt.BCryptVerifySignature
+//sys	BCryptSecretAgreement(hPrivKey BCRYPT_KEY_HANDLE, hPubKey BCRYPT_KEY_HANDLE, phAgreedSecret *BCRYPT_SECRET_HANDLE, dwFlags uint32) (r NTSTATUS) = bcrypt.BCryptSecretAgreement
+//sys	BCryptDeriveKey(hSharedSecret BCRYPT_SECRET_HANDLE, pwszKDF *PWSTRElement, pParameterList *BCryptBufferDesc, pbDerivedKey *uint8, cbDerivedKey uint32, pcbResult *uint32, dwFlags uint32) (r NTSTATUS) = bcrypt.BCryptDeriveKey
+//sys	BCryptKeyDerivation(hKey BCRYPT_KEY_HANDLE, pParameterList *BCryptBufferDesc, pbDerivedKey *uint8, cbDerivedKey uint32, pcbResult *uint32, dwFlags uint32) (r NTSTATUS) = bcrypt.BCryptKeyDerivation
+//sys	BCryptCreateHash(hAlgorithm BCRYPT_ALG_HANDLE, phHash *BCRYPT_HASH_HANDLE, pbHashObject *uint8, cbHashObject uint32, pbSecret *uint8, cbSecret uint32, dwFlags uint32) (r NTSTATUS) = bcrypt.BCryptCreateHash
+//sys	BCryptHashData(hHash BCRYPT_HASH_HANDLE, pbInput *uint8, cbInput uint32, dwFlags uint32) (r NTSTATUS) = bcrypt.BCryptHashData
+//sys	BCryptFinishHash(hHash BCRYPT_HASH_HANDLE, pbOutput *uint8, cbOutput uint32, dwFlags uint32) (r NTSTATUS) = bcrypt.BCryptFinishHash
+//sys	BCryptCreateMultiHash(hAlgorithm BCRYPT_ALG_HANDLE, phHash *BCRYPT_HASH_HANDLE, nHashes uint32, pbHashObject *uint8, cbHashObject uint32, pbSecret *uint8, cbSecret uint32, dwFlags uint32) (r NTSTATUS) = bcrypt.BCryptCreateMultiHash
+//sys	BCryptProcessMultiOperations(hObject BCRYPT_HANDLE, operationType BCRYPT_MULTI_OPERATION_TYPE, pOperations unsafe.Pointer, cbOperations uint32, dwFlags uint32) (r NTSTATUS) = bcrypt.BCryptProcessMultiOperations
+//sys	BCryptDuplicateHash(hHash BCRYPT_HASH_HANDLE, phNewHash *BCRYPT_HASH_HANDLE, pbHashObject *uint8, cbHashObject uint32, dwFlags uint32) (r NTSTATUS) = bcrypt.BCryptDuplicateHash
+//sys	BCryptDestroyHash(hHash BCRYPT_HASH_HANDLE) (r NTSTATUS) = bcrypt.BCryptDestroyHash
+//sys	BCryptHash(hAlgorithm BCRYPT_ALG_HANDLE, pbSecret *uint8, cbSecret uint32, pbInput *uint8, cbInput uint32, pbOutput *uint8, cbOutput uint32) (r NTSTATUS) = bcrypt.BCryptHash
+//sys	BCryptGenRandom(hAlgorithm BCRYPT_ALG_HANDLE, pbBuffer *uint8, cbBuffer uint32, dwFlags BCRYPTGENRANDOM_FLAGS) (r NTSTATUS) = bcrypt.BCryptGenRandom
+//sys	BCryptDeriveKeyCapi(hHash BCRYPT_HASH_HANDLE, hTargetAlg BCRYPT_ALG_HANDLE, pbDerivedKey *uint8, cbDerivedKey uint32, dwFlags uint32) (r NTSTATUS) = bcrypt.BCryptDeriveKeyCapi
+//sys	BCryptDeriveKeyPBKDF2(hPrf BCRYPT_ALG_HANDLE, pbPassword *uint8, cbPassword uint32, pbSalt *uint8, cbSalt uint32, cIterations uint64, pbDerivedKey *uint8, cbDerivedKey uint32, dwFlags uint32) (r NTSTATUS) = bcrypt.BCryptDeriveKeyPBKDF2
+//sys	BCryptEncapsulate(hKey BCRYPT_KEY_HANDLE, pbSecretKey *uint8, cbSecretKey uint32, pcbSecretKey *uint32, pbCipherText *uint8, cbCipherText uint32, pcbCipherText *uint32, dwFlags uint32) (r NTSTATUS) = bcrypt.BCryptEncapsulate
+//sys	BCryptDecapsulate(hKey BCRYPT_KEY_HANDLE, pbCipherText *uint8, cbCipherText uint32, pbSecretKey *uint8, cbSecretKey uint32, pcbSecretKey *uint32, dwFlags uint32) (r NTSTATUS) = bcrypt.BCryptDecapsulate
+//sys	BCryptQueryProviderRegistration(pszProvider *PWSTRElement, dwMode BCRYPT_QUERY_PROVIDER_MODE, dwInterface BCRYPT_INTERFACE, pcbBuffer *uint32, ppBuffer **CRYPT_PROVIDER_REG) (r NTSTATUS) = bcrypt.BCryptQueryProviderRegistration
+//sys	BCryptEnumRegisteredProviders(pcbBuffer *uint32, ppBuffer **CRYPT_PROVIDERS) (r NTSTATUS) = bcrypt.BCryptEnumRegisteredProviders
+//sys	BCryptCreateContext(dwTable BCRYPT_TABLE, pszContext *PWSTRElement, pConfig *CRYPT_CONTEXT_CONFIG) (r NTSTATUS) = bcrypt.BCryptCreateContext
+//sys	BCryptDeleteContext(dwTable BCRYPT_TABLE, pszContext *PWSTRElement) (r NTSTATUS) = bcrypt.BCryptDeleteContext
+//sys	BCryptEnumContexts(dwTable BCRYPT_TABLE, pcbBuffer *uint32, ppBuffer **CRYPT_CONTEXTS) (r NTSTATUS) = bcrypt.BCryptEnumContexts
+//sys	BCryptConfigureContext(dwTable BCRYPT_TABLE, pszContext *PWSTRElement, pConfig *CRYPT_CONTEXT_CONFIG) (r NTSTATUS) = bcrypt.BCryptConfigureContext
+//sys	BCryptQueryContextConfiguration(dwTable BCRYPT_TABLE, pszContext *PWSTRElement, pcbBuffer *uint32, ppBuffer **CRYPT_CONTEXT_CONFIG) (r NTSTATUS) = bcrypt.BCryptQueryContextConfiguration
+//sys	BCryptAddContextFunction(dwTable BCRYPT_TABLE, pszContext *PWSTRElement, dwInterface BCRYPT_INTERFACE, pszFunction *PWSTRElement, dwPosition uint32) (r NTSTATUS) = bcrypt.BCryptAddContextFunction
+//sys	BCryptRemoveContextFunction(dwTable BCRYPT_TABLE, pszContext *PWSTRElement, dwInterface BCRYPT_INTERFACE, pszFunction *PWSTRElement) (r NTSTATUS) = bcrypt.BCryptRemoveContextFunction
+//sys	BCryptEnumContextFunctions(dwTable BCRYPT_TABLE, pszContext *PWSTRElement, dwInterface BCRYPT_INTERFACE, pcbBuffer *uint32, ppBuffer **CRYPT_CONTEXT_FUNCTIONS) (r NTSTATUS) = bcrypt.BCryptEnumContextFunctions
+//sys	BCryptConfigureContextFunction(dwTable BCRYPT_TABLE, pszContext *PWSTRElement, dwInterface BCRYPT_INTERFACE, pszFunction *PWSTRElement, pConfig *CRYPT_CONTEXT_FUNCTION_CONFIG) (r NTSTATUS) = bcrypt.BCryptConfigureContextFunction
+//sys	BCryptQueryContextFunctionConfiguration(dwTable BCRYPT_TABLE, pszContext *PWSTRElement, dwInterface BCRYPT_INTERFACE, pszFunction *PWSTRElement, pcbBuffer *uint32, ppBuffer **CRYPT_CONTEXT_FUNCTION_CONFIG) (r NTSTATUS) = bcrypt.BCryptQueryContextFunctionConfiguration
+//sys	BCryptEnumContextFunctionProviders(dwTable BCRYPT_TABLE, pszContext *PWSTRElement, dwInterface BCRYPT_INTERFACE, pszFunction *PWSTRElement, pcbBuffer *uint32, ppBuffer **CRYPT_CONTEXT_FUNCTION_PROVIDERS) (r NTSTATUS) = bcrypt.BCryptEnumContextFunctionProviders
+//sys	BCryptSetContextFunctionProperty(dwTable BCRYPT_TABLE, pszContext *PWSTRElement, dwInterface BCRYPT_INTERFACE, pszFunction *PWSTRElement, pszProperty *PWSTRElement, cbValue uint32, pbValue *uint8) (r NTSTATUS) = bcrypt.BCryptSetContextFunctionProperty
+//sys	BCryptQueryContextFunctionProperty(dwTable BCRYPT_TABLE, pszContext *PWSTRElement, dwInterface BCRYPT_INTERFACE, pszFunction *PWSTRElement, pszProperty *PWSTRElement, pcbValue *uint32, ppbValue **uint8) (r NTSTATUS) = bcrypt.BCryptQueryContextFunctionProperty
+//sys	BCryptRegisterConfigChangeNotify(phEvent *HANDLE) (r NTSTATUS) = bcrypt.BCryptRegisterConfigChangeNotify
+//sys	BCryptUnregisterConfigChangeNotify(hEvent HANDLE) (r NTSTATUS) = bcrypt.BCryptUnregisterConfigChangeNotify
+//sys	BCryptResolveProviders(pszContext *PWSTRElement, dwInterface uint32, pszFunction *PWSTRElement, pszProvider *PWSTRElement, dwMode BCRYPT_QUERY_PROVIDER_MODE, dwFlags BCRYPT_RESOLVE_PROVIDERS_FLAGS, pcbBuffer *uint32, ppBuffer **CRYPT_PROVIDER_REFS) (r NTSTATUS) = bcrypt.BCryptResolveProviders
+//sys	BCryptGetFipsAlgorithmMode(pfEnabled *uint8) (r NTSTATUS) = bcrypt.BCryptGetFipsAlgorithmMode
+//sys	NCryptOpenStorageProvider(phProvider *NCRYPT_PROV_HANDLE, pszProviderName *PWSTRElement, dwFlags uint32) (r HRESULT) = ncrypt.NCryptOpenStorageProvider
+//sys	NCryptEnumAlgorithms(hProvider NCRYPT_PROV_HANDLE, dwAlgOperations NCRYPT_OPERATION, pdwAlgCount *uint32, ppAlgList **NCryptAlgorithmName, dwFlags uint32) (r HRESULT) = ncrypt.NCryptEnumAlgorithms
+//sys	NCryptIsAlgSupported(hProvider NCRYPT_PROV_HANDLE, pszAlgId *PWSTRElement, dwFlags uint32) (r HRESULT) = ncrypt.NCryptIsAlgSupported
+//sys	NCryptEnumKeys(hProvider NCRYPT_PROV_HANDLE, pszScope *PWSTRElement, ppKeyName **NCryptKeyName, ppEnumState *unsafe.Pointer, dwFlags NCRYPT_FLAGS) (r HRESULT) = ncrypt.NCryptEnumKeys
+//sys	NCryptEnumStorageProviders(pdwProviderCount *uint32, ppProviderList **NCryptProviderName, dwFlags uint32) (r HRESULT) = ncrypt.NCryptEnumStorageProviders
+//sys	NCryptFreeBuffer(pvInput unsafe.Pointer) (r HRESULT) = ncrypt.NCryptFreeBuffer
+//sys	NCryptOpenKey(hProvider NCRYPT_PROV_HANDLE, phKey *NCRYPT_KEY_HANDLE, pszKeyName *PWSTRElement, dwLegacyKeySpec CERT_KEY_SPEC, dwFlags NCRYPT_FLAGS) (r HRESULT) = ncrypt.NCryptOpenKey
+//sys	NCryptCreatePersistedKey(hProvider NCRYPT_PROV_HANDLE, phKey *NCRYPT_KEY_HANDLE, pszAlgId *PWSTRElement, pszKeyName *PWSTRElement, dwLegacyKeySpec CERT_KEY_SPEC, dwFlags NCRYPT_FLAGS) (r HRESULT) = ncrypt.NCryptCreatePersistedKey
+//sys	NCryptGetProperty(hObject NCRYPT_HANDLE, pszProperty *PWSTRElement, pbOutput *uint8, cbOutput uint32, pcbResult *uint32, dwFlags OBJECT_SECURITY_INFORMATION) (r HRESULT) = ncrypt.NCryptGetProperty
+//sys	NCryptSetProperty(hObject NCRYPT_HANDLE, pszProperty *PWSTRElement, pbInput *uint8, cbInput uint32, dwFlags NCRYPT_FLAGS) (r HRESULT) = ncrypt.NCryptSetProperty
+//sys	NCryptFinalizeKey(hKey NCRYPT_KEY_HANDLE, dwFlags NCRYPT_FLAGS) (r HRESULT) = ncrypt.NCryptFinalizeKey
+//sys	NCryptEncrypt(hKey NCRYPT_KEY_HANDLE, pbInput *uint8, cbInput uint32, pPaddingInfo unsafe.Pointer, pbOutput *uint8, cbOutput uint32, pcbResult *uint32, dwFlags NCRYPT_FLAGS) (r HRESULT) = ncrypt.NCryptEncrypt
+//sys	NCryptDecrypt(hKey NCRYPT_KEY_HANDLE, pbInput *uint8, cbInput uint32, pPaddingInfo unsafe.Pointer, pbOutput *uint8, cbOutput uint32, pcbResult *uint32, dwFlags NCRYPT_FLAGS) (r HRESULT) = ncrypt.NCryptDecrypt
+//sys	NCryptEncapsulate(hKey NCRYPT_KEY_HANDLE, pbSecretKey *uint8, cbSecretKey uint32, pcbSecretKey *uint32, pbCipherText *uint8, cbCipherText uint32, pcbCipherText *uint32, dwFlags uint32) (r HRESULT) = ncrypt.NCryptEncapsulate
+//sys	NCryptDecapsulate(hKey NCRYPT_KEY_HANDLE, pbCipherText *uint8, cbCipherText uint32, pbSecretKey *uint8, cbSecretKey uint32, pcbSecretKey *uint32, dwFlags uint32) (r HRESULT) = ncrypt.NCryptDecapsulate
+//sys	NCryptImportKey(hProvider NCRYPT_PROV_HANDLE, hImportKey NCRYPT_KEY_HANDLE, pszBlobType *PWSTRElement, pParameterList *BCryptBufferDesc, phKey *NCRYPT_KEY_HANDLE, pbData *uint8, cbData uint32, dwFlags NCRYPT_FLAGS) (r HRESULT) = ncrypt.NCryptImportKey
+//sys	NCryptExportKey(hKey NCRYPT_KEY_HANDLE, hExportKey NCRYPT_KEY_HANDLE, pszBlobType *PWSTRElement, pParameterList *BCryptBufferDesc, pbOutput *uint8, cbOutput uint32, pcbResult *uint32, dwFlags NCRYPT_FLAGS) (r HRESULT) = ncrypt.NCryptExportKey
+//sys	NCryptSignHash(hKey NCRYPT_KEY_HANDLE, pPaddingInfo unsafe.Pointer, pbHashValue *uint8, cbHashValue uint32, pbSignature *uint8, cbSignature uint32, pcbResult *uint32, dwFlags NCRYPT_FLAGS) (r HRESULT) = ncrypt.NCryptSignHash
+//sys	NCryptVerifySignature(hKey NCRYPT_KEY_HANDLE, pPaddingInfo unsafe.Pointer, pbHashValue *uint8, cbHashValue uint32, pbSignature *uint8, cbSignature uint32, dwFlags NCRYPT_FLAGS) (r HRESULT) = ncrypt.NCryptVerifySignature
+//sys	NCryptDeleteKey(hKey NCRYPT_KEY_HANDLE, dwFlags uint32) (r HRESULT) = ncrypt.NCryptDeleteKey
+//sys	NCryptFreeObject(hObject NCRYPT_HANDLE) (r HRESULT) = ncrypt.NCryptFreeObject
+//sys	NCryptIsKeyHandle(hKey NCRYPT_KEY_HANDLE) (r BOOL) = ncrypt.NCryptIsKeyHandle
+//sys	NCryptTranslateHandle(phProvider *NCRYPT_PROV_HANDLE, phKey *NCRYPT_KEY_HANDLE, hLegacyProv uintptr, hLegacyKey uintptr, dwLegacyKeySpec CERT_KEY_SPEC, dwFlags uint32) (r HRESULT) = ncrypt.NCryptTranslateHandle
+//sys	NCryptNotifyChangeKey(hProvider NCRYPT_PROV_HANDLE, phEvent *HANDLE, dwFlags NCRYPT_FLAGS) (r HRESULT) = ncrypt.NCryptNotifyChangeKey
+//sys	NCryptSecretAgreement(hPrivKey NCRYPT_KEY_HANDLE, hPubKey NCRYPT_KEY_HANDLE, phAgreedSecret *NCRYPT_SECRET_HANDLE, dwFlags NCRYPT_FLAGS) (r HRESULT) = ncrypt.NCryptSecretAgreement
+//sys	NCryptDeriveKey(hSharedSecret NCRYPT_SECRET_HANDLE, pwszKDF *PWSTRElement, pParameterList *BCryptBufferDesc, pbDerivedKey *uint8, cbDerivedKey uint32, pcbResult *uint32, dwFlags uint32) (r HRESULT) = ncrypt.NCryptDeriveKey
+//sys	NCryptKeyDerivation(hKey NCRYPT_KEY_HANDLE, pParameterList *BCryptBufferDesc, pbDerivedKey *uint8, cbDerivedKey uint32, pcbResult *uint32, dwFlags uint32) (r HRESULT) = ncrypt.NCryptKeyDerivation
+//sys	NCryptCreateClaim(hSubjectKey NCRYPT_KEY_HANDLE, hAuthorityKey NCRYPT_KEY_HANDLE, dwClaimType uint32, pParameterList *BCryptBufferDesc, pbClaimBlob *uint8, cbClaimBlob uint32, pcbResult *uint32, dwFlags uint32) (r HRESULT) = ncrypt.NCryptCreateClaim
+//sys	NCryptVerifyClaim(hSubjectKey NCRYPT_KEY_HANDLE, hAuthorityKey NCRYPT_KEY_HANDLE, dwClaimType uint32, pParameterList *BCryptBufferDesc, pbClaimBlob *uint8, cbClaimBlob uint32, pOutput *BCryptBufferDesc, dwFlags uint32) (r HRESULT) = ncrypt.NCryptVerifyClaim
+//sys	CryptFormatObject(dwCertEncodingType CERT_QUERY_ENCODING_TYPE, dwFormatType uint32, dwFormatStrType uint32, pFormatStruct unsafe.Pointer, lpszStructType *PSTRElement, pbEncoded *uint8, cbEncoded uint32, pbFormat unsafe.Pointer, pcbFormat *uint32) (r BOOL, err error) = crypt32.CryptFormatObject
+//sys	CryptEncodeObjectEx(dwCertEncodingType CERT_QUERY_ENCODING_TYPE, lpszStructType *PSTRElement, pvStructInfo unsafe.Pointer, dwFlags CRYPT_ENCODE_OBJECT_FLAGS, pEncodePara *CRYPT_ENCODE_PARA, pvEncoded unsafe.Pointer, pcbEncoded *uint32) (r BOOL, err error) = crypt32.CryptEncodeObjectEx
+//sys	CryptEncodeObject(dwCertEncodingType CERT_QUERY_ENCODING_TYPE, lpszStructType *PSTRElement, pvStructInfo unsafe.Pointer, pbEncoded *uint8, pcbEncoded *uint32) (r BOOL, err error) = crypt32.CryptEncodeObject
+//sys	CryptDecodeObjectEx(dwCertEncodingType CERT_QUERY_ENCODING_TYPE, lpszStructType *PSTRElement, pbEncoded *uint8, cbEncoded uint32, dwFlags uint32, pDecodePara *CRYPT_DECODE_PARA, pvStructInfo unsafe.Pointer, pcbStructInfo *uint32) (r BOOL, err error) = crypt32.CryptDecodeObjectEx
+//sys	CryptDecodeObject(dwCertEncodingType CERT_QUERY_ENCODING_TYPE, lpszStructType *PSTRElement, pbEncoded *uint8, cbEncoded uint32, dwFlags uint32, pvStructInfo unsafe.Pointer, pcbStructInfo *uint32) (r BOOL, err error) = crypt32.CryptDecodeObject
+//sys	CryptInstallOIDFunctionAddress(hModule HMODULE, dwEncodingType uint32, pszFuncName *PSTRElement, cFuncEntry uint32, rgFuncEntry *CRYPT_OID_FUNC_ENTRY, dwFlags uint32) (r BOOL) = crypt32.CryptInstallOIDFunctionAddress
+//sys	CryptInitOIDFunctionSet(pszFuncName *PSTRElement, dwFlags uint32) (r unsafe.Pointer) = crypt32.CryptInitOIDFunctionSet
+//sys	CryptGetOIDFunctionAddress(hFuncSet unsafe.Pointer, dwEncodingType uint32, pszOID *PSTRElement, dwFlags uint32, ppvFuncAddr *unsafe.Pointer, phFuncAddr *unsafe.Pointer) (r BOOL, err error) = crypt32.CryptGetOIDFunctionAddress
+//sys	CryptGetDefaultOIDDllList(hFuncSet unsafe.Pointer, dwEncodingType uint32, pwszDllList *PWSTRElement, pcchDllList *uint32) (r BOOL, err error) = crypt32.CryptGetDefaultOIDDllList
+//sys	CryptGetDefaultOIDFunctionAddress(hFuncSet unsafe.Pointer, dwEncodingType uint32, pwszDll *PWSTRElement, dwFlags uint32, ppvFuncAddr *unsafe.Pointer, phFuncAddr *unsafe.Pointer) (r BOOL) = crypt32.CryptGetDefaultOIDFunctionAddress
+//sys	CryptFreeOIDFunctionAddress(hFuncAddr unsafe.Pointer, dwFlags uint32) (r BOOL) = crypt32.CryptFreeOIDFunctionAddress
+//sys	CryptRegisterOIDFunction(dwEncodingType uint32, pszFuncName *PSTRElement, pszOID *PSTRElement, pwszDll *PWSTRElement, pszOverrideFuncName *PSTRElement) (r BOOL) = crypt32.CryptRegisterOIDFunction
+//sys	CryptUnregisterOIDFunction(dwEncodingType uint32, pszFuncName *PSTRElement, pszOID *PSTRElement) (r BOOL) = crypt32.CryptUnregisterOIDFunction
+//sys	CryptRegisterDefaultOIDFunction(dwEncodingType uint32, pszFuncName *PSTRElement, dwIndex uint32, pwszDll *PWSTRElement) (r BOOL) = crypt32.CryptRegisterDefaultOIDFunction
+//sys	CryptUnregisterDefaultOIDFunction(dwEncodingType uint32, pszFuncName *PSTRElement, pwszDll *PWSTRElement) (r BOOL) = crypt32.CryptUnregisterDefaultOIDFunction
+//sys	CryptSetOIDFunctionValue(dwEncodingType uint32, pszFuncName *PSTRElement, pszOID *PSTRElement, pwszValueName *PWSTRElement, dwValueType REG_VALUE_TYPE, pbValueData *uint8, cbValueData uint32) (r BOOL) = crypt32.CryptSetOIDFunctionValue
+//sys	CryptGetOIDFunctionValue(dwEncodingType uint32, pszFuncName *PSTRElement, pszOID *PSTRElement, pwszValueName *PWSTRElement, pdwValueType *uint32, pbValueData *uint8, pcbValueData *uint32) (r BOOL, err error) = crypt32.CryptGetOIDFunctionValue
+//sys	CryptEnumOIDFunction(dwEncodingType uint32, pszFuncName *PSTRElement, pszOID *PSTRElement, dwFlags uint32, pvArg unsafe.Pointer, pfnEnumOIDFunc PFN_CRYPT_ENUM_OID_FUNC) (r BOOL, err error) = crypt32.CryptEnumOIDFunction
+//sys	CryptFindOIDInfo(dwKeyType uint32, pvKey unsafe.Pointer, dwGroupId uint32) (r *CRYPT_OID_INFO) = crypt32.CryptFindOIDInfo
+//sys	CryptRegisterOIDInfo(pInfo *CRYPT_OID_INFO, dwFlags uint32) (r BOOL) = crypt32.CryptRegisterOIDInfo
+//sys	CryptUnregisterOIDInfo(pInfo *CRYPT_OID_INFO) (r BOOL) = crypt32.CryptUnregisterOIDInfo
+//sys	CryptEnumOIDInfo(dwGroupId uint32, dwFlags uint32, pvArg unsafe.Pointer, pfnEnumOIDInfo PFN_CRYPT_ENUM_OID_INFO) (r BOOL) = crypt32.CryptEnumOIDInfo
+//sys	CryptFindLocalizedName(pwszCryptName *PWSTRElement) (r *PWSTRElement) = crypt32.CryptFindLocalizedName
+//sys	CryptMsgOpenToEncode(dwMsgEncodingType uint32, dwFlags uint32, dwMsgType CRYPT_MSG_TYPE, pvMsgEncodeInfo unsafe.Pointer, pszInnerContentObjID *PSTRElement, pStreamInfo *CMSG_STREAM_INFO) (r unsafe.Pointer, err error) = crypt32.CryptMsgOpenToEncode
+//sys	CryptMsgCalculateEncodedLength(dwMsgEncodingType uint32, dwFlags uint32, dwMsgType uint32, pvMsgEncodeInfo unsafe.Pointer, pszInnerContentObjID *PSTRElement, cbData uint32) (r uint32, err error) = crypt32.CryptMsgCalculateEncodedLength
+//sys	CryptMsgOpenToDecode(dwMsgEncodingType uint32, dwFlags uint32, dwMsgType uint32, hCryptProv HCRYPTPROV_LEGACY, pRecipientInfo *CERT_INFO, pStreamInfo *CMSG_STREAM_INFO) (r unsafe.Pointer, err error) = crypt32.CryptMsgOpenToDecode
+//sys	CryptMsgDuplicate(hCryptMsg unsafe.Pointer) (r unsafe.Pointer) = crypt32.CryptMsgDuplicate
+//sys	CryptMsgClose(hCryptMsg unsafe.Pointer) (r BOOL, err error) = crypt32.CryptMsgClose
+//sys	CryptMsgUpdate(hCryptMsg unsafe.Pointer, pbData *uint8, cbData uint32, fFinal BOOL) (r BOOL, err error) = crypt32.CryptMsgUpdate
+//sys	CryptMsgGetParam(hCryptMsg unsafe.Pointer, dwParamType uint32, dwIndex uint32, pvData unsafe.Pointer, pcbData *uint32) (r BOOL, err error) = crypt32.CryptMsgGetParam
+//sys	CryptMsgControl(hCryptMsg unsafe.Pointer, dwFlags uint32, dwCtrlType uint32, pvCtrlPara unsafe.Pointer) (r BOOL, err error) = crypt32.CryptMsgControl
+//sys	CryptMsgVerifyCountersignatureEncoded(hCryptProv HCRYPTPROV_LEGACY, dwEncodingType uint32, pbSignerInfo *uint8, cbSignerInfo uint32, pbSignerInfoCountersignature *uint8, cbSignerInfoCountersignature uint32, pciCountersigner *CERT_INFO) (r BOOL, err error) = crypt32.CryptMsgVerifyCountersignatureEncoded
+//sys	CryptMsgVerifyCountersignatureEncodedEx(hCryptProv HCRYPTPROV_LEGACY, dwEncodingType uint32, pbSignerInfo *uint8, cbSignerInfo uint32, pbSignerInfoCountersignature *uint8, cbSignerInfoCountersignature uint32, dwSignerType uint32, pvSigner unsafe.Pointer, dwFlags uint32, pvExtra unsafe.Pointer) (r BOOL, err error) = crypt32.CryptMsgVerifyCountersignatureEncodedEx
+//sys	CryptMsgCountersign(hCryptMsg unsafe.Pointer, dwIndex uint32, cCountersigners uint32, rgCountersigners *CMSG_SIGNER_ENCODE_INFO) (r BOOL, err error) = crypt32.CryptMsgCountersign
+//sys	CryptMsgCountersignEncoded(dwEncodingType uint32, pbSignerInfo *uint8, cbSignerInfo uint32, cCountersigners uint32, rgCountersigners *CMSG_SIGNER_ENCODE_INFO, pbCountersignature *uint8, pcbCountersignature *uint32) (r BOOL, err error) = crypt32.CryptMsgCountersignEncoded
+//sys	CertOpenStore(lpszStoreProvider *PSTRElement, dwEncodingType CERT_QUERY_ENCODING_TYPE, hCryptProv HCRYPTPROV_LEGACY, dwFlags CERT_OPEN_STORE_FLAGS, pvPara unsafe.Pointer) (r HCERTSTORE, err error) = crypt32.CertOpenStore
+//sys	CertDuplicateStore(hCertStore HCERTSTORE) (r HCERTSTORE) = crypt32.CertDuplicateStore
+//sys	CertSaveStore(hCertStore HCERTSTORE, dwEncodingType CERT_QUERY_ENCODING_TYPE, dwSaveAs CERT_STORE_SAVE_AS, dwSaveTo CERT_STORE_SAVE_TO, pvSaveToPara unsafe.Pointer, dwFlags uint32) (r BOOL, err error) = crypt32.CertSaveStore
+//sys	CertCloseStore(hCertStore HCERTSTORE, dwFlags uint32) (r BOOL, err error) = crypt32.CertCloseStore
+//sys	CertGetSubjectCertificateFromStore(hCertStore HCERTSTORE, dwCertEncodingType CERT_QUERY_ENCODING_TYPE, pCertId *CERT_INFO) (r *CERT_CONTEXT, err error) = crypt32.CertGetSubjectCertificateFromStore
+//sys	CertEnumCertificatesInStore(hCertStore HCERTSTORE, pPrevCertContext *CERT_CONTEXT) (r *CERT_CONTEXT, err error) = crypt32.CertEnumCertificatesInStore
+//sys	CertFindCertificateInStore(hCertStore HCERTSTORE, dwCertEncodingType CERT_QUERY_ENCODING_TYPE, dwFindFlags uint32, dwFindType CERT_FIND_FLAGS, pvFindPara unsafe.Pointer, pPrevCertContext *CERT_CONTEXT) (r *CERT_CONTEXT, err error) = crypt32.CertFindCertificateInStore
+//sys	CertGetIssuerCertificateFromStore(hCertStore HCERTSTORE, pSubjectContext *CERT_CONTEXT, pPrevIssuerContext *CERT_CONTEXT, pdwFlags *uint32) (r *CERT_CONTEXT, err error) = crypt32.CertGetIssuerCertificateFromStore
+//sys	CertVerifySubjectCertificateContext(pSubject *CERT_CONTEXT, pIssuer *CERT_CONTEXT, pdwFlags *uint32) (r BOOL, err error) = crypt32.CertVerifySubjectCertificateContext
+//sys	CertDuplicateCertificateContext(pCertContext *CERT_CONTEXT) (r *CERT_CONTEXT) = crypt32.CertDuplicateCertificateContext
+//sys	CertCreateCertificateContext(dwCertEncodingType CERT_QUERY_ENCODING_TYPE, pbCertEncoded *uint8, cbCertEncoded uint32) (r *CERT_CONTEXT, err error) = crypt32.CertCreateCertificateContext
+//sys	CertFreeCertificateContext(pCertContext *CERT_CONTEXT) (r BOOL) = crypt32.CertFreeCertificateContext
+//sys	CertSetCertificateContextProperty(pCertContext *CERT_CONTEXT, dwPropId uint32, dwFlags uint32, pvData unsafe.Pointer) (r BOOL, err error) = crypt32.CertSetCertificateContextProperty
+//sys	CertGetCertificateContextProperty(pCertContext *CERT_CONTEXT, dwPropId uint32, pvData unsafe.Pointer, pcbData *uint32) (r BOOL, err error) = crypt32.CertGetCertificateContextProperty
+//sys	CertEnumCertificateContextProperties(pCertContext *CERT_CONTEXT, dwPropId uint32) (r uint32) = crypt32.CertEnumCertificateContextProperties
+//sys	CertCreateCTLEntryFromCertificateContextProperties(pCertContext *CERT_CONTEXT, cOptAttr uint32, rgOptAttr *CRYPT_ATTRIBUTE, dwFlags uint32, pvReserved unsafe.Pointer, pCtlEntry *CTL_ENTRY, pcbCtlEntry *uint32) (r BOOL, err error) = crypt32.CertCreateCTLEntryFromCertificateContextProperties
+//sys	CertSetCertificateContextPropertiesFromCTLEntry(pCertContext *CERT_CONTEXT, pCtlEntry *CTL_ENTRY, dwFlags uint32) (r BOOL, err error) = crypt32.CertSetCertificateContextPropertiesFromCTLEntry
+//sys	CertGetCRLFromStore(hCertStore HCERTSTORE, pIssuerContext *CERT_CONTEXT, pPrevCrlContext *CRL_CONTEXT, pdwFlags *uint32) (r *CRL_CONTEXT, err error) = crypt32.CertGetCRLFromStore
+//sys	CertEnumCRLsInStore(hCertStore HCERTSTORE, pPrevCrlContext *CRL_CONTEXT) (r *CRL_CONTEXT, err error) = crypt32.CertEnumCRLsInStore
+//sys	CertFindCRLInStore(hCertStore HCERTSTORE, dwCertEncodingType CERT_QUERY_ENCODING_TYPE, dwFindFlags uint32, dwFindType uint32, pvFindPara unsafe.Pointer, pPrevCrlContext *CRL_CONTEXT) (r *CRL_CONTEXT, err error) = crypt32.CertFindCRLInStore
+//sys	CertDuplicateCRLContext(pCrlContext *CRL_CONTEXT) (r *CRL_CONTEXT) = crypt32.CertDuplicateCRLContext
+//sys	CertCreateCRLContext(dwCertEncodingType CERT_QUERY_ENCODING_TYPE, pbCrlEncoded *uint8, cbCrlEncoded uint32) (r *CRL_CONTEXT, err error) = crypt32.CertCreateCRLContext
+//sys	CertFreeCRLContext(pCrlContext *CRL_CONTEXT) (r BOOL) = crypt32.CertFreeCRLContext
+//sys	CertSetCRLContextProperty(pCrlContext *CRL_CONTEXT, dwPropId uint32, dwFlags uint32, pvData unsafe.Pointer) (r BOOL, err error) = crypt32.CertSetCRLContextProperty
+//sys	CertGetCRLContextProperty(pCrlContext *CRL_CONTEXT, dwPropId uint32, pvData unsafe.Pointer, pcbData *uint32) (r BOOL, err error) = crypt32.CertGetCRLContextProperty
+//sys	CertEnumCRLContextProperties(pCrlContext *CRL_CONTEXT, dwPropId uint32) (r uint32) = crypt32.CertEnumCRLContextProperties
+//sys	CertFindCertificateInCRL(pCert *CERT_CONTEXT, pCrlContext *CRL_CONTEXT, dwFlags uint32, pvReserved unsafe.Pointer, ppCrlEntry **CRL_ENTRY) (r BOOL) = crypt32.CertFindCertificateInCRL
+//sys	CertIsValidCRLForCertificate(pCert *CERT_CONTEXT, pCrl *CRL_CONTEXT, dwFlags uint32, pvReserved unsafe.Pointer) (r BOOL) = crypt32.CertIsValidCRLForCertificate
+//sys	CertAddEncodedCertificateToStore(hCertStore HCERTSTORE, dwCertEncodingType CERT_QUERY_ENCODING_TYPE, pbCertEncoded *uint8, cbCertEncoded uint32, dwAddDisposition uint32, ppCertContext **CERT_CONTEXT) (r BOOL, err error) = crypt32.CertAddEncodedCertificateToStore
+//sys	CertAddCertificateContextToStore(hCertStore HCERTSTORE, pCertContext *CERT_CONTEXT, dwAddDisposition uint32, ppStoreContext **CERT_CONTEXT) (r BOOL, err error) = crypt32.CertAddCertificateContextToStore
+//sys	CertAddSerializedElementToStore(hCertStore HCERTSTORE, pbElement *uint8, cbElement uint32, dwAddDisposition uint32, dwFlags uint32, dwContextTypeFlags uint32, pdwContextType *uint32, ppvContext *unsafe.Pointer) (r BOOL, err error) = crypt32.CertAddSerializedElementToStore
+//sys	CertDeleteCertificateFromStore(pCertContext *CERT_CONTEXT) (r BOOL, err error) = crypt32.CertDeleteCertificateFromStore
+//sys	CertAddEncodedCRLToStore(hCertStore HCERTSTORE, dwCertEncodingType CERT_QUERY_ENCODING_TYPE, pbCrlEncoded *uint8, cbCrlEncoded uint32, dwAddDisposition uint32, ppCrlContext **CRL_CONTEXT) (r BOOL, err error) = crypt32.CertAddEncodedCRLToStore
+//sys	CertAddCRLContextToStore(hCertStore HCERTSTORE, pCrlContext *CRL_CONTEXT, dwAddDisposition uint32, ppStoreContext **CRL_CONTEXT) (r BOOL, err error) = crypt32.CertAddCRLContextToStore
+//sys	CertDeleteCRLFromStore(pCrlContext *CRL_CONTEXT) (r BOOL, err error) = crypt32.CertDeleteCRLFromStore
+//sys	CertSerializeCertificateStoreElement(pCertContext *CERT_CONTEXT, dwFlags uint32, pbElement *uint8, pcbElement *uint32) (r BOOL, err error) = crypt32.CertSerializeCertificateStoreElement
+//sys	CertSerializeCRLStoreElement(pCrlContext *CRL_CONTEXT, dwFlags uint32, pbElement *uint8, pcbElement *uint32) (r BOOL, err error) = crypt32.CertSerializeCRLStoreElement
+//sys	CertDuplicateCTLContext(pCtlContext *CTL_CONTEXT) (r *CTL_CONTEXT) = crypt32.CertDuplicateCTLContext
+//sys	CertCreateCTLContext(dwMsgAndCertEncodingType uint32, pbCtlEncoded *uint8, cbCtlEncoded uint32) (r *CTL_CONTEXT, err error) = crypt32.CertCreateCTLContext
+//sys	CertFreeCTLContext(pCtlContext *CTL_CONTEXT) (r BOOL) = crypt32.CertFreeCTLContext
+//sys	CertSetCTLContextProperty(pCtlContext *CTL_CONTEXT, dwPropId uint32, dwFlags uint32, pvData unsafe.Pointer) (r BOOL, err error) = crypt32.CertSetCTLContextProperty
+//sys	CertGetCTLContextProperty(pCtlContext *CTL_CONTEXT, dwPropId uint32, pvData unsafe.Pointer, pcbData *uint32) (r BOOL, err error) = crypt32.CertGetCTLContextProperty
+//sys	CertEnumCTLContextProperties(pCtlContext *CTL_CONTEXT, dwPropId uint32) (r uint32) = crypt32.CertEnumCTLContextProperties
+//sys	CertEnumCTLsInStore(hCertStore HCERTSTORE, pPrevCtlContext *CTL_CONTEXT) (r *CTL_CONTEXT, err error) = crypt32.CertEnumCTLsInStore
+//sys	CertFindSubjectInCTL(dwEncodingType uint32, dwSubjectType uint32, pvSubject unsafe.Pointer, pCtlContext *CTL_CONTEXT, dwFlags uint32) (r *CTL_ENTRY, err error) = crypt32.CertFindSubjectInCTL
+//sys	CertFindCTLInStore(hCertStore HCERTSTORE, dwMsgAndCertEncodingType uint32, dwFindFlags uint32, dwFindType CERT_FIND_TYPE, pvFindPara unsafe.Pointer, pPrevCtlContext *CTL_CONTEXT) (r *CTL_CONTEXT, err error) = crypt32.CertFindCTLInStore
+//sys	CertAddEncodedCTLToStore(hCertStore HCERTSTORE, dwMsgAndCertEncodingType CERT_QUERY_ENCODING_TYPE, pbCtlEncoded *uint8, cbCtlEncoded uint32, dwAddDisposition uint32, ppCtlContext **CTL_CONTEXT) (r BOOL, err error) = crypt32.CertAddEncodedCTLToStore
+//sys	CertAddCTLContextToStore(hCertStore HCERTSTORE, pCtlContext *CTL_CONTEXT, dwAddDisposition uint32, ppStoreContext **CTL_CONTEXT) (r BOOL, err error) = crypt32.CertAddCTLContextToStore
+//sys	CertSerializeCTLStoreElement(pCtlContext *CTL_CONTEXT, dwFlags uint32, pbElement *uint8, pcbElement *uint32) (r BOOL, err error) = crypt32.CertSerializeCTLStoreElement
+//sys	CertDeleteCTLFromStore(pCtlContext *CTL_CONTEXT) (r BOOL, err error) = crypt32.CertDeleteCTLFromStore
+//sys	CertAddCertificateLinkToStore(hCertStore HCERTSTORE, pCertContext *CERT_CONTEXT, dwAddDisposition uint32, ppStoreContext **CERT_CONTEXT) (r BOOL, err error) = crypt32.CertAddCertificateLinkToStore
+//sys	CertAddCRLLinkToStore(hCertStore HCERTSTORE, pCrlContext *CRL_CONTEXT, dwAddDisposition uint32, ppStoreContext **CRL_CONTEXT) (r BOOL, err error) = crypt32.CertAddCRLLinkToStore
+//sys	CertAddCTLLinkToStore(hCertStore HCERTSTORE, pCtlContext *CTL_CONTEXT, dwAddDisposition uint32, ppStoreContext **CTL_CONTEXT) (r BOOL, err error) = crypt32.CertAddCTLLinkToStore
+//sys	CertAddStoreToCollection(hCollectionStore HCERTSTORE, hSiblingStore HCERTSTORE, dwUpdateFlags uint32, dwPriority uint32) (r BOOL) = crypt32.CertAddStoreToCollection
+//sys	CertRemoveStoreFromCollection(hCollectionStore HCERTSTORE, hSiblingStore HCERTSTORE) = crypt32.CertRemoveStoreFromCollection
+//sys	CertControlStore(hCertStore HCERTSTORE, dwFlags CERT_CONTROL_STORE_FLAGS, dwCtrlType uint32, pvCtrlPara unsafe.Pointer) (r BOOL, err error) = crypt32.CertControlStore
+//sys	CertSetStoreProperty(hCertStore HCERTSTORE, dwPropId uint32, dwFlags uint32, pvData unsafe.Pointer) (r BOOL) = crypt32.CertSetStoreProperty
+//sys	CertGetStoreProperty(hCertStore HCERTSTORE, dwPropId uint32, pvData unsafe.Pointer, pcbData *uint32) (r BOOL, err error) = crypt32.CertGetStoreProperty
+//sys	CertCreateContext(dwContextType uint32, dwEncodingType uint32, pbEncoded *uint8, cbEncoded uint32, dwFlags uint32, pCreatePara *CERT_CREATE_CONTEXT_PARA) (r unsafe.Pointer, err error) = crypt32.CertCreateContext
+//sys	CertRegisterSystemStore(pvSystemStore unsafe.Pointer, dwFlags uint32, pStoreInfo *CERT_SYSTEM_STORE_INFO, pvReserved unsafe.Pointer) (r BOOL) = crypt32.CertRegisterSystemStore
+//sys	CertRegisterPhysicalStore(pvSystemStore unsafe.Pointer, dwFlags uint32, pwszStoreName *PWSTRElement, pStoreInfo *CERT_PHYSICAL_STORE_INFO, pvReserved unsafe.Pointer) (r BOOL) = crypt32.CertRegisterPhysicalStore
+//sys	CertUnregisterSystemStore(pvSystemStore unsafe.Pointer, dwFlags uint32) (r BOOL) = crypt32.CertUnregisterSystemStore
+//sys	CertUnregisterPhysicalStore(pvSystemStore unsafe.Pointer, dwFlags uint32, pwszStoreName *PWSTRElement) (r BOOL) = crypt32.CertUnregisterPhysicalStore
+//sys	CertEnumSystemStoreLocation(dwFlags uint32, pvArg unsafe.Pointer, pfnEnum PFN_CERT_ENUM_SYSTEM_STORE_LOCATION) (r BOOL) = crypt32.CertEnumSystemStoreLocation
+//sys	CertEnumSystemStore(dwFlags uint32, pvSystemStoreLocationPara unsafe.Pointer, pvArg unsafe.Pointer, pfnEnum PFN_CERT_ENUM_SYSTEM_STORE) (r BOOL) = crypt32.CertEnumSystemStore
+//sys	CertEnumPhysicalStore(pvSystemStore unsafe.Pointer, dwFlags uint32, pvArg unsafe.Pointer, pfnEnum PFN_CERT_ENUM_PHYSICAL_STORE) (r BOOL, err error) = crypt32.CertEnumPhysicalStore
+//sys	CertGetEnhancedKeyUsage(pCertContext *CERT_CONTEXT, dwFlags uint32, pUsage *CTL_USAGE, pcbUsage *uint32) (r BOOL, err error) = crypt32.CertGetEnhancedKeyUsage
+//sys	CertSetEnhancedKeyUsage(pCertContext *CERT_CONTEXT, pUsage *CTL_USAGE) (r BOOL, err error) = crypt32.CertSetEnhancedKeyUsage
+//sys	CertAddEnhancedKeyUsageIdentifier(pCertContext *CERT_CONTEXT, pszUsageIdentifier *PSTRElement) (r BOOL, err error) = crypt32.CertAddEnhancedKeyUsageIdentifier
+//sys	CertRemoveEnhancedKeyUsageIdentifier(pCertContext *CERT_CONTEXT, pszUsageIdentifier *PSTRElement) (r BOOL, err error) = crypt32.CertRemoveEnhancedKeyUsageIdentifier
+//sys	CertGetValidUsages(cCerts uint32, rghCerts **CERT_CONTEXT, cNumOIDs *int32, rghOIDs **PSTRElement, pcbOIDs *uint32) (r BOOL, err error) = crypt32.CertGetValidUsages
+//sys	CryptMsgGetAndVerifySigner(hCryptMsg unsafe.Pointer, cSignerStore uint32, rghSignerStore *HCERTSTORE, dwFlags uint32, ppSigner **CERT_CONTEXT, pdwSignerIndex *uint32) (r BOOL, err error) = crypt32.CryptMsgGetAndVerifySigner
+//sys	CryptMsgSignCTL(dwMsgEncodingType uint32, pbCtlContent *uint8, cbCtlContent uint32, pSignInfo *CMSG_SIGNED_ENCODE_INFO, dwFlags uint32, pbEncoded *uint8, pcbEncoded *uint32) (r BOOL, err error) = crypt32.CryptMsgSignCTL
+//sys	CryptMsgEncodeAndSignCTL(dwMsgEncodingType uint32, pCtlInfo *CTL_INFO, pSignInfo *CMSG_SIGNED_ENCODE_INFO, dwFlags uint32, pbEncoded *uint8, pcbEncoded *uint32) (r BOOL, err error) = crypt32.CryptMsgEncodeAndSignCTL
+//sys	CertFindSubjectInSortedCTL(pSubjectIdentifier *CRYPT_INTEGER_BLOB, pCtlContext *CTL_CONTEXT, dwFlags uint32, pvReserved unsafe.Pointer, pEncodedAttributes *CRYPT_INTEGER_BLOB) (r BOOL) = crypt32.CertFindSubjectInSortedCTL
+//sys	CertEnumSubjectInSortedCTL(pCtlContext *CTL_CONTEXT, ppvNextSubject *unsafe.Pointer, pSubjectIdentifier *CRYPT_INTEGER_BLOB, pEncodedAttributes *CRYPT_INTEGER_BLOB) (r BOOL) = crypt32.CertEnumSubjectInSortedCTL
+//sys	CertVerifyCTLUsage(dwEncodingType uint32, dwSubjectType uint32, pvSubject unsafe.Pointer, pSubjectUsage *CTL_USAGE, dwFlags uint32, pVerifyUsagePara *CTL_VERIFY_USAGE_PARA, pVerifyUsageStatus *CTL_VERIFY_USAGE_STATUS) (r BOOL, err error) = crypt32.CertVerifyCTLUsage
+//sys	CertVerifyRevocation(dwEncodingType uint32, dwRevType uint32, cContext uint32, rgpvContext *unsafe.Pointer, dwFlags uint32, pRevPara *CERT_REVOCATION_PARA, pRevStatus *CERT_REVOCATION_STATUS) (r BOOL, err error) = crypt32.CertVerifyRevocation
+//sys	CertCompareIntegerBlob(pInt1 *CRYPT_INTEGER_BLOB, pInt2 *CRYPT_INTEGER_BLOB) (r BOOL, err error) = crypt32.CertCompareIntegerBlob
+//sys	CertCompareCertificate(dwCertEncodingType CERT_QUERY_ENCODING_TYPE, pCertId1 *CERT_INFO, pCertId2 *CERT_INFO) (r BOOL) = crypt32.CertCompareCertificate
+//sys	CertCompareCertificateName(dwCertEncodingType CERT_QUERY_ENCODING_TYPE, pCertName1 *CRYPT_INTEGER_BLOB, pCertName2 *CRYPT_INTEGER_BLOB) (r BOOL) = crypt32.CertCompareCertificateName
+//sys	CertIsRDNAttrsInCertificateName(dwCertEncodingType CERT_QUERY_ENCODING_TYPE, dwFlags uint32, pCertName *CRYPT_INTEGER_BLOB, pRDN *CERT_RDN) (r BOOL, err error) = crypt32.CertIsRDNAttrsInCertificateName
+//sys	CertComparePublicKeyInfo(dwCertEncodingType CERT_QUERY_ENCODING_TYPE, pPublicKey1 *CERT_PUBLIC_KEY_INFO, pPublicKey2 *CERT_PUBLIC_KEY_INFO) (r BOOL) = crypt32.CertComparePublicKeyInfo
+//sys	CertGetPublicKeyLength(dwCertEncodingType CERT_QUERY_ENCODING_TYPE, pPublicKey *CERT_PUBLIC_KEY_INFO) (r uint32, err error) = crypt32.CertGetPublicKeyLength
+//sys	CryptVerifyCertificateSignature(hCryptProv HCRYPTPROV_LEGACY, dwCertEncodingType CERT_QUERY_ENCODING_TYPE, pbEncoded *uint8, cbEncoded uint32, pPublicKey *CERT_PUBLIC_KEY_INFO) (r BOOL, err error) = crypt32.CryptVerifyCertificateSignature
+//sys	CryptVerifyCertificateSignatureEx(hCryptProv HCRYPTPROV_LEGACY, dwCertEncodingType CERT_QUERY_ENCODING_TYPE, dwSubjectType uint32, pvSubject unsafe.Pointer, dwIssuerType uint32, pvIssuer unsafe.Pointer, dwFlags CRYPT_VERIFY_CERT_FLAGS, pvExtra unsafe.Pointer) (r BOOL, err error) = crypt32.CryptVerifyCertificateSignatureEx
+//sys	CertIsStrongHashToSign(pStrongSignPara *CERT_STRONG_SIGN_PARA, pwszCNGHashAlgid *PWSTRElement, pSigningCert *CERT_CONTEXT) (r BOOL, err error) = crypt32.CertIsStrongHashToSign
+//sys	CryptHashToBeSigned(hCryptProv HCRYPTPROV_LEGACY, dwCertEncodingType CERT_QUERY_ENCODING_TYPE, pbEncoded *uint8, cbEncoded uint32, pbComputedHash *uint8, pcbComputedHash *uint32) (r BOOL, err error) = crypt32.CryptHashToBeSigned
+//sys	CryptHashCertificate(hCryptProv HCRYPTPROV_LEGACY, Algid ALG_ID, dwFlags uint32, pbEncoded *uint8, cbEncoded uint32, pbComputedHash *uint8, pcbComputedHash *uint32) (r BOOL, err error) = crypt32.CryptHashCertificate
+//sys	CryptHashCertificate2(pwszCNGHashAlgid *PWSTRElement, dwFlags uint32, pvReserved unsafe.Pointer, pbEncoded *uint8, cbEncoded uint32, pbComputedHash *uint8, pcbComputedHash *uint32) (r BOOL, err error) = crypt32.CryptHashCertificate2
+//sys	CryptSignCertificate(hCryptProvOrNCryptKey HCRYPTPROV_OR_NCRYPT_KEY_HANDLE, dwKeySpec uint32, dwCertEncodingType CERT_QUERY_ENCODING_TYPE, pbEncodedToBeSigned *uint8, cbEncodedToBeSigned uint32, pSignatureAlgorithm *CRYPT_ALGORITHM_IDENTIFIER, pvHashAuxInfo unsafe.Pointer, pbSignature *uint8, pcbSignature *uint32) (r BOOL, err error) = crypt32.CryptSignCertificate
+//sys	CryptSignAndEncodeCertificate(hCryptProvOrNCryptKey HCRYPTPROV_OR_NCRYPT_KEY_HANDLE, dwKeySpec CERT_KEY_SPEC, dwCertEncodingType CERT_QUERY_ENCODING_TYPE, lpszStructType *PSTRElement, pvStructInfo unsafe.Pointer, pSignatureAlgorithm *CRYPT_ALGORITHM_IDENTIFIER, pvHashAuxInfo unsafe.Pointer, pbEncoded *uint8, pcbEncoded *uint32) (r BOOL, err error) = crypt32.CryptSignAndEncodeCertificate
+//sys	CertVerifyTimeValidity(pTimeToVerify *FILETIME, pCertInfo *CERT_INFO) (r int32) = crypt32.CertVerifyTimeValidity
+//sys	CertVerifyCRLTimeValidity(pTimeToVerify *FILETIME, pCrlInfo *CRL_INFO) (r int32) = crypt32.CertVerifyCRLTimeValidity
+//sys	CertVerifyValidityNesting(pSubjectInfo *CERT_INFO, pIssuerInfo *CERT_INFO) (r BOOL) = crypt32.CertVerifyValidityNesting
+//sys	CertVerifyCRLRevocation(dwCertEncodingType CERT_QUERY_ENCODING_TYPE, pCertId *CERT_INFO, cCrlInfo uint32, rgpCrlInfo **CRL_INFO) (r BOOL) = crypt32.CertVerifyCRLRevocation
+//sys	CertAlgIdToOID(dwAlgId uint32) (r *PSTRElement) = crypt32.CertAlgIdToOID
+//sys	CertOIDToAlgId(pszObjId *PSTRElement) (r uint32) = crypt32.CertOIDToAlgId
+//sys	CertFindExtension(pszObjId *PSTRElement, cExtensions uint32, rgExtensions *CERT_EXTENSION) (r *CERT_EXTENSION) = crypt32.CertFindExtension
+//sys	CertFindAttribute(pszObjId *PSTRElement, cAttr uint32, rgAttr *CRYPT_ATTRIBUTE) (r *CRYPT_ATTRIBUTE) = crypt32.CertFindAttribute
+//sys	CertFindRDNAttr(pszObjId *PSTRElement, pName *CERT_NAME_INFO) (r *CERT_RDN_ATTR) = crypt32.CertFindRDNAttr
+//sys	CertGetIntendedKeyUsage(dwCertEncodingType CERT_QUERY_ENCODING_TYPE, pCertInfo *CERT_INFO, pbKeyUsage *uint8, cbKeyUsage uint32) (r BOOL, err error) = crypt32.CertGetIntendedKeyUsage
+//sys	CryptInstallDefaultContext(hCryptProv uintptr, dwDefaultType CRYPT_DEFAULT_CONTEXT_TYPE, pvDefaultPara unsafe.Pointer, dwFlags CRYPT_DEFAULT_CONTEXT_FLAGS, pvReserved unsafe.Pointer, phDefaultContext *unsafe.Pointer) (r BOOL, err error) = crypt32.CryptInstallDefaultContext
+//sys	CryptUninstallDefaultContext(hDefaultContext unsafe.Pointer, dwFlags uint32, pvReserved unsafe.Pointer) (r BOOL, err error) = crypt32.CryptUninstallDefaultContext
+//sys	CryptExportPublicKeyInfo(hCryptProvOrNCryptKey HCRYPTPROV_OR_NCRYPT_KEY_HANDLE, dwKeySpec uint32, dwCertEncodingType CERT_QUERY_ENCODING_TYPE, pInfo *CERT_PUBLIC_KEY_INFO, pcbInfo *uint32) (r BOOL, err error) = crypt32.CryptExportPublicKeyInfo
+//sys	CryptExportPublicKeyInfoEx(hCryptProvOrNCryptKey HCRYPTPROV_OR_NCRYPT_KEY_HANDLE, dwKeySpec uint32, dwCertEncodingType CERT_QUERY_ENCODING_TYPE, pszPublicKeyObjId *PSTRElement, dwFlags uint32, pvAuxInfo unsafe.Pointer, pInfo *CERT_PUBLIC_KEY_INFO, pcbInfo *uint32) (r BOOL, err error) = crypt32.CryptExportPublicKeyInfoEx
+//sys	CryptExportPublicKeyInfoFromBCryptKeyHandle(hBCryptKey BCRYPT_KEY_HANDLE, dwCertEncodingType CERT_QUERY_ENCODING_TYPE, pszPublicKeyObjId *PSTRElement, dwFlags uint32, pvAuxInfo unsafe.Pointer, pInfo *CERT_PUBLIC_KEY_INFO, pcbInfo *uint32) (r BOOL) = crypt32.CryptExportPublicKeyInfoFromBCryptKeyHandle
+//sys	CryptImportPublicKeyInfo(hCryptProv uintptr, dwCertEncodingType CERT_QUERY_ENCODING_TYPE, pInfo *CERT_PUBLIC_KEY_INFO, phKey *uintptr) (r BOOL, err error) = crypt32.CryptImportPublicKeyInfo
+//sys	CryptImportPublicKeyInfoEx(hCryptProv uintptr, dwCertEncodingType CERT_QUERY_ENCODING_TYPE, pInfo *CERT_PUBLIC_KEY_INFO, aiKeyAlg ALG_ID, dwFlags uint32, pvAuxInfo unsafe.Pointer, phKey *uintptr) (r BOOL, err error) = crypt32.CryptImportPublicKeyInfoEx
+//sys	CryptImportPublicKeyInfoEx2(dwCertEncodingType CERT_QUERY_ENCODING_TYPE, pInfo *CERT_PUBLIC_KEY_INFO, dwFlags CRYPT_IMPORT_PUBLIC_KEY_FLAGS, pvAuxInfo unsafe.Pointer, phKey *BCRYPT_KEY_HANDLE) (r BOOL, err error) = crypt32.CryptImportPublicKeyInfoEx2
+//sys	CryptAcquireCertificatePrivateKey(pCert *CERT_CONTEXT, dwFlags CRYPT_ACQUIRE_FLAGS, pvParameters unsafe.Pointer, phCryptProvOrNCryptKey *HCRYPTPROV_OR_NCRYPT_KEY_HANDLE, pdwKeySpec *CERT_KEY_SPEC, pfCallerFreeProvOrNCryptKey *BOOL) (r BOOL, err error) = crypt32.CryptAcquireCertificatePrivateKey
+//sys	CryptFindCertificateKeyProvInfo(pCert *CERT_CONTEXT, dwFlags CRYPT_FIND_FLAGS, pvReserved unsafe.Pointer) (r BOOL, err error) = crypt32.CryptFindCertificateKeyProvInfo
+//sys	CryptImportPKCS8(sPrivateKeyAndParams CRYPT_PKCS8_IMPORT_PARAMS, dwFlags CRYPT_KEY_FLAGS, phCryptProv *uintptr, pvAuxInfo unsafe.Pointer) (r BOOL, err error) = crypt32.CryptImportPKCS8
+//sys	CryptExportPKCS8(hCryptProv uintptr, dwKeySpec uint32, pszPrivateKeyObjId *PSTRElement, dwFlags uint32, pvAuxInfo unsafe.Pointer, pbPrivateKeyBlob *uint8, pcbPrivateKeyBlob *uint32) (r BOOL, err error) = crypt32.CryptExportPKCS8
+//sys	CryptHashPublicKeyInfo(hCryptProv HCRYPTPROV_LEGACY, Algid ALG_ID, dwFlags uint32, dwCertEncodingType CERT_QUERY_ENCODING_TYPE, pInfo *CERT_PUBLIC_KEY_INFO, pbComputedHash *uint8, pcbComputedHash *uint32) (r BOOL, err error) = crypt32.CryptHashPublicKeyInfo
+//sys	CertRDNValueToStrA(dwValueType uint32, pValue *CRYPT_INTEGER_BLOB, psz *PSTRElement, csz uint32) (r uint32) = crypt32.CertRDNValueToStrA
+//sys	CertRDNValueToStrW(dwValueType uint32, pValue *CRYPT_INTEGER_BLOB, psz *PWSTRElement, csz uint32) (r uint32) = crypt32.CertRDNValueToStrW
+//sys	CertNameToStrA(dwCertEncodingType CERT_QUERY_ENCODING_TYPE, pName *CRYPT_INTEGER_BLOB, dwStrType CERT_STRING_TYPE, psz *PSTRElement, csz uint32) (r uint32) = crypt32.CertNameToStrA
+//sys	CertNameToStrW(dwCertEncodingType CERT_QUERY_ENCODING_TYPE, pName *CRYPT_INTEGER_BLOB, dwStrType CERT_STRING_TYPE, psz *PWSTRElement, csz uint32) (r uint32) = crypt32.CertNameToStrW
+//sys	CertStrToNameA(dwCertEncodingType CERT_QUERY_ENCODING_TYPE, pszX500 *PSTRElement, dwStrType CERT_STRING_TYPE, pvReserved unsafe.Pointer, pbEncoded *uint8, pcbEncoded *uint32, ppszError **PSTRElement) (r BOOL, err error) = crypt32.CertStrToNameA
+//sys	CertStrToNameW(dwCertEncodingType CERT_QUERY_ENCODING_TYPE, pszX500 *PWSTRElement, dwStrType CERT_STRING_TYPE, pvReserved unsafe.Pointer, pbEncoded *uint8, pcbEncoded *uint32, ppszError **PWSTRElement) (r BOOL, err error) = crypt32.CertStrToNameW
+//sys	CertGetNameStringA(pCertContext *CERT_CONTEXT, dwType uint32, dwFlags uint32, pvTypePara unsafe.Pointer, pszNameString *PSTRElement, cchNameString uint32) (r uint32) = crypt32.CertGetNameStringA
+//sys	CertGetNameStringW(pCertContext *CERT_CONTEXT, dwType uint32, dwFlags uint32, pvTypePara unsafe.Pointer, pszNameString *PWSTRElement, cchNameString uint32) (r uint32) = crypt32.CertGetNameStringW
+//sys	CryptSignMessage(pSignPara *CRYPT_SIGN_MESSAGE_PARA, fDetachedSignature BOOL, cToBeSigned uint32, rgpbToBeSigned **uint8, rgcbToBeSigned *uint32, pbSignedBlob *uint8, pcbSignedBlob *uint32) (r BOOL, err error) = crypt32.CryptSignMessage
+//sys	CryptVerifyMessageSignature(pVerifyPara *CRYPT_VERIFY_MESSAGE_PARA, dwSignerIndex uint32, pbSignedBlob *uint8, cbSignedBlob uint32, pbDecoded *uint8, pcbDecoded *uint32, ppSignerCert **CERT_CONTEXT) (r BOOL, err error) = crypt32.CryptVerifyMessageSignature
+//sys	CryptGetMessageSignerCount(dwMsgEncodingType uint32, pbSignedBlob *uint8, cbSignedBlob uint32) (r int32, err error) = crypt32.CryptGetMessageSignerCount
+//sys	CryptGetMessageCertificates(dwMsgAndCertEncodingType uint32, hCryptProv HCRYPTPROV_LEGACY, dwFlags uint32, pbSignedBlob *uint8, cbSignedBlob uint32) (r HCERTSTORE, err error) = crypt32.CryptGetMessageCertificates
+//sys	CryptVerifyDetachedMessageSignature(pVerifyPara *CRYPT_VERIFY_MESSAGE_PARA, dwSignerIndex uint32, pbDetachedSignBlob *uint8, cbDetachedSignBlob uint32, cToBeSigned uint32, rgpbToBeSigned **uint8, rgcbToBeSigned *uint32, ppSignerCert **CERT_CONTEXT) (r BOOL, err error) = crypt32.CryptVerifyDetachedMessageSignature
+//sys	CryptEncryptMessage(pEncryptPara *CRYPT_ENCRYPT_MESSAGE_PARA, cRecipientCert uint32, rgpRecipientCert **CERT_CONTEXT, pbToBeEncrypted *uint8, cbToBeEncrypted uint32, pbEncryptedBlob *uint8, pcbEncryptedBlob *uint32) (r BOOL, err error) = crypt32.CryptEncryptMessage
+//sys	CryptDecryptMessage(pDecryptPara *CRYPT_DECRYPT_MESSAGE_PARA, pbEncryptedBlob *uint8, cbEncryptedBlob uint32, pbDecrypted *uint8, pcbDecrypted *uint32, ppXchgCert **CERT_CONTEXT) (r BOOL, err error) = crypt32.CryptDecryptMessage
+//sys	CryptSignAndEncryptMessage(pSignPara *CRYPT_SIGN_MESSAGE_PARA, pEncryptPara *CRYPT_ENCRYPT_MESSAGE_PARA, cRecipientCert uint32, rgpRecipientCert **CERT_CONTEXT, pbToBeSignedAndEncrypted *uint8, cbToBeSignedAndEncrypted uint32, pbSignedAndEncryptedBlob *uint8, pcbSignedAndEncryptedBlob *uint32) (r BOOL, err error) = crypt32.CryptSignAndEncryptMessage
+//sys	CryptDecryptAndVerifyMessageSignature(pDecryptPara *CRYPT_DECRYPT_MESSAGE_PARA, pVerifyPara *CRYPT_VERIFY_MESSAGE_PARA, dwSignerIndex uint32, pbEncryptedBlob *uint8, cbEncryptedBlob uint32, pbDecrypted *uint8, pcbDecrypted *uint32, ppXchgCert **CERT_CONTEXT, ppSignerCert **CERT_CONTEXT) (r BOOL, err error) = crypt32.CryptDecryptAndVerifyMessageSignature
+//sys	CryptDecodeMessage(dwMsgTypeFlags uint32, pDecryptPara *CRYPT_DECRYPT_MESSAGE_PARA, pVerifyPara *CRYPT_VERIFY_MESSAGE_PARA, dwSignerIndex uint32, pbEncodedBlob *uint8, cbEncodedBlob uint32, dwPrevInnerContentType uint32, pdwMsgType *uint32, pdwInnerContentType *uint32, pbDecoded *uint8, pcbDecoded *uint32, ppXchgCert **CERT_CONTEXT, ppSignerCert **CERT_CONTEXT) (r BOOL, err error) = crypt32.CryptDecodeMessage
+//sys	CryptHashMessage(pHashPara *CRYPT_HASH_MESSAGE_PARA, fDetachedHash BOOL, cToBeHashed uint32, rgpbToBeHashed **uint8, rgcbToBeHashed *uint32, pbHashedBlob *uint8, pcbHashedBlob *uint32, pbComputedHash *uint8, pcbComputedHash *uint32) (r BOOL, err error) = crypt32.CryptHashMessage
+//sys	CryptVerifyMessageHash(pHashPara *CRYPT_HASH_MESSAGE_PARA, pbHashedBlob *uint8, cbHashedBlob uint32, pbToBeHashed *uint8, pcbToBeHashed *uint32, pbComputedHash *uint8, pcbComputedHash *uint32) (r BOOL, err error) = crypt32.CryptVerifyMessageHash
+//sys	CryptVerifyDetachedMessageHash(pHashPara *CRYPT_HASH_MESSAGE_PARA, pbDetachedHashBlob *uint8, cbDetachedHashBlob uint32, cToBeHashed uint32, rgpbToBeHashed **uint8, rgcbToBeHashed *uint32, pbComputedHash *uint8, pcbComputedHash *uint32) (r BOOL, err error) = crypt32.CryptVerifyDetachedMessageHash
+//sys	CryptSignMessageWithKey(pSignPara *CRYPT_KEY_SIGN_MESSAGE_PARA, pbToBeSigned *uint8, cbToBeSigned uint32, pbSignedBlob *uint8, pcbSignedBlob *uint32) (r BOOL, err error) = crypt32.CryptSignMessageWithKey
+//sys	CryptVerifyMessageSignatureWithKey(pVerifyPara *CRYPT_KEY_VERIFY_MESSAGE_PARA, pPublicKeyInfo *CERT_PUBLIC_KEY_INFO, pbSignedBlob *uint8, cbSignedBlob uint32, pbDecoded *uint8, pcbDecoded *uint32) (r BOOL, err error) = crypt32.CryptVerifyMessageSignatureWithKey
+//sys	CertOpenSystemStoreA(hProv HCRYPTPROV_LEGACY, szSubsystemProtocol *PSTRElement) (r HCERTSTORE, err error) = crypt32.CertOpenSystemStoreA
+//sys	CertOpenSystemStoreW(hProv HCRYPTPROV_LEGACY, szSubsystemProtocol *PWSTRElement) (r HCERTSTORE, err error) = crypt32.CertOpenSystemStoreW
+//sys	CertAddEncodedCertificateToSystemStoreA(szCertStoreName *PSTRElement, pbCertEncoded *uint8, cbCertEncoded uint32) (r BOOL, err error) = crypt32.CertAddEncodedCertificateToSystemStoreA
+//sys	CertAddEncodedCertificateToSystemStoreW(szCertStoreName *PWSTRElement, pbCertEncoded *uint8, cbCertEncoded uint32) (r BOOL, err error) = crypt32.CertAddEncodedCertificateToSystemStoreW
+//sys	FindCertsByIssuer(pCertChains *CERT_CHAIN, pcbCertChains *uint32, pcCertChains *uint32, pbEncodedIssuerName *uint8, cbEncodedIssuerName uint32, pwszPurpose *PWSTRElement, dwKeySpec uint32) (r HRESULT) = wintrust.FindCertsByIssuer
+//sys	CryptQueryObject(dwObjectType CERT_QUERY_OBJECT_TYPE, pvObject unsafe.Pointer, dwExpectedContentTypeFlags CERT_QUERY_CONTENT_TYPE_FLAGS, dwExpectedFormatTypeFlags CERT_QUERY_FORMAT_TYPE_FLAGS, dwFlags uint32, pdwMsgAndCertEncodingType *CERT_QUERY_ENCODING_TYPE, pdwContentType *CERT_QUERY_CONTENT_TYPE, pdwFormatType *CERT_QUERY_FORMAT_TYPE, phCertStore *HCERTSTORE, phMsg *unsafe.Pointer, ppvContext *unsafe.Pointer) (r BOOL, err error) = crypt32.CryptQueryObject
+//sys	CryptMemAlloc(cbSize uint32) (r unsafe.Pointer) = crypt32.CryptMemAlloc
+//sys	CryptMemRealloc(pv unsafe.Pointer, cbSize uint32) (r unsafe.Pointer) = crypt32.CryptMemRealloc
+//sys	CryptMemFree(pv unsafe.Pointer) = crypt32.CryptMemFree
+//sys	CryptCreateAsyncHandle(dwFlags uint32, phAsync *HCRYPTASYNC) (r BOOL) = crypt32.CryptCreateAsyncHandle
+//sys	CryptSetAsyncParam(hAsync HCRYPTASYNC, pszParamOid *PSTRElement, pvParam unsafe.Pointer, pfnFree PFN_CRYPT_ASYNC_PARAM_FREE_FUNC) (r BOOL) = crypt32.CryptSetAsyncParam
+//sys	CryptGetAsyncParam(hAsync HCRYPTASYNC, pszParamOid *PSTRElement, ppvParam *unsafe.Pointer, ppfnFree *PFN_CRYPT_ASYNC_PARAM_FREE_FUNC) (r BOOL) = crypt32.CryptGetAsyncParam
+//sys	CryptCloseAsyncHandle(hAsync HCRYPTASYNC) (r BOOL) = crypt32.CryptCloseAsyncHandle
+//sys	CryptRetrieveObjectByUrlA(pszUrl *PSTRElement, pszObjectOid *PSTRElement, dwRetrievalFlags uint32, dwTimeout uint32, ppvObject *unsafe.Pointer, hAsyncRetrieve HCRYPTASYNC, pCredentials *CRYPT_CREDENTIALS, pvVerify unsafe.Pointer, pAuxInfo *CRYPT_RETRIEVE_AUX_INFO) (r BOOL) = cryptnet.CryptRetrieveObjectByUrlA
+//sys	CryptRetrieveObjectByUrlW(pszUrl *PWSTRElement, pszObjectOid *PSTRElement, dwRetrievalFlags uint32, dwTimeout uint32, ppvObject *unsafe.Pointer, hAsyncRetrieve HCRYPTASYNC, pCredentials *CRYPT_CREDENTIALS, pvVerify unsafe.Pointer, pAuxInfo *CRYPT_RETRIEVE_AUX_INFO) (r BOOL) = cryptnet.CryptRetrieveObjectByUrlW
+//sys	CryptInstallCancelRetrieval(pfnCancel PFN_CRYPT_CANCEL_RETRIEVAL, pvArg unsafe.Pointer, dwFlags uint32, pvReserved unsafe.Pointer) (r BOOL) = cryptnet.CryptInstallCancelRetrieval
+//sys	CryptUninstallCancelRetrieval(dwFlags uint32, pvReserved unsafe.Pointer) (r BOOL) = cryptnet.CryptUninstallCancelRetrieval
+//sys	CryptGetObjectUrl(pszUrlOid *PSTRElement, pvPara unsafe.Pointer, dwFlags CRYPT_GET_URL_FLAGS, pUrlArray *CRYPT_URL_ARRAY, pcbUrlArray *uint32, pUrlInfo *CRYPT_URL_INFO, pcbUrlInfo *uint32, pvReserved unsafe.Pointer) (r BOOL, err error) = cryptnet.CryptGetObjectUrl
+//sys	CertCreateSelfSignCertificate(hCryptProvOrNCryptKey HCRYPTPROV_OR_NCRYPT_KEY_HANDLE, pSubjectIssuerBlob *CRYPT_INTEGER_BLOB, dwFlags CERT_CREATE_SELFSIGN_FLAGS, pKeyProvInfo *CRYPT_KEY_PROV_INFO, pSignatureAlgorithm *CRYPT_ALGORITHM_IDENTIFIER, pStartTime *SYSTEMTIME, pEndTime *SYSTEMTIME, pExtensions *CERT_EXTENSIONS) (r *CERT_CONTEXT, err error) = crypt32.CertCreateSelfSignCertificate
+//sys	CryptGetKeyIdentifierProperty(pKeyIdentifier *CRYPT_INTEGER_BLOB, dwPropId uint32, dwFlags uint32, pwszComputerName *PWSTRElement, pvReserved unsafe.Pointer, pvData unsafe.Pointer, pcbData *uint32) (r BOOL, err error) = crypt32.CryptGetKeyIdentifierProperty
+//sys	CryptSetKeyIdentifierProperty(pKeyIdentifier *CRYPT_INTEGER_BLOB, dwPropId uint32, dwFlags uint32, pwszComputerName *PWSTRElement, pvReserved unsafe.Pointer, pvData unsafe.Pointer) (r BOOL, err error) = crypt32.CryptSetKeyIdentifierProperty
+//sys	CryptEnumKeyIdentifierProperties(pKeyIdentifier *CRYPT_INTEGER_BLOB, dwPropId uint32, dwFlags uint32, pwszComputerName *PWSTRElement, pvReserved unsafe.Pointer, pvArg unsafe.Pointer, pfnEnum PFN_CRYPT_ENUM_KEYID_PROP) (r BOOL, err error) = crypt32.CryptEnumKeyIdentifierProperties
+//sys	CryptCreateKeyIdentifierFromCSP(dwCertEncodingType CERT_QUERY_ENCODING_TYPE, pszPubKeyOID *PSTRElement, pPubKeyStruc *PUBLICKEYSTRUC, cbPubKeyStruc uint32, dwFlags uint32, pvReserved unsafe.Pointer, pbHash *uint8, pcbHash *uint32) (r BOOL, err error) = crypt32.CryptCreateKeyIdentifierFromCSP
+//sys	CertCreateCertificateChainEngine(pConfig *CERT_CHAIN_ENGINE_CONFIG, phChainEngine *HCERTCHAINENGINE) (r BOOL, err error) = crypt32.CertCreateCertificateChainEngine
+//sys	CertFreeCertificateChainEngine(hChainEngine HCERTCHAINENGINE) = crypt32.CertFreeCertificateChainEngine
+//sys	CertResyncCertificateChainEngine(hChainEngine HCERTCHAINENGINE) (r BOOL, err error) = crypt32.CertResyncCertificateChainEngine
+//sys	CertGetCertificateChain(hChainEngine HCERTCHAINENGINE, pCertContext *CERT_CONTEXT, pTime *FILETIME, hAdditionalStore HCERTSTORE, pChainPara *CERT_CHAIN_PARA, dwFlags uint32, pvReserved unsafe.Pointer, ppChainContext **CERT_CHAIN_CONTEXT) (r BOOL, err error) = crypt32.CertGetCertificateChain
+//sys	CertFreeCertificateChain(pChainContext *CERT_CHAIN_CONTEXT) = crypt32.CertFreeCertificateChain
+//sys	CertDuplicateCertificateChain(pChainContext *CERT_CHAIN_CONTEXT) (r *CERT_CHAIN_CONTEXT) = crypt32.CertDuplicateCertificateChain
+//sys	CertFindChainInStore(hCertStore HCERTSTORE, dwCertEncodingType CERT_QUERY_ENCODING_TYPE, dwFindFlags CERT_FIND_CHAIN_IN_STORE_FLAGS, dwFindType uint32, pvFindPara unsafe.Pointer, pPrevChainContext *CERT_CHAIN_CONTEXT) (r *CERT_CHAIN_CONTEXT) = crypt32.CertFindChainInStore
+//sys	CertVerifyCertificateChainPolicy(pszPolicyOID *PSTRElement, pChainContext *CERT_CHAIN_CONTEXT, pPolicyPara *CERT_CHAIN_POLICY_PARA, pPolicyStatus *CERT_CHAIN_POLICY_STATUS) (r BOOL) = crypt32.CertVerifyCertificateChainPolicy
+//sys	CryptStringToBinaryA(pszString *PSTRElement, cchString uint32, dwFlags CRYPT_STRING, pbBinary *uint8, pcbBinary *uint32, pdwSkip *uint32, pdwFlags *uint32) (r BOOL, err error) = crypt32.CryptStringToBinaryA
+//sys	CryptStringToBinaryW(pszString *PWSTRElement, cchString uint32, dwFlags CRYPT_STRING, pbBinary *uint8, pcbBinary *uint32, pdwSkip *uint32, pdwFlags *uint32) (r BOOL, err error) = crypt32.CryptStringToBinaryW
+//sys	CryptBinaryToStringA(pbBinary *uint8, cbBinary uint32, dwFlags CRYPT_STRING, pszString *PSTRElement, pcchString *uint32) (r BOOL) = crypt32.CryptBinaryToStringA
+//sys	CryptBinaryToStringW(pbBinary *uint8, cbBinary uint32, dwFlags CRYPT_STRING, pszString *PWSTRElement, pcchString *uint32) (r BOOL) = crypt32.CryptBinaryToStringW
+//sys	PFXImportCertStore(pPFX *CRYPT_INTEGER_BLOB, szPassword *PWSTRElement, dwFlags CRYPT_KEY_FLAGS) (r HCERTSTORE, err error) = crypt32.PFXImportCertStore
+//sys	PFXIsPFXBlob(pPFX *CRYPT_INTEGER_BLOB) (r BOOL) = crypt32.PFXIsPFXBlob
+//sys	PFXVerifyPassword(pPFX *CRYPT_INTEGER_BLOB, szPassword *PWSTRElement, dwFlags uint32) (r BOOL) = crypt32.PFXVerifyPassword
+//sys	PFXExportCertStoreEx(hStore HCERTSTORE, pPFX *CRYPT_INTEGER_BLOB, szPassword *PWSTRElement, pvPara unsafe.Pointer, dwFlags uint32) (r BOOL, err error) = crypt32.PFXExportCertStoreEx
+//sys	PFXExportCertStore(hStore HCERTSTORE, pPFX *CRYPT_INTEGER_BLOB, szPassword *PWSTRElement, dwFlags uint32) (r BOOL, err error) = crypt32.PFXExportCertStore
+//sys	CertOpenServerOcspResponse(pChainContext *CERT_CHAIN_CONTEXT, dwFlags uint32, pOpenPara *CERT_SERVER_OCSP_RESPONSE_OPEN_PARA) (r unsafe.Pointer, err error) = crypt32.CertOpenServerOcspResponse
+//sys	CertAddRefServerOcspResponse(hServerOcspResponse unsafe.Pointer) = crypt32.CertAddRefServerOcspResponse
+//sys	CertCloseServerOcspResponse(hServerOcspResponse unsafe.Pointer, dwFlags uint32) = crypt32.CertCloseServerOcspResponse
+//sys	CertGetServerOcspResponseContext(hServerOcspResponse unsafe.Pointer, dwFlags uint32, pvReserved unsafe.Pointer) (r *CERT_SERVER_OCSP_RESPONSE_CONTEXT) = crypt32.CertGetServerOcspResponseContext
+//sys	CertAddRefServerOcspResponseContext(pServerOcspResponseContext *CERT_SERVER_OCSP_RESPONSE_CONTEXT) = crypt32.CertAddRefServerOcspResponseContext
+//sys	CertFreeServerOcspResponseContext(pServerOcspResponseContext *CERT_SERVER_OCSP_RESPONSE_CONTEXT) = crypt32.CertFreeServerOcspResponseContext
+//sys	CertRetrieveLogoOrBiometricInfo(pCertContext *CERT_CONTEXT, lpszLogoOrBiometricType *PSTRElement, dwRetrievalFlags uint32, dwTimeout uint32, dwFlags uint32, pvReserved unsafe.Pointer, ppbData **uint8, pcbData *uint32, ppwszMimeType **PWSTRElement) (r BOOL, err error) = crypt32.CertRetrieveLogoOrBiometricInfo
+//sys	CertSelectCertificateChains(pSelectionContext *Guid, dwFlags uint32, pChainParameters *CERT_SELECT_CHAIN_PARA, cCriteria uint32, rgpCriteria *CERT_SELECT_CRITERIA, hStore HCERTSTORE, pcSelection *uint32, pprgpSelection ***CERT_CHAIN_CONTEXT) (r BOOL, err error) = crypt32.CertSelectCertificateChains
+//sys	CertFreeCertificateChainList(prgpSelection **CERT_CHAIN_CONTEXT) = crypt32.CertFreeCertificateChainList
+//sys	CryptRetrieveTimeStamp(wszUrl *PWSTRElement, dwRetrievalFlags uint32, dwTimeout uint32, pszHashId *PSTRElement, pPara *CRYPT_TIMESTAMP_PARA, pbData *uint8, cbData uint32, ppTsContext **CRYPT_TIMESTAMP_CONTEXT, ppTsSigner **CERT_CONTEXT, phStore *HCERTSTORE) (r BOOL, err error) = crypt32.CryptRetrieveTimeStamp
+//sys	CryptVerifyTimeStampSignature(pbTSContentInfo *uint8, cbTSContentInfo uint32, pbData *uint8, cbData uint32, hAdditionalStore HCERTSTORE, ppTsContext **CRYPT_TIMESTAMP_CONTEXT, ppTsSigner **CERT_CONTEXT, phStore *HCERTSTORE) (r BOOL, err error) = crypt32.CryptVerifyTimeStampSignature
+//sys	CertIsWeakHash(dwHashUseType uint32, pwszCNGHashAlgid *PWSTRElement, dwChainFlags uint32, pSignerChainContext *CERT_CHAIN_CONTEXT, pTimeStamp *FILETIME, pwszFileName *PWSTRElement) (r BOOL) = crypt32.CertIsWeakHash
+//sys	CryptProtectData(pDataIn *CRYPT_INTEGER_BLOB, szDataDescr *PWSTRElement, pOptionalEntropy *CRYPT_INTEGER_BLOB, pvReserved unsafe.Pointer, pPromptStruct *CRYPTPROTECT_PROMPTSTRUCT, dwFlags uint32, pDataOut *CRYPT_INTEGER_BLOB) (r BOOL, err error) = crypt32.CryptProtectData
+//sys	CryptUnprotectData(pDataIn *CRYPT_INTEGER_BLOB, ppszDataDescr **PWSTRElement, pOptionalEntropy *CRYPT_INTEGER_BLOB, pvReserved unsafe.Pointer, pPromptStruct *CRYPTPROTECT_PROMPTSTRUCT, dwFlags uint32, pDataOut *CRYPT_INTEGER_BLOB) (r BOOL, err error) = crypt32.CryptUnprotectData
+//sys	CryptUpdateProtectedState(pOldSid PSID, pwszOldPassword *PWSTRElement, dwFlags uint32, pdwSuccessCount *uint32, pdwFailureCount *uint32) (r BOOL, err error) = crypt32.CryptUpdateProtectedState
+//sys	CryptProtectMemory(pDataIn unsafe.Pointer, cbDataIn uint32, dwFlags uint32) (r BOOL, err error) = crypt32.CryptProtectMemory
+//sys	CryptUnprotectMemory(pDataIn unsafe.Pointer, cbDataIn uint32, dwFlags uint32) (r BOOL, err error) = crypt32.CryptUnprotectMemory
+//sys	NCryptRegisterProtectionDescriptorName(pwszName *PWSTRElement, pwszDescriptorString *PWSTRElement, dwFlags uint32) (r HRESULT) = ncrypt.NCryptRegisterProtectionDescriptorName
+//sys	NCryptQueryProtectionDescriptorName(pwszName *PWSTRElement, pwszDescriptorString *PWSTRElement, pcDescriptorString *uintptr, dwFlags uint32) (r HRESULT) = ncrypt.NCryptQueryProtectionDescriptorName
+//sys	NCryptCreateProtectionDescriptor(pwszDescriptorString *PWSTRElement, dwFlags uint32, phDescriptor *NCRYPT_DESCRIPTOR_HANDLE) (r HRESULT) = ncrypt.NCryptCreateProtectionDescriptor
+//sys	NCryptCloseProtectionDescriptor(hDescriptor NCRYPT_DESCRIPTOR_HANDLE) (r HRESULT) = ncrypt.NCryptCloseProtectionDescriptor
+//sys	NCryptGetProtectionDescriptorInfo(hDescriptor NCRYPT_DESCRIPTOR_HANDLE, pMemPara *NCRYPT_ALLOC_PARA, dwInfoType uint32, ppvInfo *unsafe.Pointer) (r HRESULT) = ncrypt.NCryptGetProtectionDescriptorInfo
+//sys	NCryptProtectSecret(hDescriptor NCRYPT_DESCRIPTOR_HANDLE, dwFlags uint32, pbData *uint8, cbData uint32, pMemPara *NCRYPT_ALLOC_PARA, hWnd HWND, ppbProtectedBlob **uint8, pcbProtectedBlob *uint32) (r HRESULT) = ncrypt.NCryptProtectSecret
+//sys	NCryptUnprotectSecret(phDescriptor *NCRYPT_DESCRIPTOR_HANDLE, dwFlags NCRYPT_FLAGS, pbProtectedBlob *uint8, cbProtectedBlob uint32, pMemPara *NCRYPT_ALLOC_PARA, hWnd HWND, ppbData **uint8, pcbData *uint32) (r HRESULT) = ncrypt.NCryptUnprotectSecret
+//sys	NCryptStreamOpenToProtect(hDescriptor NCRYPT_DESCRIPTOR_HANDLE, dwFlags uint32, hWnd HWND, pStreamInfo *NCRYPT_PROTECT_STREAM_INFO, phStream *NCRYPT_STREAM_HANDLE) (r HRESULT) = ncrypt.NCryptStreamOpenToProtect
+//sys	NCryptStreamOpenToUnprotect(pStreamInfo *NCRYPT_PROTECT_STREAM_INFO, dwFlags uint32, hWnd HWND, phStream *NCRYPT_STREAM_HANDLE) (r HRESULT) = ncrypt.NCryptStreamOpenToUnprotect
+//sys	NCryptStreamOpenToUnprotectEx(pStreamInfo *NCRYPT_PROTECT_STREAM_INFO_EX, dwFlags uint32, hWnd HWND, phStream *NCRYPT_STREAM_HANDLE) (r HRESULT) = ncrypt.NCryptStreamOpenToUnprotectEx
+//sys	NCryptStreamUpdate(hStream NCRYPT_STREAM_HANDLE, pbData *uint8, cbData uintptr, fFinal BOOL) (r HRESULT) = ncrypt.NCryptStreamUpdate
+//sys	NCryptStreamClose(hStream NCRYPT_STREAM_HANDLE) (r HRESULT) = ncrypt.NCryptStreamClose
+//sys	SignError() (r HRESULT) = mssign32.SignError
+//sys	SignerFreeSignerContext(pSignerContext *SIGNER_CONTEXT) (r HRESULT) = mssign32.SignerFreeSignerContext
+//sys	SignerSign(pSubjectInfo *SIGNER_SUBJECT_INFO, pSignerCert *SIGNER_CERT, pSignatureInfo *SIGNER_SIGNATURE_INFO, pProviderInfo *SIGNER_PROVIDER_INFO, pwszHttpTimeStamp *PWSTRElement, psRequest *CRYPT_ATTRIBUTES, pSipData unsafe.Pointer) (r HRESULT) = mssign32.SignerSign
+//sys	SignerSignEx(dwFlags SIGNER_SIGN_FLAGS, pSubjectInfo *SIGNER_SUBJECT_INFO, pSignerCert *SIGNER_CERT, pSignatureInfo *SIGNER_SIGNATURE_INFO, pProviderInfo *SIGNER_PROVIDER_INFO, pwszHttpTimeStamp *PWSTRElement, psRequest *CRYPT_ATTRIBUTES, pSipData unsafe.Pointer, ppSignerContext **SIGNER_CONTEXT) (r HRESULT) = mssign32.SignerSignEx
+//sys	SignerSignEx2(dwFlags SIGNER_SIGN_FLAGS, pSubjectInfo *SIGNER_SUBJECT_INFO, pSignerCert *SIGNER_CERT, pSignatureInfo *SIGNER_SIGNATURE_INFO, pProviderInfo *SIGNER_PROVIDER_INFO, dwTimestampFlags SIGNER_TIMESTAMP_FLAGS, pszTimestampAlgorithmOid *PSTRElement, pwszHttpTimeStamp *PWSTRElement, psRequest *CRYPT_ATTRIBUTES, pSipData unsafe.Pointer, ppSignerContext **SIGNER_CONTEXT, pCryptoPolicy *CERT_STRONG_SIGN_PARA, pReserved unsafe.Pointer) (r HRESULT) = mssign32.SignerSignEx2
+//sys	SignerSignEx3(dwFlags SIGNER_SIGN_FLAGS, pSubjectInfo *SIGNER_SUBJECT_INFO, pSignerCert *SIGNER_CERT, pSignatureInfo *SIGNER_SIGNATURE_INFO, pProviderInfo *SIGNER_PROVIDER_INFO, dwTimestampFlags SIGNER_TIMESTAMP_FLAGS, pszTimestampAlgorithmOid *PSTRElement, pwszHttpTimeStamp *PWSTRElement, psRequest *CRYPT_ATTRIBUTES, pSipData unsafe.Pointer, ppSignerContext **SIGNER_CONTEXT, pCryptoPolicy *CERT_STRONG_SIGN_PARA, pDigestSignInfo *SIGNER_DIGEST_SIGN_INFO, pReserved unsafe.Pointer) (r HRESULT) = mssign32.SignerSignEx3
+//sys	SignerTimeStamp(pSubjectInfo *SIGNER_SUBJECT_INFO, pwszHttpTimeStamp *PWSTRElement, psRequest *CRYPT_ATTRIBUTES, pSipData unsafe.Pointer) (r HRESULT) = mssign32.SignerTimeStamp
+//sys	SignerTimeStampEx(dwFlags uint32, pSubjectInfo *SIGNER_SUBJECT_INFO, pwszHttpTimeStamp *PWSTRElement, psRequest *CRYPT_ATTRIBUTES, pSipData unsafe.Pointer, ppSignerContext **SIGNER_CONTEXT) (r HRESULT) = mssign32.SignerTimeStampEx
+//sys	SignerTimeStampEx2(dwFlags SIGNER_TIMESTAMP_FLAGS, pSubjectInfo *SIGNER_SUBJECT_INFO, pwszHttpTimeStamp *PWSTRElement, dwAlgId ALG_ID, psRequest *CRYPT_ATTRIBUTES, pSipData unsafe.Pointer, ppSignerContext **SIGNER_CONTEXT) (r HRESULT) = mssign32.SignerTimeStampEx2
+//sys	SignerTimeStampEx3(dwFlags SIGNER_TIMESTAMP_FLAGS, dwIndex uint32, pSubjectInfo *SIGNER_SUBJECT_INFO, pwszHttpTimeStamp *PWSTRElement, pszAlgorithmOid *PWSTRElement, psRequest *CRYPT_ATTRIBUTES, pSipData unsafe.Pointer, ppSignerContext **SIGNER_CONTEXT, pCryptoPolicy *CERT_STRONG_SIGN_PARA, pReserved unsafe.Pointer) (r HRESULT) = mssign32.SignerTimeStampEx3
+//sys	CryptXmlClose(hCryptXml unsafe.Pointer) (r HRESULT) = cryptxml.CryptXmlClose
+//sys	CryptXmlGetTransforms(ppConfig **CRYPT_XML_TRANSFORM_CHAIN_CONFIG) (r HRESULT) = cryptxml.CryptXmlGetTransforms
+//sys	CryptXmlOpenToEncode(pConfig *CRYPT_XML_TRANSFORM_CHAIN_CONFIG, dwFlags CRYPT_XML_FLAGS, wszId *PWSTRElement, rgProperty *CRYPT_XML_PROPERTY, cProperty uint32, pEncoded *CRYPT_XML_BLOB, phSignature *unsafe.Pointer) (r HRESULT) = cryptxml.CryptXmlOpenToEncode
+//sys	CryptXmlOpenToDecode(pConfig *CRYPT_XML_TRANSFORM_CHAIN_CONFIG, dwFlags CRYPT_XML_FLAGS, rgProperty *CRYPT_XML_PROPERTY, cProperty uint32, pEncoded *CRYPT_XML_BLOB, phCryptXml *unsafe.Pointer) (r HRESULT) = cryptxml.CryptXmlOpenToDecode
+//sys	CryptXmlAddObject(hSignatureOrObject unsafe.Pointer, dwFlags uint32, rgProperty *CRYPT_XML_PROPERTY, cProperty uint32, pEncoded *CRYPT_XML_BLOB, ppObject **CRYPT_XML_OBJECT) (r HRESULT) = cryptxml.CryptXmlAddObject
+//sys	CryptXmlCreateReference(hCryptXml unsafe.Pointer, dwFlags uint32, wszId *PWSTRElement, wszURI *PWSTRElement, wszType *PWSTRElement, pDigestMethod *CRYPT_XML_ALGORITHM, cTransform uint32, rgTransform *CRYPT_XML_ALGORITHM, phReference *unsafe.Pointer) (r HRESULT) = cryptxml.CryptXmlCreateReference
+//sys	CryptXmlDigestReference(hReference unsafe.Pointer, dwFlags uint32, pDataProviderIn *CRYPT_XML_DATA_PROVIDER) (r HRESULT) = cryptxml.CryptXmlDigestReference
+//sys	CryptXmlSetHMACSecret(hSignature unsafe.Pointer, pbSecret *uint8, cbSecret uint32) (r HRESULT) = cryptxml.CryptXmlSetHMACSecret
+//sys	CryptXmlSign(hSignature unsafe.Pointer, hKey HCRYPTPROV_OR_NCRYPT_KEY_HANDLE, dwKeySpec CERT_KEY_SPEC, dwFlags CRYPT_XML_FLAGS, dwKeyInfoSpec CRYPT_XML_KEYINFO_SPEC, pvKeyInfoSpec unsafe.Pointer, pSignatureMethod *CRYPT_XML_ALGORITHM, pCanonicalization *CRYPT_XML_ALGORITHM) (r HRESULT) = cryptxml.CryptXmlSign
+//sys	CryptXmlImportPublicKey(dwFlags CRYPT_XML_FLAGS, pKeyValue *CRYPT_XML_KEY_VALUE, phKey *BCRYPT_KEY_HANDLE) (r HRESULT) = cryptxml.CryptXmlImportPublicKey
+//sys	CryptXmlVerifySignature(hSignature unsafe.Pointer, hKey BCRYPT_KEY_HANDLE, dwFlags CRYPT_XML_FLAGS) (r HRESULT) = cryptxml.CryptXmlVerifySignature
+//sys	CryptXmlGetDocContext(hCryptXml unsafe.Pointer, ppStruct **CRYPT_XML_DOC_CTXT) (r HRESULT) = cryptxml.CryptXmlGetDocContext
+//sys	CryptXmlGetSignature(hCryptXml unsafe.Pointer, ppStruct **CRYPT_XML_SIGNATURE) (r HRESULT) = cryptxml.CryptXmlGetSignature
+//sys	CryptXmlGetReference(hCryptXml unsafe.Pointer, ppStruct **CRYPT_XML_REFERENCE) (r HRESULT) = cryptxml.CryptXmlGetReference
+//sys	CryptXmlGetStatus(hCryptXml unsafe.Pointer, pStatus *CRYPT_XML_STATUS) (r HRESULT) = cryptxml.CryptXmlGetStatus
+//sys	CryptXmlEncode(hCryptXml unsafe.Pointer, dwCharset CRYPT_XML_CHARSET, rgProperty *CRYPT_XML_PROPERTY, cProperty uint32, pvCallbackState unsafe.Pointer, pfnWrite PFN_CRYPT_XML_WRITE_CALLBACK) (r HRESULT) = cryptxml.CryptXmlEncode
+//sys	CryptXmlGetAlgorithmInfo(pXmlAlgorithm *CRYPT_XML_ALGORITHM, dwFlags CRYPT_XML_FLAGS, ppAlgInfo **CRYPT_XML_ALGORITHM_INFO) (r HRESULT) = cryptxml.CryptXmlGetAlgorithmInfo
+//sys	CryptXmlFindAlgorithmInfo(dwFindByType uint32, pvFindBy unsafe.Pointer, dwGroupId uint32, dwFlags uint32) (r *CRYPT_XML_ALGORITHM_INFO) = cryptxml.CryptXmlFindAlgorithmInfo
+//sys	CryptXmlEnumAlgorithmInfo(dwGroupId uint32, dwFlags uint32, pvArg unsafe.Pointer, pfnEnumAlgInfo PFN_CRYPT_XML_ENUM_ALG_INFO) (r HRESULT) = cryptxml.CryptXmlEnumAlgorithmInfo
+//sys	GetToken(cPolicyChain uint32, pPolicyChain *POLICY_ELEMENT, securityToken **GENERIC_XML_TOKEN, phProofTokenCrypto **INFORMATIONCARD_CRYPTO_HANDLE) (r HRESULT) = infocardapi.GetToken
+//sys	ManageCardSpace() (r HRESULT) = infocardapi.ManageCardSpace
+//sys	ImportInformationCard(fileName *PWSTRElement) (r HRESULT) = infocardapi.ImportInformationCard
+//sys	Encrypt(hCrypto *INFORMATIONCARD_CRYPTO_HANDLE, fOAEP BOOL, cbInData uint32, pInData *uint8, pcbOutData *uint32, ppOutData **uint8) (r HRESULT) = infocardapi.Encrypt
+//sys	Decrypt(hCrypto *INFORMATIONCARD_CRYPTO_HANDLE, fOAEP BOOL, cbInData uint32, pInData *uint8, pcbOutData *uint32, ppOutData **uint8) (r HRESULT) = infocardapi.Decrypt
+//sys	SignHash(hCrypto *INFORMATIONCARD_CRYPTO_HANDLE, cbHash uint32, pHash *uint8, hashAlgOid *PWSTRElement, pcbSig *uint32, ppSig **uint8) (r HRESULT) = infocardapi.SignHash
+//sys	VerifyHash(hCrypto *INFORMATIONCARD_CRYPTO_HANDLE, cbHash uint32, pHash *uint8, hashAlgOid *PWSTRElement, cbSig uint32, pSig *uint8, pfVerified *BOOL) (r HRESULT) = infocardapi.VerifyHash
+//sys	GetCryptoTransform(hSymmetricCrypto *INFORMATIONCARD_CRYPTO_HANDLE, mode uint32, padding PaddingMode, feedbackSize uint32, direction Direction, cbIV uint32, pIV *uint8, pphTransform **INFORMATIONCARD_CRYPTO_HANDLE) (r HRESULT) = infocardapi.GetCryptoTransform
+//sys	GetKeyedHash(hSymmetricCrypto *INFORMATIONCARD_CRYPTO_HANDLE, pphHash **INFORMATIONCARD_CRYPTO_HANDLE) (r HRESULT) = infocardapi.GetKeyedHash
+//sys	TransformBlock(hCrypto *INFORMATIONCARD_CRYPTO_HANDLE, cbInData uint32, pInData *uint8, pcbOutData *uint32, ppOutData **uint8) (r HRESULT) = infocardapi.TransformBlock
+//sys	TransformFinalBlock(hCrypto *INFORMATIONCARD_CRYPTO_HANDLE, cbInData uint32, pInData *uint8, pcbOutData *uint32, ppOutData **uint8) (r HRESULT) = infocardapi.TransformFinalBlock
+//sys	HashCore(hCrypto *INFORMATIONCARD_CRYPTO_HANDLE, cbInData uint32, pInData *uint8) (r HRESULT) = infocardapi.HashCore
+//sys	HashFinal(hCrypto *INFORMATIONCARD_CRYPTO_HANDLE, cbInData uint32, pInData *uint8, pcbOutData *uint32, ppOutData **uint8) (r HRESULT) = infocardapi.HashFinal
+//sys	FreeToken(pAllocMemory *GENERIC_XML_TOKEN) (r BOOL) = infocardapi.FreeToken
+//sys	CloseCryptoHandle(hCrypto *INFORMATIONCARD_CRYPTO_HANDLE) (r HRESULT) = infocardapi.CloseCryptoHandle
+//sys	GenerateDerivedKey(hCrypto *INFORMATIONCARD_CRYPTO_HANDLE, cbLabel uint32, pLabel *uint8, cbNonce uint32, pNonce *uint8, derivedKeyLength uint32, offset uint32, algId *PWSTRElement, pcbKey *uint32, ppKey **uint8) (r HRESULT) = infocardapi.GenerateDerivedKey
+//sys	GetBrowserToken(dwParamType uint32, pParam unsafe.Pointer, pcbToken *uint32, ppToken **uint8) (r HRESULT) = infocardapi.GetBrowserToken
+//sys	GetCipherInterface(pszProviderName *PWSTRElement, pszAlgId *PWSTRElement, ppFunctionTable **BCRYPT_CIPHER_FUNCTION_TABLE, dwFlags uint32) (r NTSTATUS) = bcryptprimitives.GetCipherInterface
+//sys	GetHashInterface(pszProviderName *PWSTRElement, pszAlgId *PWSTRElement, ppFunctionTable **BCRYPT_HASH_FUNCTION_TABLE, dwFlags uint32) (r NTSTATUS) = bcryptprimitives.GetHashInterface
+//sys	GetAsymmetricEncryptionInterface(pszProviderName *PWSTRElement, pszAlgId *PWSTRElement, ppFunctionTable **BCRYPT_ASYMMETRIC_ENCRYPTION_FUNCTION_TABLE, dwFlags uint32) (r NTSTATUS) = bcryptprimitives.GetAsymmetricEncryptionInterface
+//sys	GetSecretAgreementInterface(pszProviderName *PWSTRElement, pszAlgId *PWSTRElement, ppFunctionTable **BCRYPT_SECRET_AGREEMENT_FUNCTION_TABLE, dwFlags uint32) (r NTSTATUS) = bcryptprimitives.GetSecretAgreementInterface
+//sys	GetSignatureInterface(pszProviderName *PWSTRElement, pszAlgId *PWSTRElement, ppFunctionTable **BCRYPT_SIGNATURE_FUNCTION_TABLE, dwFlags uint32) (r NTSTATUS) = bcryptprimitives.GetSignatureInterface
+//sys	GetRngInterface(pszProviderName *PWSTRElement, ppFunctionTable **BCRYPT_RNG_FUNCTION_TABLE, dwFlags uint32) (r NTSTATUS) = bcryptprimitives.GetRngInterface
+//sys	GetKeyDerivationInterface(pszProviderName *PWSTRElement, pszAlgId *PWSTRElement, ppFunctionTable **BCRYPT_KEY_DERIVATION_FUNCTION_TABLE, dwFlags uint32) (r NTSTATUS) = bcryptprimitives.GetKeyDerivationInterface
+//sys	BCryptRegisterProvider(pszProvider *PWSTRElement, dwFlags uint32, pReg *CRYPT_PROVIDER_REG) (r NTSTATUS) = bcrypt.BCryptRegisterProvider
+//sys	BCryptUnregisterProvider(pszProvider *PWSTRElement) (r NTSTATUS) = bcrypt.BCryptUnregisterProvider
+//sys	BCryptAddContextFunctionProvider(dwTable uint32, pszContext *PWSTRElement, dwInterface uint32, pszFunction *PWSTRElement, pszProvider *PWSTRElement, dwPosition uint32) (r NTSTATUS) = bcrypt.BCryptAddContextFunctionProvider
+//sys	BCryptRemoveContextFunctionProvider(dwTable uint32, pszContext *PWSTRElement, dwInterface uint32, pszFunction *PWSTRElement, pszProvider *PWSTRElement) (r NTSTATUS) = bcrypt.BCryptRemoveContextFunctionProvider
+//sys	GetKeyStorageInterface(pszProviderName *PWSTRElement, ppFunctionTable **NCRYPT_KEY_STORAGE_FUNCTION_TABLE, dwFlags uint32) (r NTSTATUS) = ncrypt.GetKeyStorageInterface
+//sys	SslChangeNotify(hEvent HANDLE, dwFlags uint32) (r HRESULT) = ncrypt.SslChangeNotify
+//sys	SslComputeClientAuthHash(hSslProvider NCRYPT_PROV_HANDLE, hMasterKey NCRYPT_KEY_HANDLE, hHandshakeHash NCRYPT_HASH_HANDLE, pszAlgId *PWSTRElement, pbOutput *uint8, cbOutput uint32, pcbResult *uint32, dwFlags uint32) (r HRESULT) = ncrypt.SslComputeClientAuthHash
+//sys	SslComputeEapKeyBlock(hSslProvider NCRYPT_PROV_HANDLE, hMasterKey NCRYPT_KEY_HANDLE, pbRandoms *uint8, cbRandoms uint32, pbOutput *uint8, cbOutput uint32, pcbResult *uint32, dwFlags uint32) (r HRESULT) = ncrypt.SslComputeEapKeyBlock
+//sys	SslComputeFinishedHash(hSslProvider NCRYPT_PROV_HANDLE, hMasterKey NCRYPT_KEY_HANDLE, hHandshakeHash NCRYPT_HASH_HANDLE, pbOutput *uint8, cbOutput uint32, dwFlags uint32) (r HRESULT) = ncrypt.SslComputeFinishedHash
+//sys	SslCreateEphemeralKey(hSslProvider NCRYPT_PROV_HANDLE, phEphemeralKey *NCRYPT_KEY_HANDLE, dwProtocol uint32, dwCipherSuite uint32, dwKeyType uint32, dwKeyBitLen uint32, pbParams *uint8, cbParams uint32, dwFlags uint32) (r HRESULT) = ncrypt.SslCreateEphemeralKey
+//sys	SslCreateHandshakeHash(hSslProvider NCRYPT_PROV_HANDLE, phHandshakeHash *NCRYPT_HASH_HANDLE, dwProtocol uint32, dwCipherSuite uint32, dwFlags uint32) (r HRESULT) = ncrypt.SslCreateHandshakeHash
+//sys	SslDecryptPacket(hSslProvider NCRYPT_PROV_HANDLE, hKey NCRYPT_KEY_HANDLE, pbInput *uint8, cbInput uint32, pbOutput *uint8, cbOutput uint32, pcbResult *uint32, SequenceNumber uint64, dwFlags uint32) (r HRESULT) = ncrypt.SslDecryptPacket
+//sys	SslEncryptPacket(hSslProvider NCRYPT_PROV_HANDLE, hKey NCRYPT_KEY_HANDLE, pbInput *uint8, cbInput uint32, pbOutput *uint8, cbOutput uint32, pcbResult *uint32, SequenceNumber uint64, dwContentType uint32, dwFlags uint32) (r HRESULT) = ncrypt.SslEncryptPacket
+//sys	SslEnumCipherSuites(hSslProvider NCRYPT_PROV_HANDLE, hPrivateKey NCRYPT_KEY_HANDLE, ppCipherSuite **NCRYPT_SSL_CIPHER_SUITE, ppEnumState *unsafe.Pointer, dwFlags uint32) (r HRESULT) = ncrypt.SslEnumCipherSuites
+//sys	SslEnumCipherSuitesEx(hSslProvider NCRYPT_PROV_HANDLE, hPrivateKey NCRYPT_KEY_HANDLE, ppCipherSuite **NCRYPT_SSL_CIPHER_SUITE_EX, ppEnumState *unsafe.Pointer, dwFlags uint32) (r HRESULT) = ncrypt.SslEnumCipherSuitesEx
+//sys	SslEnumEccCurves(hSslProvider NCRYPT_PROV_HANDLE, pEccCurveCount *uint32, ppEccCurve **NCRYPT_SSL_ECC_CURVE, dwFlags uint32) (r HRESULT) = ncrypt.SslEnumEccCurves
+//sys	SslEnumProtocolProviders(pdwProviderCount *uint32, ppProviderList **NCryptProviderName, dwFlags uint32) (r HRESULT) = ncrypt.SslEnumProtocolProviders
+//sys	SslExportKey(hSslProvider NCRYPT_PROV_HANDLE, hKey NCRYPT_KEY_HANDLE, pszBlobType *PWSTRElement, pbOutput *uint8, cbOutput uint32, pcbResult *uint32, dwFlags uint32) (r HRESULT) = ncrypt.SslExportKey
+//sys	SslFreeBuffer(pvInput unsafe.Pointer) (r HRESULT) = ncrypt.SslFreeBuffer
+//sys	SslFreeObject(hObject NCRYPT_HANDLE, dwFlags uint32) (r HRESULT) = ncrypt.SslFreeObject
+//sys	SslGenerateMasterKey(hSslProvider NCRYPT_PROV_HANDLE, hPrivateKey NCRYPT_KEY_HANDLE, hPublicKey NCRYPT_KEY_HANDLE, phMasterKey *NCRYPT_KEY_HANDLE, dwProtocol uint32, dwCipherSuite uint32, pParameterList *BCryptBufferDesc, pbOutput *uint8, cbOutput uint32, pcbResult *uint32, dwFlags uint32) (r HRESULT) = ncrypt.SslGenerateMasterKey
+//sys	SslGenerateSessionKeys(hSslProvider NCRYPT_PROV_HANDLE, hMasterKey NCRYPT_KEY_HANDLE, phReadKey *NCRYPT_KEY_HANDLE, phWriteKey *NCRYPT_KEY_HANDLE, pParameterList *BCryptBufferDesc, dwFlags uint32) (r HRESULT) = ncrypt.SslGenerateSessionKeys
+//sys	SslGetKeyProperty(hKey NCRYPT_KEY_HANDLE, pszProperty *PWSTRElement, ppbOutput **uint8, pcbOutput *uint32, dwFlags uint32) (r HRESULT) = ncrypt.SslGetKeyProperty
+//sys	SslGetProviderProperty(hSslProvider NCRYPT_PROV_HANDLE, pszProperty *PWSTRElement, ppbOutput **uint8, pcbOutput *uint32, ppEnumState *unsafe.Pointer, dwFlags uint32) (r HRESULT) = ncrypt.SslGetProviderProperty
+//sys	SslHashHandshake(hSslProvider NCRYPT_PROV_HANDLE, hHandshakeHash NCRYPT_HASH_HANDLE, pbInput *uint8, cbInput uint32, dwFlags uint32) (r HRESULT) = ncrypt.SslHashHandshake
+//sys	SslImportKey(hSslProvider NCRYPT_PROV_HANDLE, phKey *NCRYPT_KEY_HANDLE, pszBlobType *PWSTRElement, pbKeyBlob *uint8, cbKeyBlob uint32, dwFlags uint32) (r HRESULT) = ncrypt.SslImportKey
+//sys	SslImportMasterKey(hSslProvider NCRYPT_PROV_HANDLE, hPrivateKey NCRYPT_KEY_HANDLE, phMasterKey *NCRYPT_KEY_HANDLE, dwProtocol uint32, dwCipherSuite uint32, pParameterList *BCryptBufferDesc, pbEncryptedKey *uint8, cbEncryptedKey uint32, dwFlags uint32) (r HRESULT) = ncrypt.SslImportMasterKey
+//sys	SslLookupCipherSuiteInfo(hSslProvider NCRYPT_PROV_HANDLE, dwProtocol uint32, dwCipherSuite uint32, dwKeyType uint32, pCipherSuite *NCRYPT_SSL_CIPHER_SUITE, dwFlags uint32) (r HRESULT) = ncrypt.SslLookupCipherSuiteInfo
+//sys	SslOpenPrivateKey(hSslProvider NCRYPT_PROV_HANDLE, phPrivateKey *NCRYPT_KEY_HANDLE, pCertContext *CERT_CONTEXT, dwFlags uint32) (r HRESULT) = ncrypt.SslOpenPrivateKey
+//sys	SslOpenProvider(phSslProvider *NCRYPT_PROV_HANDLE, pszProviderName *PWSTRElement, dwFlags uint32) (r HRESULT) = ncrypt.SslOpenProvider
+//sys	SslSignHash(hSslProvider NCRYPT_PROV_HANDLE, hPrivateKey NCRYPT_KEY_HANDLE, pbHashValue *uint8, cbHashValue uint32, pbSignature *uint8, cbSignature uint32, pcbResult *uint32, dwFlags uint32) (r HRESULT) = ncrypt.SslSignHash
+//sys	SslVerifySignature(hSslProvider NCRYPT_PROV_HANDLE, hPublicKey NCRYPT_KEY_HANDLE, pbHashValue *uint8, cbHashValue uint32, pbSignature *uint8, cbSignature uint32, dwFlags uint32) (r HRESULT) = ncrypt.SslVerifySignature
+//sys	SslLookupCipherLengths(hSslProvider NCRYPT_PROV_HANDLE, dwProtocol uint32, dwCipherSuite uint32, dwKeyType uint32, pCipherLengths *NCRYPT_SSL_CIPHER_LENGTHS, cbCipherLengths uint32, dwFlags uint32) (r HRESULT) = ncrypt.SslLookupCipherLengths
+//sys	SslCreateClientAuthHash(hSslProvider NCRYPT_PROV_HANDLE, phHandshakeHash *NCRYPT_HASH_HANDLE, dwProtocol uint32, dwCipherSuite uint32, pszHashAlgId *PWSTRElement, dwFlags uint32) (r HRESULT) = ncrypt.SslCreateClientAuthHash
+//sys	SslGetCipherSuitePRFHashAlgorithm(hSslProvider NCRYPT_PROV_HANDLE, dwProtocol uint32, dwCipherSuite uint32, dwKeyType uint32, szPRFHash *PWSTRElement, dwFlags uint32) (r HRESULT) = ncrypt.SslGetCipherSuitePRFHashAlgorithm
+//sys	SslComputeSessionHash(hSslProvider NCRYPT_PROV_HANDLE, hHandshakeHash NCRYPT_HASH_HANDLE, dwProtocol uint32, pbOutput *uint8, cbOutput uint32, pcbResult *uint32, dwFlags uint32) (r HRESULT) = ncrypt.SslComputeSessionHash
+//sys	SslGeneratePreMasterKey(hSslProvider NCRYPT_PROV_HANDLE, hPublicKey NCRYPT_KEY_HANDLE, phPreMasterKey *NCRYPT_KEY_HANDLE, dwProtocol uint32, dwCipherSuite uint32, pParameterList *BCryptBufferDesc, pbOutput *uint8, cbOutput uint32, pcbResult *uint32, dwFlags uint32) (r HRESULT) = ncrypt.SslGeneratePreMasterKey
+//sys	SslExportKeyingMaterial(hSslProvider NCRYPT_PROV_HANDLE, hMasterKey NCRYPT_KEY_HANDLE, sLabel *PSTRElement, pbRandoms *uint8, cbRandoms uint32, pbContextValue *uint8, cbContextValue uint16, pbOutput *uint8, cbOutput uint32, dwFlags uint32) (r HRESULT) = ncrypt.SslExportKeyingMaterial
+//sys	SslExtractEarlyKey(hSslProvider NCRYPT_PROV_HANDLE, hPreSharedKey NCRYPT_KEY_HANDLE, phEarlyKey *NCRYPT_KEY_HANDLE, dwProtocol uint32, dwCipherSuite uint32, pParameterList *BCryptBufferDesc, dwFlags uint32) (r HRESULT) = ncrypt.SslExtractEarlyKey
+//sys	SslExtractHandshakeKey(hSslProvider NCRYPT_PROV_HANDLE, hPrivateKey NCRYPT_KEY_HANDLE, hPublicKey NCRYPT_KEY_HANDLE, hEarlyKey NCRYPT_KEY_HANDLE, phHandshakeKey *NCRYPT_KEY_HANDLE, pParameterList *BCryptBufferDesc, dwFlags uint32) (r HRESULT) = ncrypt.SslExtractHandshakeKey
+//sys	SslExtractMasterKey(hSslProvider NCRYPT_PROV_HANDLE, hHandshakeKey NCRYPT_KEY_HANDLE, phMasterKey *NCRYPT_KEY_HANDLE, pParameterList *BCryptBufferDesc, dwFlags uint32) (r HRESULT) = ncrypt.SslExtractMasterKey
+//sys	SslExpandTrafficKeys(hSslProvider NCRYPT_PROV_HANDLE, hBaseKey NCRYPT_KEY_HANDLE, hHashValue NCRYPT_HASH_HANDLE, phClientTrafficKey *NCRYPT_KEY_HANDLE, phServerTrafficKey *NCRYPT_KEY_HANDLE, pParameterList *BCryptBufferDesc, dwFlags uint32) (r HRESULT) = ncrypt.SslExpandTrafficKeys
+//sys	SslExpandWriteKey(hSslProvider NCRYPT_PROV_HANDLE, hBaseTrafficKey NCRYPT_KEY_HANDLE, phWriteKey *NCRYPT_KEY_HANDLE, pParameterList *BCryptBufferDesc, dwFlags uint32) (r HRESULT) = ncrypt.SslExpandWriteKey
+//sys	SslExpandExporterMasterKey(hSslProvider NCRYPT_PROV_HANDLE, hBaseKey NCRYPT_KEY_HANDLE, hHashValue NCRYPT_HASH_HANDLE, phExporterMasterKey *NCRYPT_KEY_HANDLE, pParameterList *BCryptBufferDesc, dwFlags uint32) (r HRESULT) = ncrypt.SslExpandExporterMasterKey
+//sys	SslExpandResumptionMasterKey(hSslProvider NCRYPT_PROV_HANDLE, hMasterKey NCRYPT_KEY_HANDLE, hHashValue NCRYPT_HASH_HANDLE, phResumptionMasterKey *NCRYPT_KEY_HANDLE, pParameterList *BCryptBufferDesc, dwFlags uint32) (r HRESULT) = ncrypt.SslExpandResumptionMasterKey
+//sys	SslDuplicateTranscriptHash(hSslProvider NCRYPT_PROV_HANDLE, hTranscriptHash NCRYPT_HASH_HANDLE, phTranscriptHash *NCRYPT_HASH_HANDLE, dwFlags uint32) (r HRESULT) = ncrypt.SslDuplicateTranscriptHash
+//sys	SslExpandBinderKey(hSslProvider NCRYPT_PROV_HANDLE, hEarlyKey NCRYPT_KEY_HANDLE, phBinderKey *NCRYPT_KEY_HANDLE, pParameterList *BCryptBufferDesc, dwFlags uint32) (r HRESULT) = ncrypt.SslExpandBinderKey
+//sys	SslExpandPreSharedKey(hSslProvider NCRYPT_PROV_HANDLE, hResumptionMasterKey NCRYPT_KEY_HANDLE, pbTicketNonce *uint8, cbTicketNonce uint32, phPreSharedKey *NCRYPT_KEY_HANDLE, pParameterList *BCryptBufferDesc, dwFlags uint32) (r HRESULT) = ncrypt.SslExpandPreSharedKey
+//sys	GetSChannelInterface(pszProviderName *PWSTRElement, ppFunctionTable **NCRYPT_SSL_FUNCTION_TABLE, dwFlags uint32) (r NTSTATUS) = ncrypt.GetSChannelInterface
+//sys	SslIncrementProviderReferenceCount(hSslProvider NCRYPT_PROV_HANDLE) (r HRESULT) = ncrypt.SslIncrementProviderReferenceCount
+//sys	SslDecrementProviderReferenceCount(hSslProvider NCRYPT_PROV_HANDLE) (r HRESULT) = ncrypt.SslDecrementProviderReferenceCount
 
 // APIs for Windows.Win32.System.Diagnostics.Debug
-//sys	ReadProcessMemory(hProcess HANDLE, lpBaseAddress unsafe.Pointer, lpBuffer unsafe.Pointer, nSize uintptr, lpNumberOfBytesRead *uintptr) (r BOOL, err error) = kernel32.dll.ReadProcessMemory
-//sys	WriteProcessMemory(hProcess HANDLE, lpBaseAddress unsafe.Pointer, lpBuffer unsafe.Pointer, nSize uintptr, lpNumberOfBytesWritten *uintptr) (r BOOL, err error) = kernel32.dll.WriteProcessMemory
-//sys	GetThreadContext(hThread HANDLE, lpContext *CONTEXT) (r BOOL, err error) = kernel32.dll.GetThreadContext
-//sys	SetThreadContext(hThread HANDLE, lpContext *CONTEXT) (r BOOL, err error) = kernel32.dll.SetThreadContext
-//sys	FlushInstructionCache(hProcess HANDLE, lpBaseAddress unsafe.Pointer, dwSize uintptr) (r BOOL, err error) = kernel32.dll.FlushInstructionCache
-//sys	Wow64GetThreadContext(hThread HANDLE, lpContext *WOW64_CONTEXT) (r BOOL, err error) = kernel32.dll.Wow64GetThreadContext
-//sys	Wow64SetThreadContext(hThread HANDLE, lpContext *WOW64_CONTEXT) (r BOOL, err error) = kernel32.dll.Wow64SetThreadContext
-//sys	RtlCaptureStackBackTrace(FramesToSkip uint32, FramesToCapture uint32, BackTrace *unsafe.Pointer, BackTraceHash *uint32) (r uint16) = kernel32.dll.RtlCaptureStackBackTrace
-//sys	RtlCaptureContext(ContextRecord *CONTEXT) = kernel32.dll.RtlCaptureContext
-//sys	RtlUnwind(TargetFrame unsafe.Pointer, TargetIp unsafe.Pointer, ExceptionRecord *EXCEPTION_RECORD, ReturnValue unsafe.Pointer) = kernel32.dll.RtlUnwind
-//sys	RtlRestoreContext(ContextRecord *CONTEXT, ExceptionRecord *EXCEPTION_RECORD) = kernel32.dll.RtlRestoreContext
-//sys	RtlRaiseException(ExceptionRecord *EXCEPTION_RECORD) = kernel32.dll.RtlRaiseException
-//sys	RtlPcToFileHeader(PcValue unsafe.Pointer, BaseOfImage *unsafe.Pointer) (r unsafe.Pointer) = kernel32.dll.RtlPcToFileHeader
-//sys	IsDebuggerPresent() (r BOOL) = kernel32.dll.IsDebuggerPresent
-//sys	DebugBreak() = kernel32.dll.DebugBreak
-//sys	OutputDebugStringA(lpOutputString *PSTRElement) = kernel32.dll.OutputDebugStringA
-//sys	OutputDebugStringW(lpOutputString *PWSTRElement) = kernel32.dll.OutputDebugStringW
-//sys	ContinueDebugEvent(dwProcessId uint32, dwThreadId uint32, dwContinueStatus NTSTATUS) (r BOOL, err error) = kernel32.dll.ContinueDebugEvent
-//sys	WaitForDebugEvent(lpDebugEvent *DEBUG_EVENT, dwMilliseconds uint32) (r BOOL, err error) = kernel32.dll.WaitForDebugEvent
-//sys	DebugActiveProcess(dwProcessId uint32) (r BOOL, err error) = kernel32.dll.DebugActiveProcess
-//sys	DebugActiveProcessStop(dwProcessId uint32) (r BOOL, err error) = kernel32.dll.DebugActiveProcessStop
-//sys	CheckRemoteDebuggerPresent(hProcess HANDLE, pbDebuggerPresent *BOOL) (r BOOL, err error) = kernel32.dll.CheckRemoteDebuggerPresent
-//sys	WaitForDebugEventEx(lpDebugEvent *DEBUG_EVENT, dwMilliseconds uint32) (r BOOL, err error) = kernel32.dll.WaitForDebugEventEx
-//sys	EncodePointer(Ptr unsafe.Pointer) (r unsafe.Pointer) = kernel32.dll.EncodePointer
-//sys	DecodePointer(Ptr unsafe.Pointer) (r unsafe.Pointer) = kernel32.dll.DecodePointer
-//sys	EncodeSystemPointer(Ptr unsafe.Pointer) (r unsafe.Pointer) = kernel32.dll.EncodeSystemPointer
-//sys	DecodeSystemPointer(Ptr unsafe.Pointer) (r unsafe.Pointer) = kernel32.dll.DecodeSystemPointer
-//sys	EncodeRemotePointer(ProcessHandle HANDLE, Ptr unsafe.Pointer, EncodedPtr *unsafe.Pointer) (r HRESULT) = api-ms-win-core-util-l1-1-1.dll.EncodeRemotePointer
-//sys	DecodeRemotePointer(ProcessHandle HANDLE, Ptr unsafe.Pointer, DecodedPtr *unsafe.Pointer) (r HRESULT) = api-ms-win-core-util-l1-1-1.dll.DecodeRemotePointer
-//sys	Beep(dwFreq uint32, dwDuration uint32) (r BOOL, err error) = kernel32.dll.Beep
-//sys	RaiseException(dwExceptionCode uint32, dwExceptionFlags uint32, nNumberOfArguments uint32, lpArguments *uintptr) = kernel32.dll.RaiseException
-//sys	UnhandledExceptionFilter(ExceptionInfo *EXCEPTION_POINTERS) (r int32) = kernel32.dll.UnhandledExceptionFilter
-//sys	SetUnhandledExceptionFilter(lpTopLevelExceptionFilter LPTOP_LEVEL_EXCEPTION_FILTER) (r LPTOP_LEVEL_EXCEPTION_FILTER) = kernel32.dll.SetUnhandledExceptionFilter
-//sys	GetErrorMode() (r uint32) = kernel32.dll.GetErrorMode
-//sys	SetErrorMode(uMode THREAD_ERROR_MODE) (r THREAD_ERROR_MODE) = kernel32.dll.SetErrorMode
-//sys	AddVectoredExceptionHandler(First uint32, Handler PVECTORED_EXCEPTION_HANDLER) (r unsafe.Pointer) = kernel32.dll.AddVectoredExceptionHandler
-//sys	RemoveVectoredExceptionHandler(Handle unsafe.Pointer) (r uint32) = kernel32.dll.RemoveVectoredExceptionHandler
-//sys	AddVectoredContinueHandler(First uint32, Handler PVECTORED_EXCEPTION_HANDLER) (r unsafe.Pointer) = kernel32.dll.AddVectoredContinueHandler
-//sys	RemoveVectoredContinueHandler(Handle unsafe.Pointer) (r uint32) = kernel32.dll.RemoveVectoredContinueHandler
-//sys	RaiseFailFastException(pExceptionRecord *EXCEPTION_RECORD, pContextRecord *CONTEXT, dwFlags uint32) = kernel32.dll.RaiseFailFastException
-//sys	FatalAppExitA(uAction uint32, lpMessageText *PSTRElement) = kernel32.dll.FatalAppExitA
-//sys	FatalAppExitW(uAction uint32, lpMessageText *PWSTRElement) = kernel32.dll.FatalAppExitW
-//sys	GetThreadErrorMode() (r uint32) = kernel32.dll.GetThreadErrorMode
-//sys	SetThreadErrorMode(dwNewMode THREAD_ERROR_MODE, lpOldMode *THREAD_ERROR_MODE) (r BOOL, err error) = kernel32.dll.SetThreadErrorMode
-//sys	TerminateProcessOnMemoryExhaustion(FailedAllocationSize uintptr) = api-ms-win-core-errorhandling-l1-1-3.dll.TerminateProcessOnMemoryExhaustion
-//sys	OpenThreadWaitChainSession(Flags OPEN_THREAD_WAIT_CHAIN_SESSION_FLAGS, callback PWAITCHAINCALLBACK) (r unsafe.Pointer, err error) = advapi32.dll.OpenThreadWaitChainSession
-//sys	CloseThreadWaitChainSession(WctHandle unsafe.Pointer) = advapi32.dll.CloseThreadWaitChainSession
-//sys	GetThreadWaitChain(WctHandle unsafe.Pointer, Context uintptr, Flags WAIT_CHAIN_THREAD_OPTIONS, ThreadId uint32, NodeCount *uint32, NodeInfoArray *WAITCHAIN_NODE_INFO, IsCycle *BOOL) (r BOOL, err error) = advapi32.dll.GetThreadWaitChain
-//sys	RegisterWaitChainCOMCallback(CallStateCallback PCOGETCALLSTATE, ActivationStateCallback PCOGETACTIVATIONSTATE) = advapi32.dll.RegisterWaitChainCOMCallback
-//sys	MiniDumpWriteDump(hProcess HANDLE, ProcessId uint32, hFile HANDLE, DumpType MINIDUMP_TYPE, ExceptionParam *MINIDUMP_EXCEPTION_INFORMATION, UserStreamParam *MINIDUMP_USER_STREAM_INFORMATION, CallbackParam *MINIDUMP_CALLBACK_INFORMATION) (r BOOL, err error) = dbghelp.dll.MiniDumpWriteDump
-//sys	MiniDumpReadDumpStream(BaseOfDump unsafe.Pointer, StreamNumber uint32, Dir **MINIDUMP_DIRECTORY, StreamPointer *unsafe.Pointer, StreamSize *uint32) (r BOOL) = dbghelp.dll.MiniDumpReadDumpStream
-//sys	BindImage(ImageName *PSTRElement, DllPath *PSTRElement, SymbolPath *PSTRElement) (r BOOL, err error) = imagehlp.dll.BindImage
-//sys	BindImageEx(Flags uint32, ImageName *PSTRElement, DllPath *PSTRElement, SymbolPath *PSTRElement, StatusRoutine PIMAGEHLP_STATUS_ROUTINE) (r BOOL, err error) = imagehlp.dll.BindImageEx
-//sys	ReBaseImage(CurrentImageName *PSTRElement, SymbolPath *PSTRElement, fReBase BOOL, fRebaseSysfileOk BOOL, fGoingDown BOOL, CheckImageSize uint32, OldImageSize *uint32, OldImageBase *uintptr, NewImageSize *uint32, NewImageBase *uintptr, TimeStamp uint32) (r BOOL, err error) = imagehlp.dll.ReBaseImage
-//sys	ReBaseImage64(CurrentImageName *PSTRElement, SymbolPath *PSTRElement, fReBase BOOL, fRebaseSysfileOk BOOL, fGoingDown BOOL, CheckImageSize uint32, OldImageSize *uint32, OldImageBase *uint64, NewImageSize *uint32, NewImageBase *uint64, TimeStamp uint32) (r BOOL, err error) = imagehlp.dll.ReBaseImage64
-//sys	MapFileAndCheckSumA(Filename *PSTRElement, HeaderSum *uint32, CheckSum *uint32) (r uint32) = imagehlp.dll.MapFileAndCheckSumA
-//sys	MapFileAndCheckSumW(Filename *PWSTRElement, HeaderSum *uint32, CheckSum *uint32) (r uint32) = imagehlp.dll.MapFileAndCheckSumW
-//sys	GetImageUnusedHeaderBytes(LoadedImage *LOADED_IMAGE, SizeUnusedHeaderBytes *uint32) (r uint32, err error) = imagehlp.dll.GetImageUnusedHeaderBytes
-//sys	ImageGetDigestStream(FileHandle HANDLE, DigestLevel uint32, DigestFunction DIGEST_FUNCTION, DigestHandle unsafe.Pointer) (r BOOL, err error) = imagehlp.dll.ImageGetDigestStream
-//sys	ImageAddCertificate(FileHandle HANDLE, Certificate *WIN_CERTIFICATE, Index *uint32) (r BOOL, err error) = imagehlp.dll.ImageAddCertificate
-//sys	ImageRemoveCertificate(FileHandle HANDLE, Index uint32) (r BOOL, err error) = imagehlp.dll.ImageRemoveCertificate
-//sys	ImageEnumerateCertificates(FileHandle HANDLE, TypeFilter uint16, CertificateCount *uint32, Indices *uint32, IndexCount uint32) (r BOOL, err error) = imagehlp.dll.ImageEnumerateCertificates
-//sys	ImageGetCertificateData(FileHandle HANDLE, CertificateIndex uint32, Certificate *WIN_CERTIFICATE, RequiredLength *uint32) (r BOOL, err error) = imagehlp.dll.ImageGetCertificateData
-//sys	ImageGetCertificateHeader(FileHandle HANDLE, CertificateIndex uint32, Certificateheader *WIN_CERTIFICATE) (r BOOL, err error) = imagehlp.dll.ImageGetCertificateHeader
-//sys	ImageLoad(DllName *PSTRElement, DllPath *PSTRElement) (r *LOADED_IMAGE, err error) = imagehlp.dll.ImageLoad
-//sys	ImageUnload(LoadedImage *LOADED_IMAGE) (r BOOL, err error) = imagehlp.dll.ImageUnload
-//sys	MapAndLoad(ImageName *PSTRElement, DllPath *PSTRElement, LoadedImage *LOADED_IMAGE, DotDll BOOL, ReadOnly BOOL) (r BOOL, err error) = imagehlp.dll.MapAndLoad
-//sys	UnMapAndLoad(LoadedImage *LOADED_IMAGE) (r BOOL, err error) = imagehlp.dll.UnMapAndLoad
-//sys	TouchFileTimes(FileHandle HANDLE, pSystemTime *SYSTEMTIME) (r BOOL, err error) = imagehlp.dll.TouchFileTimes
-//sys	UpdateDebugInfoFile(ImageFileName *PSTRElement, SymbolPath *PSTRElement, DebugFilePath *PSTRElement, NtHeaders *IMAGE_NT_HEADERS32) (r BOOL, err error) = imagehlp.dll.UpdateDebugInfoFile
-//sys	UpdateDebugInfoFileEx(ImageFileName *PSTRElement, SymbolPath *PSTRElement, DebugFilePath *PSTRElement, NtHeaders *IMAGE_NT_HEADERS32, OldCheckSum uint32) (r BOOL) = imagehlp.dll.UpdateDebugInfoFileEx
-//sys	SymFindDebugInfoFile(hProcess HANDLE, FileName *PSTRElement, DebugFilePath *PSTRElement, Callback PFIND_DEBUG_FILE_CALLBACK, CallerData unsafe.Pointer) (r HANDLE, err error) = dbghelp.dll.SymFindDebugInfoFile
-//sys	SymFindDebugInfoFileW(hProcess HANDLE, FileName *PWSTRElement, DebugFilePath *PWSTRElement, Callback PFIND_DEBUG_FILE_CALLBACKW, CallerData unsafe.Pointer) (r HANDLE, err error) = dbghelp.dll.SymFindDebugInfoFileW
-//sys	FindDebugInfoFile(FileName *PSTRElement, SymbolPath *PSTRElement, DebugFilePath *PSTRElement) (r HANDLE, err error) = dbghelp.dll.FindDebugInfoFile
-//sys	FindDebugInfoFileEx(FileName *PSTRElement, SymbolPath *PSTRElement, DebugFilePath *PSTRElement, Callback PFIND_DEBUG_FILE_CALLBACK, CallerData unsafe.Pointer) (r HANDLE, err error) = dbghelp.dll.FindDebugInfoFileEx
-//sys	FindDebugInfoFileExW(FileName *PWSTRElement, SymbolPath *PWSTRElement, DebugFilePath *PWSTRElement, Callback PFIND_DEBUG_FILE_CALLBACKW, CallerData unsafe.Pointer) (r HANDLE, err error) = dbghelp.dll.FindDebugInfoFileExW
-//sys	SymFindFileInPath(hprocess HANDLE, SearchPathA *PSTRElement, FileName *PSTRElement, id unsafe.Pointer, two uint32, three uint32, flags SYM_FIND_ID_OPTION, FoundFile *PSTRElement, callback PFINDFILEINPATHCALLBACK, context unsafe.Pointer) (r BOOL, err error) = dbghelp.dll.SymFindFileInPath
-//sys	SymFindFileInPathW(hprocess HANDLE, SearchPathA *PWSTRElement, FileName *PWSTRElement, id unsafe.Pointer, two uint32, three uint32, flags SYM_FIND_ID_OPTION, FoundFile *PWSTRElement, callback PFINDFILEINPATHCALLBACKW, context unsafe.Pointer) (r BOOL, err error) = dbghelp.dll.SymFindFileInPathW
-//sys	SymFindExecutableImage(hProcess HANDLE, FileName *PSTRElement, ImageFilePath *PSTRElement, Callback PFIND_EXE_FILE_CALLBACK, CallerData unsafe.Pointer) (r HANDLE, err error) = dbghelp.dll.SymFindExecutableImage
-//sys	SymFindExecutableImageW(hProcess HANDLE, FileName *PWSTRElement, ImageFilePath *PWSTRElement, Callback PFIND_EXE_FILE_CALLBACKW, CallerData unsafe.Pointer) (r HANDLE, err error) = dbghelp.dll.SymFindExecutableImageW
-//sys	FindExecutableImage(FileName *PSTRElement, SymbolPath *PSTRElement, ImageFilePath *PSTRElement) (r HANDLE, err error) = dbghelp.dll.FindExecutableImage
-//sys	FindExecutableImageEx(FileName *PSTRElement, SymbolPath *PSTRElement, ImageFilePath *PSTRElement, Callback PFIND_EXE_FILE_CALLBACK, CallerData unsafe.Pointer) (r HANDLE, err error) = dbghelp.dll.FindExecutableImageEx
-//sys	FindExecutableImageExW(FileName *PWSTRElement, SymbolPath *PWSTRElement, ImageFilePath *PWSTRElement, Callback PFIND_EXE_FILE_CALLBACKW, CallerData unsafe.Pointer) (r HANDLE, err error) = dbghelp.dll.FindExecutableImageExW
-//sys	ImageDirectoryEntryToDataEx(Base unsafe.Pointer, MappedAsImage BOOLEAN, DirectoryEntry IMAGE_DIRECTORY_ENTRY, Size *uint32, FoundHeader **IMAGE_SECTION_HEADER) (r unsafe.Pointer, err error) = dbghelp.dll.ImageDirectoryEntryToDataEx
-//sys	ImageDirectoryEntryToData(Base unsafe.Pointer, MappedAsImage BOOLEAN, DirectoryEntry IMAGE_DIRECTORY_ENTRY, Size *uint32) (r unsafe.Pointer, err error) = dbghelp.dll.ImageDirectoryEntryToData
-//sys	SearchTreeForFile(RootPath *PSTRElement, InputPathName *PSTRElement, OutputPathBuffer *PSTRElement) (r BOOL, err error) = dbghelp.dll.SearchTreeForFile
-//sys	SearchTreeForFileW(RootPath *PWSTRElement, InputPathName *PWSTRElement, OutputPathBuffer *PWSTRElement) (r BOOL, err error) = dbghelp.dll.SearchTreeForFileW
-//sys	EnumDirTree(hProcess HANDLE, RootPath *PSTRElement, InputPathName *PSTRElement, OutputPathBuffer *PSTRElement, cb PENUMDIRTREE_CALLBACK, data unsafe.Pointer) (r BOOL, err error) = dbghelp.dll.EnumDirTree
-//sys	EnumDirTreeW(hProcess HANDLE, RootPath *PWSTRElement, InputPathName *PWSTRElement, OutputPathBuffer *PWSTRElement, cb PENUMDIRTREE_CALLBACKW, data unsafe.Pointer) (r BOOL, err error) = dbghelp.dll.EnumDirTreeW
-//sys	MakeSureDirectoryPathExists(DirPath *PSTRElement) (r BOOL, err error) = dbghelp.dll.MakeSureDirectoryPathExists
-//sys	UnDecorateSymbolName(name *PSTRElement, outputString *PSTRElement, maxStringLength uint32, flags uint32) (r uint32, err error) = dbghelp.dll.UnDecorateSymbolName
-//sys	UnDecorateSymbolNameW(name *PWSTRElement, outputString *PWSTRElement, maxStringLength uint32, flags uint32) (r uint32, err error) = dbghelp.dll.UnDecorateSymbolNameW
-//sys	StackWalk64(MachineType uint32, hProcess HANDLE, hThread HANDLE, StackFrame *STACKFRAME64, ContextRecord unsafe.Pointer, ReadMemoryRoutine PREAD_PROCESS_MEMORY_ROUTINE64, FunctionTableAccessRoutine PFUNCTION_TABLE_ACCESS_ROUTINE64, GetModuleBaseRoutine PGET_MODULE_BASE_ROUTINE64, TranslateAddress PTRANSLATE_ADDRESS_ROUTINE64) (r BOOL) = dbghelp.dll.StackWalk64
-//sys	StackWalkEx(MachineType uint32, hProcess HANDLE, hThread HANDLE, StackFrame *STACKFRAME_EX, ContextRecord unsafe.Pointer, ReadMemoryRoutine PREAD_PROCESS_MEMORY_ROUTINE64, FunctionTableAccessRoutine PFUNCTION_TABLE_ACCESS_ROUTINE64, GetModuleBaseRoutine PGET_MODULE_BASE_ROUTINE64, TranslateAddress PTRANSLATE_ADDRESS_ROUTINE64, Flags uint32) (r BOOL) = dbghelp.dll.StackWalkEx
-//sys	StackWalk2(MachineType uint32, hProcess HANDLE, hThread HANDLE, StackFrame *STACKFRAME_EX, ContextRecord unsafe.Pointer, ReadMemoryRoutine PREAD_PROCESS_MEMORY_ROUTINE64, FunctionTableAccessRoutine PFUNCTION_TABLE_ACCESS_ROUTINE64, GetModuleBaseRoutine PGET_MODULE_BASE_ROUTINE64, TranslateAddress PTRANSLATE_ADDRESS_ROUTINE64, GetTargetAttributeValue PGET_TARGET_ATTRIBUTE_VALUE64, Flags uint32) (r BOOL) = dbghelp.dll.StackWalk2
-//sys	ImagehlpApiVersion() (r *API_VERSION) = dbghelp.dll.ImagehlpApiVersion
-//sys	ImagehlpApiVersionEx(AppVersion *API_VERSION) (r *API_VERSION) = dbghelp.dll.ImagehlpApiVersionEx
-//sys	GetTimestampForLoadedLibrary(Module HMODULE) (r uint32, err error) = dbghelp.dll.GetTimestampForLoadedLibrary
-//sys	SymSetParentWindow(hwnd HWND) (r BOOL, err error) = dbghelp.dll.SymSetParentWindow
-//sys	SymGetParentWindow(pHwnd *HWND) (r BOOL) = dbghelp.dll.SymGetParentWindow
-//sys	SymSetHomeDirectory(hProcess HANDLE, dir *PSTRElement) (r *PSTRElement, err error) = dbghelp.dll.SymSetHomeDirectory
-//sys	SymSetHomeDirectoryW(hProcess HANDLE, dir *PWSTRElement) (r *PWSTRElement, err error) = dbghelp.dll.SymSetHomeDirectoryW
-//sys	SymGetHomeDirectory(typeParam uint32, dir *PSTRElement, size uintptr) (r *PSTRElement, err error) = dbghelp.dll.SymGetHomeDirectory
-//sys	SymGetHomeDirectoryW(typeParam uint32, dir *PWSTRElement, size uintptr) (r *PWSTRElement, err error) = dbghelp.dll.SymGetHomeDirectoryW
-//sys	SymGetOmaps(hProcess HANDLE, BaseOfDll uint64, OmapTo **OMAP, cOmapTo *uint64, OmapFrom **OMAP, cOmapFrom *uint64) (r BOOL, err error) = dbghelp.dll.SymGetOmaps
-//sys	SymSetOptions(SymOptions uint32) (r uint32) = dbghelp.dll.SymSetOptions
-//sys	SymGetOptions() (r uint32) = dbghelp.dll.SymGetOptions
-//sys	SymCleanup(hProcess HANDLE) (r BOOL, err error) = dbghelp.dll.SymCleanup
-//sys	SymGetExtendedOption(option IMAGEHLP_EXTENDED_OPTIONS) (r BOOL) = dbghelp.dll.SymGetExtendedOption
-//sys	SymSetExtendedOption(option IMAGEHLP_EXTENDED_OPTIONS, value BOOL) (r BOOL) = dbghelp.dll.SymSetExtendedOption
-//sys	SymMatchString(string *PSTRElement, expression *PSTRElement, fCase BOOL) (r BOOL, err error) = dbghelp.dll.SymMatchString
-//sys	SymMatchStringA(string *PSTRElement, expression *PSTRElement, fCase BOOL) (r BOOL) = dbghelp.dll.SymMatchStringA
-//sys	SymMatchStringW(string *PWSTRElement, expression *PWSTRElement, fCase BOOL) (r BOOL, err error) = dbghelp.dll.SymMatchStringW
-//sys	SymEnumSourceFiles(hProcess HANDLE, ModBase uint64, Mask *PSTRElement, cbSrcFiles PSYM_ENUMSOURCEFILES_CALLBACK, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.dll.SymEnumSourceFiles
-//sys	SymEnumSourceFilesW(hProcess HANDLE, ModBase uint64, Mask *PWSTRElement, cbSrcFiles PSYM_ENUMSOURCEFILES_CALLBACKW, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.dll.SymEnumSourceFilesW
-//sys	SymEnumerateModules64(hProcess HANDLE, EnumModulesCallback PSYM_ENUMMODULES_CALLBACK64, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.dll.SymEnumerateModules64
-//sys	SymEnumerateModulesW64(hProcess HANDLE, EnumModulesCallback PSYM_ENUMMODULES_CALLBACKW64, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.dll.SymEnumerateModulesW64
-//sys	EnumerateLoadedModulesEx(hProcess HANDLE, EnumLoadedModulesCallback PENUMLOADED_MODULES_CALLBACK64, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.dll.EnumerateLoadedModulesEx
-//sys	EnumerateLoadedModulesExW(hProcess HANDLE, EnumLoadedModulesCallback PENUMLOADED_MODULES_CALLBACKW64, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.dll.EnumerateLoadedModulesExW
-//sys	EnumerateLoadedModules64(hProcess HANDLE, EnumLoadedModulesCallback PENUMLOADED_MODULES_CALLBACK64, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.dll.EnumerateLoadedModules64
-//sys	EnumerateLoadedModulesW64(hProcess HANDLE, EnumLoadedModulesCallback PENUMLOADED_MODULES_CALLBACKW64, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.dll.EnumerateLoadedModulesW64
-//sys	SymFunctionTableAccess64(hProcess HANDLE, AddrBase uint64) (r unsafe.Pointer, err error) = dbghelp.dll.SymFunctionTableAccess64
-//sys	SymFunctionTableAccess64AccessRoutines(hProcess HANDLE, AddrBase uint64, ReadMemoryRoutine PREAD_PROCESS_MEMORY_ROUTINE64, GetModuleBaseRoutine PGET_MODULE_BASE_ROUTINE64) (r unsafe.Pointer) = dbghelp.dll.SymFunctionTableAccess64AccessRoutines
-//sys	SymGetUnwindInfo(hProcess HANDLE, Address uint64, Buffer unsafe.Pointer, Size *uint32) (r BOOL) = dbghelp.dll.SymGetUnwindInfo
-//sys	SymGetModuleInfo64(hProcess HANDLE, qwAddr uint64, ModuleInfo *IMAGEHLP_MODULE64) (r BOOL, err error) = dbghelp.dll.SymGetModuleInfo64
-//sys	SymGetModuleInfoW64(hProcess HANDLE, qwAddr uint64, ModuleInfo *IMAGEHLP_MODULEW64) (r BOOL, err error) = dbghelp.dll.SymGetModuleInfoW64
-//sys	SymGetModuleBase64(hProcess HANDLE, qwAddr uint64) (r uint64, err error) = dbghelp.dll.SymGetModuleBase64
-//sys	SymEnumLines(hProcess HANDLE, Base uint64, Obj *PSTRElement, File *PSTRElement, EnumLinesCallback PSYM_ENUMLINES_CALLBACK, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.dll.SymEnumLines
-//sys	SymEnumLinesW(hProcess HANDLE, Base uint64, Obj *PWSTRElement, File *PWSTRElement, EnumLinesCallback PSYM_ENUMLINES_CALLBACKW, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.dll.SymEnumLinesW
-//sys	SymGetLineFromAddr64(hProcess HANDLE, qwAddr uint64, pdwDisplacement *uint32, Line64 *IMAGEHLP_LINE64) (r BOOL, err error) = dbghelp.dll.SymGetLineFromAddr64
-//sys	SymGetLineFromAddrW64(hProcess HANDLE, dwAddr uint64, pdwDisplacement *uint32, Line *IMAGEHLP_LINEW64) (r BOOL, err error) = dbghelp.dll.SymGetLineFromAddrW64
-//sys	SymGetLineFromInlineContext(hProcess HANDLE, qwAddr uint64, InlineContext uint32, qwModuleBaseAddress uint64, pdwDisplacement *uint32, Line64 *IMAGEHLP_LINE64) (r BOOL, err error) = dbghelp.dll.SymGetLineFromInlineContext
-//sys	SymGetLineFromInlineContextW(hProcess HANDLE, dwAddr uint64, InlineContext uint32, qwModuleBaseAddress uint64, pdwDisplacement *uint32, Line *IMAGEHLP_LINEW64) (r BOOL, err error) = dbghelp.dll.SymGetLineFromInlineContextW
-//sys	SymEnumSourceLines(hProcess HANDLE, Base uint64, Obj *PSTRElement, File *PSTRElement, Line uint32, Flags uint32, EnumLinesCallback PSYM_ENUMLINES_CALLBACK, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.dll.SymEnumSourceLines
-//sys	SymEnumSourceLinesW(hProcess HANDLE, Base uint64, Obj *PWSTRElement, File *PWSTRElement, Line uint32, Flags uint32, EnumLinesCallback PSYM_ENUMLINES_CALLBACKW, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.dll.SymEnumSourceLinesW
-//sys	SymAddrIncludeInlineTrace(hProcess HANDLE, Address uint64) (r uint32) = dbghelp.dll.SymAddrIncludeInlineTrace
-//sys	SymCompareInlineTrace(hProcess HANDLE, Address1 uint64, InlineContext1 uint32, RetAddress1 uint64, Address2 uint64, RetAddress2 uint64) (r uint32) = dbghelp.dll.SymCompareInlineTrace
-//sys	SymQueryInlineTrace(hProcess HANDLE, StartAddress uint64, StartContext uint32, StartRetAddress uint64, CurAddress uint64, CurContext *uint32, CurFrameIndex *uint32) (r BOOL, err error) = dbghelp.dll.SymQueryInlineTrace
-//sys	SymGetLineFromName64(hProcess HANDLE, ModuleName *PSTRElement, FileName *PSTRElement, dwLineNumber uint32, plDisplacement *int32, Line *IMAGEHLP_LINE64) (r BOOL, err error) = dbghelp.dll.SymGetLineFromName64
-//sys	SymGetLineFromNameW64(hProcess HANDLE, ModuleName *PWSTRElement, FileName *PWSTRElement, dwLineNumber uint32, plDisplacement *int32, Line *IMAGEHLP_LINEW64) (r BOOL, err error) = dbghelp.dll.SymGetLineFromNameW64
-//sys	SymGetLineNext64(hProcess HANDLE, Line *IMAGEHLP_LINE64) (r BOOL, err error) = dbghelp.dll.SymGetLineNext64
-//sys	SymGetLineNextW64(hProcess HANDLE, Line *IMAGEHLP_LINEW64) (r BOOL, err error) = dbghelp.dll.SymGetLineNextW64
-//sys	SymGetLinePrev64(hProcess HANDLE, Line *IMAGEHLP_LINE64) (r BOOL, err error) = dbghelp.dll.SymGetLinePrev64
-//sys	SymGetLinePrevW64(hProcess HANDLE, Line *IMAGEHLP_LINEW64) (r BOOL, err error) = dbghelp.dll.SymGetLinePrevW64
-//sys	SymGetFileLineOffsets64(hProcess HANDLE, ModuleName *PSTRElement, FileName *PSTRElement, Buffer *uint64, BufferLines uint32) (r uint32, err error) = dbghelp.dll.SymGetFileLineOffsets64
-//sys	SymMatchFileName(FileName *PSTRElement, Match *PSTRElement, FileNameStop **PSTRElement, MatchStop **PSTRElement) (r BOOL, err error) = dbghelp.dll.SymMatchFileName
-//sys	SymMatchFileNameW(FileName *PWSTRElement, Match *PWSTRElement, FileNameStop **PWSTRElement, MatchStop **PWSTRElement) (r BOOL, err error) = dbghelp.dll.SymMatchFileNameW
-//sys	SymGetSourceFile(hProcess HANDLE, Base uint64, Params *PSTRElement, FileSpec *PSTRElement, FilePath *PSTRElement, Size uint32) (r BOOL, err error) = dbghelp.dll.SymGetSourceFile
-//sys	SymGetSourceFileW(hProcess HANDLE, Base uint64, Params *PWSTRElement, FileSpec *PWSTRElement, FilePath *PWSTRElement, Size uint32) (r BOOL, err error) = dbghelp.dll.SymGetSourceFileW
-//sys	SymGetSourceFileToken(hProcess HANDLE, Base uint64, FileSpec *PSTRElement, Token *unsafe.Pointer, Size *uint32) (r BOOL, err error) = dbghelp.dll.SymGetSourceFileToken
-//sys	SymGetSourceFileTokenByTokenName(hProcess HANDLE, Base uint64, FileSpec *PSTRElement, TokenName *PSTRElement, TokenParameters *PSTRElement, Token *unsafe.Pointer, Size *uint32) (r BOOL) = dbghelp.dll.SymGetSourceFileTokenByTokenName
-//sys	SymGetSourceFileChecksumW(hProcess HANDLE, Base uint64, FileSpec *PWSTRElement, pCheckSumType *uint32, pChecksum *uint8, checksumSize uint32, pActualBytesWritten *uint32) (r BOOL, err error) = dbghelp.dll.SymGetSourceFileChecksumW
-//sys	SymGetSourceFileChecksum(hProcess HANDLE, Base uint64, FileSpec *PSTRElement, pCheckSumType *uint32, pChecksum *uint8, checksumSize uint32, pActualBytesWritten *uint32) (r BOOL, err error) = dbghelp.dll.SymGetSourceFileChecksum
-//sys	SymGetSourceFileTokenW(hProcess HANDLE, Base uint64, FileSpec *PWSTRElement, Token *unsafe.Pointer, Size *uint32) (r BOOL, err error) = dbghelp.dll.SymGetSourceFileTokenW
-//sys	SymGetSourceFileTokenByTokenNameW(hProcess HANDLE, Base uint64, FileSpec *PWSTRElement, TokenName *PWSTRElement, TokenParameters *PWSTRElement, Token *unsafe.Pointer, Size *uint32) (r BOOL) = dbghelp.dll.SymGetSourceFileTokenByTokenNameW
-//sys	SymGetSourceFileFromToken(hProcess HANDLE, Token unsafe.Pointer, Params *PSTRElement, FilePath *PSTRElement, Size uint32) (r BOOL, err error) = dbghelp.dll.SymGetSourceFileFromToken
-//sys	SymGetSourceFileFromTokenByTokenName(hProcess HANDLE, Token unsafe.Pointer, TokenName *PSTRElement, Params *PSTRElement, FilePath *PSTRElement, Size uint32) (r BOOL) = dbghelp.dll.SymGetSourceFileFromTokenByTokenName
-//sys	SymGetSourceFileFromTokenW(hProcess HANDLE, Token unsafe.Pointer, Params *PWSTRElement, FilePath *PWSTRElement, Size uint32) (r BOOL, err error) = dbghelp.dll.SymGetSourceFileFromTokenW
-//sys	SymGetSourceFileFromTokenByTokenNameW(hProcess HANDLE, Token unsafe.Pointer, TokenName *PWSTRElement, Params *PWSTRElement, FilePath *PWSTRElement, Size uint32) (r BOOL) = dbghelp.dll.SymGetSourceFileFromTokenByTokenNameW
-//sys	SymGetSourceVarFromToken(hProcess HANDLE, Token unsafe.Pointer, Params *PSTRElement, VarName *PSTRElement, Value *PSTRElement, Size uint32) (r BOOL, err error) = dbghelp.dll.SymGetSourceVarFromToken
-//sys	SymGetSourceVarFromTokenW(hProcess HANDLE, Token unsafe.Pointer, Params *PWSTRElement, VarName *PWSTRElement, Value *PWSTRElement, Size uint32) (r BOOL, err error) = dbghelp.dll.SymGetSourceVarFromTokenW
-//sys	SymEnumSourceFileTokens(hProcess HANDLE, Base uint64, Callback PENUMSOURCEFILETOKENSCALLBACK) (r BOOL, err error) = dbghelp.dll.SymEnumSourceFileTokens
-//sys	SymInitialize(hProcess HANDLE, UserSearchPath *PSTRElement, fInvadeProcess BOOL) (r BOOL, err error) = dbghelp.dll.SymInitialize
-//sys	SymInitializeW(hProcess HANDLE, UserSearchPath *PWSTRElement, fInvadeProcess BOOL) (r BOOL, err error) = dbghelp.dll.SymInitializeW
-//sys	SymGetSearchPath(hProcess HANDLE, SearchPathA *PSTRElement, SearchPathLength uint32) (r BOOL, err error) = dbghelp.dll.SymGetSearchPath
-//sys	SymGetSearchPathW(hProcess HANDLE, SearchPathA *PWSTRElement, SearchPathLength uint32) (r BOOL, err error) = dbghelp.dll.SymGetSearchPathW
-//sys	SymSetSearchPath(hProcess HANDLE, SearchPathA *PSTRElement) (r BOOL, err error) = dbghelp.dll.SymSetSearchPath
-//sys	SymSetSearchPathW(hProcess HANDLE, SearchPathA *PWSTRElement) (r BOOL, err error) = dbghelp.dll.SymSetSearchPathW
-//sys	SymLoadModuleEx(hProcess HANDLE, hFile HANDLE, ImageName *PSTRElement, ModuleName *PSTRElement, BaseOfDll uint64, DllSize uint32, Data *MODLOAD_DATA, Flags SYM_LOAD_FLAGS) (r uint64, err error) = dbghelp.dll.SymLoadModuleEx
-//sys	SymLoadModuleExW(hProcess HANDLE, hFile HANDLE, ImageName *PWSTRElement, ModuleName *PWSTRElement, BaseOfDll uint64, DllSize uint32, Data *MODLOAD_DATA, Flags SYM_LOAD_FLAGS) (r uint64, err error) = dbghelp.dll.SymLoadModuleExW
-//sys	SymUnloadModule64(hProcess HANDLE, BaseOfDll uint64) (r BOOL, err error) = dbghelp.dll.SymUnloadModule64
-//sys	SymUnDName64(sym *IMAGEHLP_SYMBOL64, UnDecName *PSTRElement, UnDecNameLength uint32) (r BOOL, err error) = dbghelp.dll.SymUnDName64
-//sys	SymRegisterCallback64(hProcess HANDLE, CallbackFunction PSYMBOL_REGISTERED_CALLBACK64, UserContext uint64) (r BOOL, err error) = dbghelp.dll.SymRegisterCallback64
-//sys	SymRegisterCallbackW64(hProcess HANDLE, CallbackFunction PSYMBOL_REGISTERED_CALLBACK64, UserContext uint64) (r BOOL, err error) = dbghelp.dll.SymRegisterCallbackW64
-//sys	SymRegisterFunctionEntryCallback64(hProcess HANDLE, CallbackFunction PSYMBOL_FUNCENTRY_CALLBACK64, UserContext uint64) (r BOOL, err error) = dbghelp.dll.SymRegisterFunctionEntryCallback64
-//sys	SymSetContext(hProcess HANDLE, StackFrame *IMAGEHLP_STACK_FRAME, Context unsafe.Pointer) (r BOOL, err error) = dbghelp.dll.SymSetContext
-//sys	SymSetScopeFromAddr(hProcess HANDLE, Address uint64) (r BOOL, err error) = dbghelp.dll.SymSetScopeFromAddr
-//sys	SymSetScopeFromInlineContext(hProcess HANDLE, Address uint64, InlineContext uint32) (r BOOL, err error) = dbghelp.dll.SymSetScopeFromInlineContext
-//sys	SymSetScopeFromIndex(hProcess HANDLE, BaseOfDll uint64, Index uint32) (r BOOL, err error) = dbghelp.dll.SymSetScopeFromIndex
-//sys	SymEnumProcesses(EnumProcessesCallback PSYM_ENUMPROCESSES_CALLBACK, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.dll.SymEnumProcesses
-//sys	SymFromAddr(hProcess HANDLE, Address uint64, Displacement *uint64, Symbol *SYMBOL_INFO) (r BOOL, err error) = dbghelp.dll.SymFromAddr
-//sys	SymFromAddrW(hProcess HANDLE, Address uint64, Displacement *uint64, Symbol *SYMBOL_INFOW) (r BOOL, err error) = dbghelp.dll.SymFromAddrW
-//sys	SymFromInlineContext(hProcess HANDLE, Address uint64, InlineContext uint32, Displacement *uint64, Symbol *SYMBOL_INFO) (r BOOL, err error) = dbghelp.dll.SymFromInlineContext
-//sys	SymFromInlineContextW(hProcess HANDLE, Address uint64, InlineContext uint32, Displacement *uint64, Symbol *SYMBOL_INFOW) (r BOOL, err error) = dbghelp.dll.SymFromInlineContextW
-//sys	SymFromToken(hProcess HANDLE, Base uint64, Token uint32, Symbol *SYMBOL_INFO) (r BOOL, err error) = dbghelp.dll.SymFromToken
-//sys	SymFromTokenW(hProcess HANDLE, Base uint64, Token uint32, Symbol *SYMBOL_INFOW) (r BOOL, err error) = dbghelp.dll.SymFromTokenW
-//sys	SymNext(hProcess HANDLE, si *SYMBOL_INFO) (r BOOL, err error) = dbghelp.dll.SymNext
-//sys	SymNextW(hProcess HANDLE, siw *SYMBOL_INFOW) (r BOOL, err error) = dbghelp.dll.SymNextW
-//sys	SymPrev(hProcess HANDLE, si *SYMBOL_INFO) (r BOOL, err error) = dbghelp.dll.SymPrev
-//sys	SymPrevW(hProcess HANDLE, siw *SYMBOL_INFOW) (r BOOL, err error) = dbghelp.dll.SymPrevW
-//sys	SymFromName(hProcess HANDLE, Name *PSTRElement, Symbol *SYMBOL_INFO) (r BOOL, err error) = dbghelp.dll.SymFromName
-//sys	SymFromNameW(hProcess HANDLE, Name *PWSTRElement, Symbol *SYMBOL_INFOW) (r BOOL, err error) = dbghelp.dll.SymFromNameW
-//sys	SymEnumSymbols(hProcess HANDLE, BaseOfDll uint64, Mask *PSTRElement, EnumSymbolsCallback PSYM_ENUMERATESYMBOLS_CALLBACK, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.dll.SymEnumSymbols
-//sys	SymEnumSymbolsEx(hProcess HANDLE, BaseOfDll uint64, Mask *PSTRElement, EnumSymbolsCallback PSYM_ENUMERATESYMBOLS_CALLBACK, UserContext unsafe.Pointer, Options uint32) (r BOOL, err error) = dbghelp.dll.SymEnumSymbolsEx
-//sys	SymEnumSymbolsW(hProcess HANDLE, BaseOfDll uint64, Mask *PWSTRElement, EnumSymbolsCallback PSYM_ENUMERATESYMBOLS_CALLBACKW, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.dll.SymEnumSymbolsW
-//sys	SymEnumSymbolsExW(hProcess HANDLE, BaseOfDll uint64, Mask *PWSTRElement, EnumSymbolsCallback PSYM_ENUMERATESYMBOLS_CALLBACKW, UserContext unsafe.Pointer, Options uint32) (r BOOL, err error) = dbghelp.dll.SymEnumSymbolsExW
-//sys	SymEnumSymbolsForAddr(hProcess HANDLE, Address uint64, EnumSymbolsCallback PSYM_ENUMERATESYMBOLS_CALLBACK, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.dll.SymEnumSymbolsForAddr
-//sys	SymEnumSymbolsForAddrW(hProcess HANDLE, Address uint64, EnumSymbolsCallback PSYM_ENUMERATESYMBOLS_CALLBACKW, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.dll.SymEnumSymbolsForAddrW
-//sys	SymSearch(hProcess HANDLE, BaseOfDll uint64, Index uint32, SymTag uint32, Mask *PSTRElement, Address uint64, EnumSymbolsCallback PSYM_ENUMERATESYMBOLS_CALLBACK, UserContext unsafe.Pointer, Options uint32) (r BOOL, err error) = dbghelp.dll.SymSearch
-//sys	SymSearchW(hProcess HANDLE, BaseOfDll uint64, Index uint32, SymTag uint32, Mask *PWSTRElement, Address uint64, EnumSymbolsCallback PSYM_ENUMERATESYMBOLS_CALLBACKW, UserContext unsafe.Pointer, Options uint32) (r BOOL, err error) = dbghelp.dll.SymSearchW
-//sys	SymGetScope(hProcess HANDLE, BaseOfDll uint64, Index uint32, Symbol *SYMBOL_INFO) (r BOOL, err error) = dbghelp.dll.SymGetScope
-//sys	SymGetScopeW(hProcess HANDLE, BaseOfDll uint64, Index uint32, Symbol *SYMBOL_INFOW) (r BOOL, err error) = dbghelp.dll.SymGetScopeW
-//sys	SymFromIndex(hProcess HANDLE, BaseOfDll uint64, Index uint32, Symbol *SYMBOL_INFO) (r BOOL, err error) = dbghelp.dll.SymFromIndex
-//sys	SymFromIndexW(hProcess HANDLE, BaseOfDll uint64, Index uint32, Symbol *SYMBOL_INFOW) (r BOOL, err error) = dbghelp.dll.SymFromIndexW
-//sys	SymGetTypeInfo(hProcess HANDLE, ModBase uint64, TypeId uint32, GetType IMAGEHLP_SYMBOL_TYPE_INFO, pInfo unsafe.Pointer) (r BOOL, err error) = dbghelp.dll.SymGetTypeInfo
-//sys	SymGetTypeInfoEx(hProcess HANDLE, ModBase uint64, Params *IMAGEHLP_GET_TYPE_INFO_PARAMS) (r BOOL, err error) = dbghelp.dll.SymGetTypeInfoEx
-//sys	SymEnumTypes(hProcess HANDLE, BaseOfDll uint64, EnumSymbolsCallback PSYM_ENUMERATESYMBOLS_CALLBACK, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.dll.SymEnumTypes
-//sys	SymEnumTypesW(hProcess HANDLE, BaseOfDll uint64, EnumSymbolsCallback PSYM_ENUMERATESYMBOLS_CALLBACKW, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.dll.SymEnumTypesW
-//sys	SymEnumTypesByName(hProcess HANDLE, BaseOfDll uint64, mask *PSTRElement, EnumSymbolsCallback PSYM_ENUMERATESYMBOLS_CALLBACK, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.dll.SymEnumTypesByName
-//sys	SymEnumTypesByNameW(hProcess HANDLE, BaseOfDll uint64, mask *PWSTRElement, EnumSymbolsCallback PSYM_ENUMERATESYMBOLS_CALLBACKW, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.dll.SymEnumTypesByNameW
-//sys	SymGetTypeFromName(hProcess HANDLE, BaseOfDll uint64, Name *PSTRElement, Symbol *SYMBOL_INFO) (r BOOL, err error) = dbghelp.dll.SymGetTypeFromName
-//sys	SymGetTypeFromNameW(hProcess HANDLE, BaseOfDll uint64, Name *PWSTRElement, Symbol *SYMBOL_INFOW) (r BOOL, err error) = dbghelp.dll.SymGetTypeFromNameW
-//sys	SymAddSymbol(hProcess HANDLE, BaseOfDll uint64, Name *PSTRElement, Address uint64, Size uint32, Flags uint32) (r BOOL, err error) = dbghelp.dll.SymAddSymbol
-//sys	SymAddSymbolW(hProcess HANDLE, BaseOfDll uint64, Name *PWSTRElement, Address uint64, Size uint32, Flags uint32) (r BOOL, err error) = dbghelp.dll.SymAddSymbolW
-//sys	SymDeleteSymbol(hProcess HANDLE, BaseOfDll uint64, Name *PSTRElement, Address uint64, Flags uint32) (r BOOL, err error) = dbghelp.dll.SymDeleteSymbol
-//sys	SymDeleteSymbolW(hProcess HANDLE, BaseOfDll uint64, Name *PWSTRElement, Address uint64, Flags uint32) (r BOOL, err error) = dbghelp.dll.SymDeleteSymbolW
-//sys	SymRefreshModuleList(hProcess HANDLE) (r BOOL, err error) = dbghelp.dll.SymRefreshModuleList
-//sys	SymAddSourceStream(hProcess HANDLE, Base uint64, StreamFile *PSTRElement, Buffer *uint8, Size uintptr) (r BOOL, err error) = dbghelp.dll.SymAddSourceStream
-//sys	SymAddSourceStreamA(hProcess HANDLE, Base uint64, StreamFile *PSTRElement, Buffer *uint8, Size uintptr) (r BOOL) = dbghelp.dll.SymAddSourceStreamA
-//sys	SymAddSourceStreamW(hProcess HANDLE, Base uint64, FileSpec *PWSTRElement, Buffer *uint8, Size uintptr) (r BOOL, err error) = dbghelp.dll.SymAddSourceStreamW
-//sys	SymSrvIsStoreW(hProcess HANDLE, path *PWSTRElement) (r BOOL, err error) = dbghelp.dll.SymSrvIsStoreW
-//sys	SymSrvIsStore(hProcess HANDLE, path *PSTRElement) (r BOOL, err error) = dbghelp.dll.SymSrvIsStore
-//sys	SymSrvDeltaName(hProcess HANDLE, SymPath *PSTRElement, Type *PSTRElement, File1 *PSTRElement, File2 *PSTRElement) (r *PSTRElement, err error) = dbghelp.dll.SymSrvDeltaName
-//sys	SymSrvDeltaNameW(hProcess HANDLE, SymPath *PWSTRElement, Type *PWSTRElement, File1 *PWSTRElement, File2 *PWSTRElement) (r *PWSTRElement, err error) = dbghelp.dll.SymSrvDeltaNameW
-//sys	SymSrvGetSupplement(hProcess HANDLE, SymPath *PSTRElement, Node *PSTRElement, File *PSTRElement) (r *PSTRElement, err error) = dbghelp.dll.SymSrvGetSupplement
-//sys	SymSrvGetSupplementW(hProcess HANDLE, SymPath *PWSTRElement, Node *PWSTRElement, File *PWSTRElement) (r *PWSTRElement, err error) = dbghelp.dll.SymSrvGetSupplementW
-//sys	SymSrvGetFileIndexes(File *PSTRElement, Id *Guid, Val1 *uint32, Val2 *uint32, Flags uint32) (r BOOL, err error) = dbghelp.dll.SymSrvGetFileIndexes
-//sys	SymSrvGetFileIndexesW(File *PWSTRElement, Id *Guid, Val1 *uint32, Val2 *uint32, Flags uint32) (r BOOL, err error) = dbghelp.dll.SymSrvGetFileIndexesW
-//sys	SymSrvGetFileIndexStringW(hProcess HANDLE, SrvPath *PWSTRElement, File *PWSTRElement, Index *PWSTRElement, Size uintptr, Flags uint32) (r BOOL, err error) = dbghelp.dll.SymSrvGetFileIndexStringW
-//sys	SymSrvGetFileIndexString(hProcess HANDLE, SrvPath *PSTRElement, File *PSTRElement, Index *PSTRElement, Size uintptr, Flags uint32) (r BOOL, err error) = dbghelp.dll.SymSrvGetFileIndexString
-//sys	SymSrvGetFileIndexInfo(File *PSTRElement, Info *SYMSRV_INDEX_INFO, Flags uint32) (r BOOL, err error) = dbghelp.dll.SymSrvGetFileIndexInfo
-//sys	SymSrvGetFileIndexInfoW(File *PWSTRElement, Info *SYMSRV_INDEX_INFOW, Flags uint32) (r BOOL, err error) = dbghelp.dll.SymSrvGetFileIndexInfoW
-//sys	SymSrvStoreSupplement(hProcess HANDLE, SrvPath *PSTRElement, Node *PSTRElement, File *PSTRElement, Flags uint32) (r *PSTRElement, err error) = dbghelp.dll.SymSrvStoreSupplement
-//sys	SymSrvStoreSupplementW(hProcess HANDLE, SymPath *PWSTRElement, Node *PWSTRElement, File *PWSTRElement, Flags uint32) (r *PWSTRElement, err error) = dbghelp.dll.SymSrvStoreSupplementW
-//sys	SymSrvStoreFile(hProcess HANDLE, SrvPath *PSTRElement, File *PSTRElement, Flags SYM_SRV_STORE_FILE_FLAGS) (r *PSTRElement, err error) = dbghelp.dll.SymSrvStoreFile
-//sys	SymSrvStoreFileW(hProcess HANDLE, SrvPath *PWSTRElement, File *PWSTRElement, Flags SYM_SRV_STORE_FILE_FLAGS) (r *PWSTRElement, err error) = dbghelp.dll.SymSrvStoreFileW
-//sys	SymGetSymbolFile(hProcess HANDLE, SymPath *PSTRElement, ImageFile *PSTRElement, Type uint32, SymbolFile *PSTRElement, cSymbolFile uintptr, DbgFile *PSTRElement, cDbgFile uintptr) (r BOOL, err error) = dbghelp.dll.SymGetSymbolFile
-//sys	SymGetSymbolFileW(hProcess HANDLE, SymPath *PWSTRElement, ImageFile *PWSTRElement, Type uint32, SymbolFile *PWSTRElement, cSymbolFile uintptr, DbgFile *PWSTRElement, cDbgFile uintptr) (r BOOL, err error) = dbghelp.dll.SymGetSymbolFileW
-//sys	DbgHelpCreateUserDump(FileName *PSTRElement, Callback PDBGHELP_CREATE_USER_DUMP_CALLBACK, UserData unsafe.Pointer) (r BOOL) = dbghelp.dll.DbgHelpCreateUserDump
-//sys	DbgHelpCreateUserDumpW(FileName *PWSTRElement, Callback PDBGHELP_CREATE_USER_DUMP_CALLBACK, UserData unsafe.Pointer) (r BOOL) = dbghelp.dll.DbgHelpCreateUserDumpW
-//sys	SymGetSymFromAddr64(hProcess HANDLE, qwAddr uint64, pdwDisplacement *uint64, Symbol *IMAGEHLP_SYMBOL64) (r BOOL, err error) = dbghelp.dll.SymGetSymFromAddr64
-//sys	SymGetSymFromName64(hProcess HANDLE, Name *PSTRElement, Symbol *IMAGEHLP_SYMBOL64) (r BOOL, err error) = dbghelp.dll.SymGetSymFromName64
-//sys	FindFileInPath(hprocess HANDLE, SearchPathA *PSTRElement, FileName *PSTRElement, id unsafe.Pointer, two uint32, three uint32, flags uint32, FilePath *PSTRElement) (r BOOL) = dbghelp.dll.FindFileInPath
-//sys	FindFileInSearchPath(hprocess HANDLE, SearchPathA *PSTRElement, FileName *PSTRElement, one uint32, two uint32, three uint32, FilePath *PSTRElement) (r BOOL) = dbghelp.dll.FindFileInSearchPath
-//sys	SymEnumSym(hProcess HANDLE, BaseOfDll uint64, EnumSymbolsCallback PSYM_ENUMERATESYMBOLS_CALLBACK, UserContext unsafe.Pointer) (r BOOL) = dbghelp.dll.SymEnumSym
-//sys	SymEnumerateSymbols64(hProcess HANDLE, BaseOfDll uint64, EnumSymbolsCallback PSYM_ENUMSYMBOLS_CALLBACK64, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.dll.SymEnumerateSymbols64
-//sys	SymEnumerateSymbolsW64(hProcess HANDLE, BaseOfDll uint64, EnumSymbolsCallback PSYM_ENUMSYMBOLS_CALLBACK64W, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.dll.SymEnumerateSymbolsW64
-//sys	SymLoadModule64(hProcess HANDLE, hFile HANDLE, ImageName *PSTRElement, ModuleName *PSTRElement, BaseOfDll uint64, SizeOfDll uint32) (r uint64, err error) = dbghelp.dll.SymLoadModule64
-//sys	SymGetSymNext64(hProcess HANDLE, Symbol *IMAGEHLP_SYMBOL64) (r BOOL, err error) = dbghelp.dll.SymGetSymNext64
-//sys	SymGetSymPrev64(hProcess HANDLE, Symbol *IMAGEHLP_SYMBOL64) (r BOOL, err error) = dbghelp.dll.SymGetSymPrev64
-//sys	SetCheckUserInterruptShared(lpStartAddress LPCALL_BACK_USER_INTERRUPT_ROUTINE) = dbghelp.dll.SetCheckUserInterruptShared
-//sys	GetSymLoadError() (r uint32) = dbghelp.dll.GetSymLoadError
-//sys	SetSymLoadError(error uint32) = dbghelp.dll.SetSymLoadError
-//sys	ReportSymbolLoadSummary(hProcess HANDLE, pLoadModule *PWSTRElement, pSymbolData *DBGHELP_DATA_REPORT_STRUCT) (r BOOL) = dbghelp.dll.ReportSymbolLoadSummary
-//sys	RemoveInvalidModuleList(hProcess HANDLE) = dbghelp.dll.RemoveInvalidModuleList
-//sys	RangeMapCreate() (r unsafe.Pointer) = dbghelp.dll.RangeMapCreate
-//sys	RangeMapFree(RmapHandle unsafe.Pointer) = dbghelp.dll.RangeMapFree
-//sys	RangeMapAddPeImageSections(RmapHandle unsafe.Pointer, ImageName *PWSTRElement, MappedImage unsafe.Pointer, MappingBytes uint32, ImageBase uint64, UserTag uint64, MappingFlags uint32) (r BOOL) = dbghelp.dll.RangeMapAddPeImageSections
-//sys	RangeMapRemove(RmapHandle unsafe.Pointer, UserTag uint64) (r BOOL) = dbghelp.dll.RangeMapRemove
-//sys	RangeMapRead(RmapHandle unsafe.Pointer, Offset uint64, Buffer unsafe.Pointer, RequestBytes uint32, Flags uint32, DoneBytes *uint32) (r BOOL) = dbghelp.dll.RangeMapRead
-//sys	RangeMapWrite(RmapHandle unsafe.Pointer, Offset uint64, Buffer unsafe.Pointer, RequestBytes uint32, Flags uint32, DoneBytes *uint32) (r BOOL) = dbghelp.dll.RangeMapWrite
-//sys	MessageBeep(uType MESSAGEBOX_STYLE) (r BOOL, err error) = user32.dll.MessageBeep
-//sys	FatalExit(ExitCode int32) = kernel32.dll.FatalExit
-//sys	GetThreadSelectorEntry(hThread HANDLE, dwSelector uint32, lpSelectorEntry *LDT_ENTRY) (r BOOL, err error) = kernel32.dll.GetThreadSelectorEntry
-//sys	Wow64GetThreadSelectorEntry(hThread HANDLE, dwSelector uint32, lpSelectorEntry *WOW64_LDT_ENTRY) (r BOOL, err error) = kernel32.dll.Wow64GetThreadSelectorEntry
-//sys	DebugSetProcessKillOnExit(KillOnExit BOOL) (r BOOL, err error) = kernel32.dll.DebugSetProcessKillOnExit
-//sys	DebugBreakProcess(Process HANDLE) (r BOOL, err error) = kernel32.dll.DebugBreakProcess
-//sys	FormatMessageA(dwFlags FORMAT_MESSAGE_OPTIONS, lpSource unsafe.Pointer, dwMessageId uint32, dwLanguageId uint32, lpBuffer *PSTRElement, nSize uint32, Arguments **int8) (r uint32, err error) = kernel32.dll.FormatMessageA
-//sys	FormatMessageW(dwFlags FORMAT_MESSAGE_OPTIONS, lpSource unsafe.Pointer, dwMessageId uint32, dwLanguageId uint32, lpBuffer *PWSTRElement, nSize uint32, Arguments **int8) (r uint32, err error) = kernel32.dll.FormatMessageW
-//sys	CopyContext(Destination *CONTEXT, ContextFlags CONTEXT_FLAGS, Source *CONTEXT) (r BOOL, err error) = kernel32.dll.CopyContext
-//sys	InitializeContext(Buffer unsafe.Pointer, ContextFlags CONTEXT_FLAGS, Context **CONTEXT, ContextLength *uint32) (r BOOL, err error) = kernel32.dll.InitializeContext
-//sys	InitializeContext2(Buffer unsafe.Pointer, ContextFlags CONTEXT_FLAGS, Context **CONTEXT, ContextLength *uint32, XStateCompactionMask uint64) (r BOOL, err error) = kernel32.dll.InitializeContext2
-//sys	GetEnabledXStateFeatures() (r uint64) = kernel32.dll.GetEnabledXStateFeatures
-//sys	GetXStateFeaturesMask(Context *CONTEXT, FeatureMask *uint64) (r BOOL) = kernel32.dll.GetXStateFeaturesMask
-//sys	LocateXStateFeature(Context *CONTEXT, FeatureId uint32, Length *uint32) (r unsafe.Pointer) = kernel32.dll.LocateXStateFeature
-//sys	SetXStateFeaturesMask(Context *CONTEXT, FeatureMask uint64) (r BOOL) = kernel32.dll.SetXStateFeaturesMask
+//sys	ReadProcessMemory(hProcess HANDLE, lpBaseAddress unsafe.Pointer, lpBuffer unsafe.Pointer, nSize uintptr, lpNumberOfBytesRead *uintptr) (r BOOL, err error)
+//sys	WriteProcessMemory(hProcess HANDLE, lpBaseAddress unsafe.Pointer, lpBuffer unsafe.Pointer, nSize uintptr, lpNumberOfBytesWritten *uintptr) (r BOOL, err error)
+//sys	GetThreadContext(hThread HANDLE, lpContext *CONTEXT) (r BOOL, err error)
+//sys	SetThreadContext(hThread HANDLE, lpContext *CONTEXT) (r BOOL, err error)
+//sys	FlushInstructionCache(hProcess HANDLE, lpBaseAddress unsafe.Pointer, dwSize uintptr) (r BOOL, err error)
+//sys	Wow64GetThreadContext(hThread HANDLE, lpContext *WOW64_CONTEXT) (r BOOL, err error)
+//sys	Wow64SetThreadContext(hThread HANDLE, lpContext *WOW64_CONTEXT) (r BOOL, err error)
+//sys	RtlCaptureStackBackTrace(FramesToSkip uint32, FramesToCapture uint32, BackTrace *unsafe.Pointer, BackTraceHash *uint32) (r uint16)
+//sys	RtlCaptureContext(ContextRecord *CONTEXT)
+//sys	RtlUnwind(TargetFrame unsafe.Pointer, TargetIp unsafe.Pointer, ExceptionRecord *EXCEPTION_RECORD, ReturnValue unsafe.Pointer)
+//sys	RtlRestoreContext(ContextRecord *CONTEXT, ExceptionRecord *EXCEPTION_RECORD)
+//sys	RtlRaiseException(ExceptionRecord *EXCEPTION_RECORD)
+//sys	RtlPcToFileHeader(PcValue unsafe.Pointer, BaseOfImage *unsafe.Pointer) (r unsafe.Pointer)
+//sys	IsDebuggerPresent() (r BOOL)
+//sys	DebugBreak()
+//sys	OutputDebugStringA(lpOutputString *PSTRElement)
+//sys	OutputDebugStringW(lpOutputString *PWSTRElement)
+//sys	ContinueDebugEvent(dwProcessId uint32, dwThreadId uint32, dwContinueStatus NTSTATUS) (r BOOL, err error)
+//sys	WaitForDebugEvent(lpDebugEvent *DEBUG_EVENT, dwMilliseconds uint32) (r BOOL, err error)
+//sys	DebugActiveProcess(dwProcessId uint32) (r BOOL, err error)
+//sys	DebugActiveProcessStop(dwProcessId uint32) (r BOOL, err error)
+//sys	CheckRemoteDebuggerPresent(hProcess HANDLE, pbDebuggerPresent *BOOL) (r BOOL, err error)
+//sys	WaitForDebugEventEx(lpDebugEvent *DEBUG_EVENT, dwMilliseconds uint32) (r BOOL, err error)
+//sys	EncodePointer(Ptr unsafe.Pointer) (r unsafe.Pointer)
+//sys	DecodePointer(Ptr unsafe.Pointer) (r unsafe.Pointer)
+//sys	EncodeSystemPointer(Ptr unsafe.Pointer) (r unsafe.Pointer)
+//sys	DecodeSystemPointer(Ptr unsafe.Pointer) (r unsafe.Pointer)
+//sys	EncodeRemotePointer(ProcessHandle HANDLE, Ptr unsafe.Pointer, EncodedPtr *unsafe.Pointer) (r HRESULT) = api-ms-win-core-util-l1-1-1.EncodeRemotePointer
+//sys	DecodeRemotePointer(ProcessHandle HANDLE, Ptr unsafe.Pointer, DecodedPtr *unsafe.Pointer) (r HRESULT) = api-ms-win-core-util-l1-1-1.DecodeRemotePointer
+//sys	Beep(dwFreq uint32, dwDuration uint32) (r BOOL, err error)
+//sys	RaiseException(dwExceptionCode uint32, dwExceptionFlags uint32, nNumberOfArguments uint32, lpArguments *uintptr)
+//sys	UnhandledExceptionFilter(ExceptionInfo *EXCEPTION_POINTERS) (r int32)
+//sys	SetUnhandledExceptionFilter(lpTopLevelExceptionFilter LPTOP_LEVEL_EXCEPTION_FILTER) (r LPTOP_LEVEL_EXCEPTION_FILTER)
+//sys	GetErrorMode() (r uint32)
+//sys	SetErrorMode(uMode THREAD_ERROR_MODE) (r THREAD_ERROR_MODE)
+//sys	AddVectoredExceptionHandler(First uint32, Handler PVECTORED_EXCEPTION_HANDLER) (r unsafe.Pointer)
+//sys	RemoveVectoredExceptionHandler(Handle unsafe.Pointer) (r uint32)
+//sys	AddVectoredContinueHandler(First uint32, Handler PVECTORED_EXCEPTION_HANDLER) (r unsafe.Pointer)
+//sys	RemoveVectoredContinueHandler(Handle unsafe.Pointer) (r uint32)
+//sys	RaiseFailFastException(pExceptionRecord *EXCEPTION_RECORD, pContextRecord *CONTEXT, dwFlags uint32)
+//sys	FatalAppExitA(uAction uint32, lpMessageText *PSTRElement)
+//sys	FatalAppExitW(uAction uint32, lpMessageText *PWSTRElement)
+//sys	GetThreadErrorMode() (r uint32)
+//sys	SetThreadErrorMode(dwNewMode THREAD_ERROR_MODE, lpOldMode *THREAD_ERROR_MODE) (r BOOL, err error)
+//sys	TerminateProcessOnMemoryExhaustion(FailedAllocationSize uintptr) = api-ms-win-core-errorhandling-l1-1-3.TerminateProcessOnMemoryExhaustion
+//sys	OpenThreadWaitChainSession(Flags OPEN_THREAD_WAIT_CHAIN_SESSION_FLAGS, callback PWAITCHAINCALLBACK) (r unsafe.Pointer, err error) = advapi32.OpenThreadWaitChainSession
+//sys	CloseThreadWaitChainSession(WctHandle unsafe.Pointer) = advapi32.CloseThreadWaitChainSession
+//sys	GetThreadWaitChain(WctHandle unsafe.Pointer, Context uintptr, Flags WAIT_CHAIN_THREAD_OPTIONS, ThreadId uint32, NodeCount *uint32, NodeInfoArray *WAITCHAIN_NODE_INFO, IsCycle *BOOL) (r BOOL, err error) = advapi32.GetThreadWaitChain
+//sys	RegisterWaitChainCOMCallback(CallStateCallback PCOGETCALLSTATE, ActivationStateCallback PCOGETACTIVATIONSTATE) = advapi32.RegisterWaitChainCOMCallback
+//sys	MiniDumpWriteDump(hProcess HANDLE, ProcessId uint32, hFile HANDLE, DumpType MINIDUMP_TYPE, ExceptionParam *MINIDUMP_EXCEPTION_INFORMATION, UserStreamParam *MINIDUMP_USER_STREAM_INFORMATION, CallbackParam *MINIDUMP_CALLBACK_INFORMATION) (r BOOL, err error) = dbghelp.MiniDumpWriteDump
+//sys	MiniDumpReadDumpStream(BaseOfDump unsafe.Pointer, StreamNumber uint32, Dir **MINIDUMP_DIRECTORY, StreamPointer *unsafe.Pointer, StreamSize *uint32) (r BOOL) = dbghelp.MiniDumpReadDumpStream
+//sys	BindImage(ImageName *PSTRElement, DllPath *PSTRElement, SymbolPath *PSTRElement) (r BOOL, err error) = imagehlp.BindImage
+//sys	BindImageEx(Flags uint32, ImageName *PSTRElement, DllPath *PSTRElement, SymbolPath *PSTRElement, StatusRoutine PIMAGEHLP_STATUS_ROUTINE) (r BOOL, err error) = imagehlp.BindImageEx
+//sys	ReBaseImage(CurrentImageName *PSTRElement, SymbolPath *PSTRElement, fReBase BOOL, fRebaseSysfileOk BOOL, fGoingDown BOOL, CheckImageSize uint32, OldImageSize *uint32, OldImageBase *uintptr, NewImageSize *uint32, NewImageBase *uintptr, TimeStamp uint32) (r BOOL, err error) = imagehlp.ReBaseImage
+//sys	ReBaseImage64(CurrentImageName *PSTRElement, SymbolPath *PSTRElement, fReBase BOOL, fRebaseSysfileOk BOOL, fGoingDown BOOL, CheckImageSize uint32, OldImageSize *uint32, OldImageBase *uint64, NewImageSize *uint32, NewImageBase *uint64, TimeStamp uint32) (r BOOL, err error) = imagehlp.ReBaseImage64
+//sys	MapFileAndCheckSumA(Filename *PSTRElement, HeaderSum *uint32, CheckSum *uint32) (r uint32) = imagehlp.MapFileAndCheckSumA
+//sys	MapFileAndCheckSumW(Filename *PWSTRElement, HeaderSum *uint32, CheckSum *uint32) (r uint32) = imagehlp.MapFileAndCheckSumW
+//sys	GetImageUnusedHeaderBytes(LoadedImage *LOADED_IMAGE, SizeUnusedHeaderBytes *uint32) (r uint32, err error) = imagehlp.GetImageUnusedHeaderBytes
+//sys	ImageGetDigestStream(FileHandle HANDLE, DigestLevel uint32, DigestFunction DIGEST_FUNCTION, DigestHandle unsafe.Pointer) (r BOOL, err error) = imagehlp.ImageGetDigestStream
+//sys	ImageAddCertificate(FileHandle HANDLE, Certificate *WIN_CERTIFICATE, Index *uint32) (r BOOL, err error) = imagehlp.ImageAddCertificate
+//sys	ImageRemoveCertificate(FileHandle HANDLE, Index uint32) (r BOOL, err error) = imagehlp.ImageRemoveCertificate
+//sys	ImageEnumerateCertificates(FileHandle HANDLE, TypeFilter uint16, CertificateCount *uint32, Indices *uint32, IndexCount uint32) (r BOOL, err error) = imagehlp.ImageEnumerateCertificates
+//sys	ImageGetCertificateData(FileHandle HANDLE, CertificateIndex uint32, Certificate *WIN_CERTIFICATE, RequiredLength *uint32) (r BOOL, err error) = imagehlp.ImageGetCertificateData
+//sys	ImageGetCertificateHeader(FileHandle HANDLE, CertificateIndex uint32, Certificateheader *WIN_CERTIFICATE) (r BOOL, err error) = imagehlp.ImageGetCertificateHeader
+//sys	ImageLoad(DllName *PSTRElement, DllPath *PSTRElement) (r *LOADED_IMAGE, err error) = imagehlp.ImageLoad
+//sys	ImageUnload(LoadedImage *LOADED_IMAGE) (r BOOL, err error) = imagehlp.ImageUnload
+//sys	MapAndLoad(ImageName *PSTRElement, DllPath *PSTRElement, LoadedImage *LOADED_IMAGE, DotDll BOOL, ReadOnly BOOL) (r BOOL, err error) = imagehlp.MapAndLoad
+//sys	UnMapAndLoad(LoadedImage *LOADED_IMAGE) (r BOOL, err error) = imagehlp.UnMapAndLoad
+//sys	TouchFileTimes(FileHandle HANDLE, pSystemTime *SYSTEMTIME) (r BOOL, err error) = imagehlp.TouchFileTimes
+//sys	UpdateDebugInfoFile(ImageFileName *PSTRElement, SymbolPath *PSTRElement, DebugFilePath *PSTRElement, NtHeaders *IMAGE_NT_HEADERS32) (r BOOL, err error) = imagehlp.UpdateDebugInfoFile
+//sys	UpdateDebugInfoFileEx(ImageFileName *PSTRElement, SymbolPath *PSTRElement, DebugFilePath *PSTRElement, NtHeaders *IMAGE_NT_HEADERS32, OldCheckSum uint32) (r BOOL) = imagehlp.UpdateDebugInfoFileEx
+//sys	SymFindDebugInfoFile(hProcess HANDLE, FileName *PSTRElement, DebugFilePath *PSTRElement, Callback PFIND_DEBUG_FILE_CALLBACK, CallerData unsafe.Pointer) (r HANDLE, err error) = dbghelp.SymFindDebugInfoFile
+//sys	SymFindDebugInfoFileW(hProcess HANDLE, FileName *PWSTRElement, DebugFilePath *PWSTRElement, Callback PFIND_DEBUG_FILE_CALLBACKW, CallerData unsafe.Pointer) (r HANDLE, err error) = dbghelp.SymFindDebugInfoFileW
+//sys	FindDebugInfoFile(FileName *PSTRElement, SymbolPath *PSTRElement, DebugFilePath *PSTRElement) (r HANDLE, err error) = dbghelp.FindDebugInfoFile
+//sys	FindDebugInfoFileEx(FileName *PSTRElement, SymbolPath *PSTRElement, DebugFilePath *PSTRElement, Callback PFIND_DEBUG_FILE_CALLBACK, CallerData unsafe.Pointer) (r HANDLE, err error) = dbghelp.FindDebugInfoFileEx
+//sys	FindDebugInfoFileExW(FileName *PWSTRElement, SymbolPath *PWSTRElement, DebugFilePath *PWSTRElement, Callback PFIND_DEBUG_FILE_CALLBACKW, CallerData unsafe.Pointer) (r HANDLE, err error) = dbghelp.FindDebugInfoFileExW
+//sys	SymFindFileInPath(hprocess HANDLE, SearchPathA *PSTRElement, FileName *PSTRElement, id unsafe.Pointer, two uint32, three uint32, flags SYM_FIND_ID_OPTION, FoundFile *PSTRElement, callback PFINDFILEINPATHCALLBACK, context unsafe.Pointer) (r BOOL, err error) = dbghelp.SymFindFileInPath
+//sys	SymFindFileInPathW(hprocess HANDLE, SearchPathA *PWSTRElement, FileName *PWSTRElement, id unsafe.Pointer, two uint32, three uint32, flags SYM_FIND_ID_OPTION, FoundFile *PWSTRElement, callback PFINDFILEINPATHCALLBACKW, context unsafe.Pointer) (r BOOL, err error) = dbghelp.SymFindFileInPathW
+//sys	SymFindExecutableImage(hProcess HANDLE, FileName *PSTRElement, ImageFilePath *PSTRElement, Callback PFIND_EXE_FILE_CALLBACK, CallerData unsafe.Pointer) (r HANDLE, err error) = dbghelp.SymFindExecutableImage
+//sys	SymFindExecutableImageW(hProcess HANDLE, FileName *PWSTRElement, ImageFilePath *PWSTRElement, Callback PFIND_EXE_FILE_CALLBACKW, CallerData unsafe.Pointer) (r HANDLE, err error) = dbghelp.SymFindExecutableImageW
+//sys	FindExecutableImage(FileName *PSTRElement, SymbolPath *PSTRElement, ImageFilePath *PSTRElement) (r HANDLE, err error) = dbghelp.FindExecutableImage
+//sys	FindExecutableImageEx(FileName *PSTRElement, SymbolPath *PSTRElement, ImageFilePath *PSTRElement, Callback PFIND_EXE_FILE_CALLBACK, CallerData unsafe.Pointer) (r HANDLE, err error) = dbghelp.FindExecutableImageEx
+//sys	FindExecutableImageExW(FileName *PWSTRElement, SymbolPath *PWSTRElement, ImageFilePath *PWSTRElement, Callback PFIND_EXE_FILE_CALLBACKW, CallerData unsafe.Pointer) (r HANDLE, err error) = dbghelp.FindExecutableImageExW
+//sys	ImageDirectoryEntryToDataEx(Base unsafe.Pointer, MappedAsImage BOOLEAN, DirectoryEntry IMAGE_DIRECTORY_ENTRY, Size *uint32, FoundHeader **IMAGE_SECTION_HEADER) (r unsafe.Pointer, err error) = dbghelp.ImageDirectoryEntryToDataEx
+//sys	ImageDirectoryEntryToData(Base unsafe.Pointer, MappedAsImage BOOLEAN, DirectoryEntry IMAGE_DIRECTORY_ENTRY, Size *uint32) (r unsafe.Pointer, err error) = dbghelp.ImageDirectoryEntryToData
+//sys	SearchTreeForFile(RootPath *PSTRElement, InputPathName *PSTRElement, OutputPathBuffer *PSTRElement) (r BOOL, err error) = dbghelp.SearchTreeForFile
+//sys	SearchTreeForFileW(RootPath *PWSTRElement, InputPathName *PWSTRElement, OutputPathBuffer *PWSTRElement) (r BOOL, err error) = dbghelp.SearchTreeForFileW
+//sys	EnumDirTree(hProcess HANDLE, RootPath *PSTRElement, InputPathName *PSTRElement, OutputPathBuffer *PSTRElement, cb PENUMDIRTREE_CALLBACK, data unsafe.Pointer) (r BOOL, err error) = dbghelp.EnumDirTree
+//sys	EnumDirTreeW(hProcess HANDLE, RootPath *PWSTRElement, InputPathName *PWSTRElement, OutputPathBuffer *PWSTRElement, cb PENUMDIRTREE_CALLBACKW, data unsafe.Pointer) (r BOOL, err error) = dbghelp.EnumDirTreeW
+//sys	MakeSureDirectoryPathExists(DirPath *PSTRElement) (r BOOL, err error) = dbghelp.MakeSureDirectoryPathExists
+//sys	UnDecorateSymbolName(name *PSTRElement, outputString *PSTRElement, maxStringLength uint32, flags uint32) (r uint32, err error) = dbghelp.UnDecorateSymbolName
+//sys	UnDecorateSymbolNameW(name *PWSTRElement, outputString *PWSTRElement, maxStringLength uint32, flags uint32) (r uint32, err error) = dbghelp.UnDecorateSymbolNameW
+//sys	StackWalk64(MachineType uint32, hProcess HANDLE, hThread HANDLE, StackFrame *STACKFRAME64, ContextRecord unsafe.Pointer, ReadMemoryRoutine PREAD_PROCESS_MEMORY_ROUTINE64, FunctionTableAccessRoutine PFUNCTION_TABLE_ACCESS_ROUTINE64, GetModuleBaseRoutine PGET_MODULE_BASE_ROUTINE64, TranslateAddress PTRANSLATE_ADDRESS_ROUTINE64) (r BOOL) = dbghelp.StackWalk64
+//sys	StackWalkEx(MachineType uint32, hProcess HANDLE, hThread HANDLE, StackFrame *STACKFRAME_EX, ContextRecord unsafe.Pointer, ReadMemoryRoutine PREAD_PROCESS_MEMORY_ROUTINE64, FunctionTableAccessRoutine PFUNCTION_TABLE_ACCESS_ROUTINE64, GetModuleBaseRoutine PGET_MODULE_BASE_ROUTINE64, TranslateAddress PTRANSLATE_ADDRESS_ROUTINE64, Flags uint32) (r BOOL) = dbghelp.StackWalkEx
+//sys	StackWalk2(MachineType uint32, hProcess HANDLE, hThread HANDLE, StackFrame *STACKFRAME_EX, ContextRecord unsafe.Pointer, ReadMemoryRoutine PREAD_PROCESS_MEMORY_ROUTINE64, FunctionTableAccessRoutine PFUNCTION_TABLE_ACCESS_ROUTINE64, GetModuleBaseRoutine PGET_MODULE_BASE_ROUTINE64, TranslateAddress PTRANSLATE_ADDRESS_ROUTINE64, GetTargetAttributeValue PGET_TARGET_ATTRIBUTE_VALUE64, Flags uint32) (r BOOL) = dbghelp.StackWalk2
+//sys	ImagehlpApiVersion() (r *API_VERSION) = dbghelp.ImagehlpApiVersion
+//sys	ImagehlpApiVersionEx(AppVersion *API_VERSION) (r *API_VERSION) = dbghelp.ImagehlpApiVersionEx
+//sys	GetTimestampForLoadedLibrary(Module HMODULE) (r uint32, err error) = dbghelp.GetTimestampForLoadedLibrary
+//sys	SymSetParentWindow(hwnd HWND) (r BOOL, err error) = dbghelp.SymSetParentWindow
+//sys	SymGetParentWindow(pHwnd *HWND) (r BOOL) = dbghelp.SymGetParentWindow
+//sys	SymSetHomeDirectory(hProcess HANDLE, dir *PSTRElement) (r *PSTRElement, err error) = dbghelp.SymSetHomeDirectory
+//sys	SymSetHomeDirectoryW(hProcess HANDLE, dir *PWSTRElement) (r *PWSTRElement, err error) = dbghelp.SymSetHomeDirectoryW
+//sys	SymGetHomeDirectory(typeParam uint32, dir *PSTRElement, size uintptr) (r *PSTRElement, err error) = dbghelp.SymGetHomeDirectory
+//sys	SymGetHomeDirectoryW(typeParam uint32, dir *PWSTRElement, size uintptr) (r *PWSTRElement, err error) = dbghelp.SymGetHomeDirectoryW
+//sys	SymGetOmaps(hProcess HANDLE, BaseOfDll uint64, OmapTo **OMAP, cOmapTo *uint64, OmapFrom **OMAP, cOmapFrom *uint64) (r BOOL, err error) = dbghelp.SymGetOmaps
+//sys	SymSetOptions(SymOptions uint32) (r uint32) = dbghelp.SymSetOptions
+//sys	SymGetOptions() (r uint32) = dbghelp.SymGetOptions
+//sys	SymCleanup(hProcess HANDLE) (r BOOL, err error) = dbghelp.SymCleanup
+//sys	SymGetExtendedOption(option IMAGEHLP_EXTENDED_OPTIONS) (r BOOL) = dbghelp.SymGetExtendedOption
+//sys	SymSetExtendedOption(option IMAGEHLP_EXTENDED_OPTIONS, value BOOL) (r BOOL) = dbghelp.SymSetExtendedOption
+//sys	SymMatchString(string *PSTRElement, expression *PSTRElement, fCase BOOL) (r BOOL, err error) = dbghelp.SymMatchString
+//sys	SymMatchStringA(string *PSTRElement, expression *PSTRElement, fCase BOOL) (r BOOL) = dbghelp.SymMatchStringA
+//sys	SymMatchStringW(string *PWSTRElement, expression *PWSTRElement, fCase BOOL) (r BOOL, err error) = dbghelp.SymMatchStringW
+//sys	SymEnumSourceFiles(hProcess HANDLE, ModBase uint64, Mask *PSTRElement, cbSrcFiles PSYM_ENUMSOURCEFILES_CALLBACK, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.SymEnumSourceFiles
+//sys	SymEnumSourceFilesW(hProcess HANDLE, ModBase uint64, Mask *PWSTRElement, cbSrcFiles PSYM_ENUMSOURCEFILES_CALLBACKW, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.SymEnumSourceFilesW
+//sys	SymEnumerateModules64(hProcess HANDLE, EnumModulesCallback PSYM_ENUMMODULES_CALLBACK64, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.SymEnumerateModules64
+//sys	SymEnumerateModulesW64(hProcess HANDLE, EnumModulesCallback PSYM_ENUMMODULES_CALLBACKW64, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.SymEnumerateModulesW64
+//sys	EnumerateLoadedModulesEx(hProcess HANDLE, EnumLoadedModulesCallback PENUMLOADED_MODULES_CALLBACK64, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.EnumerateLoadedModulesEx
+//sys	EnumerateLoadedModulesExW(hProcess HANDLE, EnumLoadedModulesCallback PENUMLOADED_MODULES_CALLBACKW64, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.EnumerateLoadedModulesExW
+//sys	EnumerateLoadedModules64(hProcess HANDLE, EnumLoadedModulesCallback PENUMLOADED_MODULES_CALLBACK64, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.EnumerateLoadedModules64
+//sys	EnumerateLoadedModulesW64(hProcess HANDLE, EnumLoadedModulesCallback PENUMLOADED_MODULES_CALLBACKW64, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.EnumerateLoadedModulesW64
+//sys	SymFunctionTableAccess64(hProcess HANDLE, AddrBase uint64) (r unsafe.Pointer, err error) = dbghelp.SymFunctionTableAccess64
+//sys	SymFunctionTableAccess64AccessRoutines(hProcess HANDLE, AddrBase uint64, ReadMemoryRoutine PREAD_PROCESS_MEMORY_ROUTINE64, GetModuleBaseRoutine PGET_MODULE_BASE_ROUTINE64) (r unsafe.Pointer) = dbghelp.SymFunctionTableAccess64AccessRoutines
+//sys	SymGetUnwindInfo(hProcess HANDLE, Address uint64, Buffer unsafe.Pointer, Size *uint32) (r BOOL) = dbghelp.SymGetUnwindInfo
+//sys	SymGetModuleInfo64(hProcess HANDLE, qwAddr uint64, ModuleInfo *IMAGEHLP_MODULE64) (r BOOL, err error) = dbghelp.SymGetModuleInfo64
+//sys	SymGetModuleInfoW64(hProcess HANDLE, qwAddr uint64, ModuleInfo *IMAGEHLP_MODULEW64) (r BOOL, err error) = dbghelp.SymGetModuleInfoW64
+//sys	SymGetModuleBase64(hProcess HANDLE, qwAddr uint64) (r uint64, err error) = dbghelp.SymGetModuleBase64
+//sys	SymEnumLines(hProcess HANDLE, Base uint64, Obj *PSTRElement, File *PSTRElement, EnumLinesCallback PSYM_ENUMLINES_CALLBACK, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.SymEnumLines
+//sys	SymEnumLinesW(hProcess HANDLE, Base uint64, Obj *PWSTRElement, File *PWSTRElement, EnumLinesCallback PSYM_ENUMLINES_CALLBACKW, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.SymEnumLinesW
+//sys	SymGetLineFromAddr64(hProcess HANDLE, qwAddr uint64, pdwDisplacement *uint32, Line64 *IMAGEHLP_LINE64) (r BOOL, err error) = dbghelp.SymGetLineFromAddr64
+//sys	SymGetLineFromAddrW64(hProcess HANDLE, dwAddr uint64, pdwDisplacement *uint32, Line *IMAGEHLP_LINEW64) (r BOOL, err error) = dbghelp.SymGetLineFromAddrW64
+//sys	SymGetLineFromInlineContext(hProcess HANDLE, qwAddr uint64, InlineContext uint32, qwModuleBaseAddress uint64, pdwDisplacement *uint32, Line64 *IMAGEHLP_LINE64) (r BOOL, err error) = dbghelp.SymGetLineFromInlineContext
+//sys	SymGetLineFromInlineContextW(hProcess HANDLE, dwAddr uint64, InlineContext uint32, qwModuleBaseAddress uint64, pdwDisplacement *uint32, Line *IMAGEHLP_LINEW64) (r BOOL, err error) = dbghelp.SymGetLineFromInlineContextW
+//sys	SymEnumSourceLines(hProcess HANDLE, Base uint64, Obj *PSTRElement, File *PSTRElement, Line uint32, Flags uint32, EnumLinesCallback PSYM_ENUMLINES_CALLBACK, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.SymEnumSourceLines
+//sys	SymEnumSourceLinesW(hProcess HANDLE, Base uint64, Obj *PWSTRElement, File *PWSTRElement, Line uint32, Flags uint32, EnumLinesCallback PSYM_ENUMLINES_CALLBACKW, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.SymEnumSourceLinesW
+//sys	SymAddrIncludeInlineTrace(hProcess HANDLE, Address uint64) (r uint32) = dbghelp.SymAddrIncludeInlineTrace
+//sys	SymCompareInlineTrace(hProcess HANDLE, Address1 uint64, InlineContext1 uint32, RetAddress1 uint64, Address2 uint64, RetAddress2 uint64) (r uint32) = dbghelp.SymCompareInlineTrace
+//sys	SymQueryInlineTrace(hProcess HANDLE, StartAddress uint64, StartContext uint32, StartRetAddress uint64, CurAddress uint64, CurContext *uint32, CurFrameIndex *uint32) (r BOOL, err error) = dbghelp.SymQueryInlineTrace
+//sys	SymGetLineFromName64(hProcess HANDLE, ModuleName *PSTRElement, FileName *PSTRElement, dwLineNumber uint32, plDisplacement *int32, Line *IMAGEHLP_LINE64) (r BOOL, err error) = dbghelp.SymGetLineFromName64
+//sys	SymGetLineFromNameW64(hProcess HANDLE, ModuleName *PWSTRElement, FileName *PWSTRElement, dwLineNumber uint32, plDisplacement *int32, Line *IMAGEHLP_LINEW64) (r BOOL, err error) = dbghelp.SymGetLineFromNameW64
+//sys	SymGetLineNext64(hProcess HANDLE, Line *IMAGEHLP_LINE64) (r BOOL, err error) = dbghelp.SymGetLineNext64
+//sys	SymGetLineNextW64(hProcess HANDLE, Line *IMAGEHLP_LINEW64) (r BOOL, err error) = dbghelp.SymGetLineNextW64
+//sys	SymGetLinePrev64(hProcess HANDLE, Line *IMAGEHLP_LINE64) (r BOOL, err error) = dbghelp.SymGetLinePrev64
+//sys	SymGetLinePrevW64(hProcess HANDLE, Line *IMAGEHLP_LINEW64) (r BOOL, err error) = dbghelp.SymGetLinePrevW64
+//sys	SymGetFileLineOffsets64(hProcess HANDLE, ModuleName *PSTRElement, FileName *PSTRElement, Buffer *uint64, BufferLines uint32) (r uint32, err error) = dbghelp.SymGetFileLineOffsets64
+//sys	SymMatchFileName(FileName *PSTRElement, Match *PSTRElement, FileNameStop **PSTRElement, MatchStop **PSTRElement) (r BOOL, err error) = dbghelp.SymMatchFileName
+//sys	SymMatchFileNameW(FileName *PWSTRElement, Match *PWSTRElement, FileNameStop **PWSTRElement, MatchStop **PWSTRElement) (r BOOL, err error) = dbghelp.SymMatchFileNameW
+//sys	SymGetSourceFile(hProcess HANDLE, Base uint64, Params *PSTRElement, FileSpec *PSTRElement, FilePath *PSTRElement, Size uint32) (r BOOL, err error) = dbghelp.SymGetSourceFile
+//sys	SymGetSourceFileW(hProcess HANDLE, Base uint64, Params *PWSTRElement, FileSpec *PWSTRElement, FilePath *PWSTRElement, Size uint32) (r BOOL, err error) = dbghelp.SymGetSourceFileW
+//sys	SymGetSourceFileToken(hProcess HANDLE, Base uint64, FileSpec *PSTRElement, Token *unsafe.Pointer, Size *uint32) (r BOOL, err error) = dbghelp.SymGetSourceFileToken
+//sys	SymGetSourceFileTokenByTokenName(hProcess HANDLE, Base uint64, FileSpec *PSTRElement, TokenName *PSTRElement, TokenParameters *PSTRElement, Token *unsafe.Pointer, Size *uint32) (r BOOL) = dbghelp.SymGetSourceFileTokenByTokenName
+//sys	SymGetSourceFileChecksumW(hProcess HANDLE, Base uint64, FileSpec *PWSTRElement, pCheckSumType *uint32, pChecksum *uint8, checksumSize uint32, pActualBytesWritten *uint32) (r BOOL, err error) = dbghelp.SymGetSourceFileChecksumW
+//sys	SymGetSourceFileChecksum(hProcess HANDLE, Base uint64, FileSpec *PSTRElement, pCheckSumType *uint32, pChecksum *uint8, checksumSize uint32, pActualBytesWritten *uint32) (r BOOL, err error) = dbghelp.SymGetSourceFileChecksum
+//sys	SymGetSourceFileTokenW(hProcess HANDLE, Base uint64, FileSpec *PWSTRElement, Token *unsafe.Pointer, Size *uint32) (r BOOL, err error) = dbghelp.SymGetSourceFileTokenW
+//sys	SymGetSourceFileTokenByTokenNameW(hProcess HANDLE, Base uint64, FileSpec *PWSTRElement, TokenName *PWSTRElement, TokenParameters *PWSTRElement, Token *unsafe.Pointer, Size *uint32) (r BOOL) = dbghelp.SymGetSourceFileTokenByTokenNameW
+//sys	SymGetSourceFileFromToken(hProcess HANDLE, Token unsafe.Pointer, Params *PSTRElement, FilePath *PSTRElement, Size uint32) (r BOOL, err error) = dbghelp.SymGetSourceFileFromToken
+//sys	SymGetSourceFileFromTokenByTokenName(hProcess HANDLE, Token unsafe.Pointer, TokenName *PSTRElement, Params *PSTRElement, FilePath *PSTRElement, Size uint32) (r BOOL) = dbghelp.SymGetSourceFileFromTokenByTokenName
+//sys	SymGetSourceFileFromTokenW(hProcess HANDLE, Token unsafe.Pointer, Params *PWSTRElement, FilePath *PWSTRElement, Size uint32) (r BOOL, err error) = dbghelp.SymGetSourceFileFromTokenW
+//sys	SymGetSourceFileFromTokenByTokenNameW(hProcess HANDLE, Token unsafe.Pointer, TokenName *PWSTRElement, Params *PWSTRElement, FilePath *PWSTRElement, Size uint32) (r BOOL) = dbghelp.SymGetSourceFileFromTokenByTokenNameW
+//sys	SymGetSourceVarFromToken(hProcess HANDLE, Token unsafe.Pointer, Params *PSTRElement, VarName *PSTRElement, Value *PSTRElement, Size uint32) (r BOOL, err error) = dbghelp.SymGetSourceVarFromToken
+//sys	SymGetSourceVarFromTokenW(hProcess HANDLE, Token unsafe.Pointer, Params *PWSTRElement, VarName *PWSTRElement, Value *PWSTRElement, Size uint32) (r BOOL, err error) = dbghelp.SymGetSourceVarFromTokenW
+//sys	SymEnumSourceFileTokens(hProcess HANDLE, Base uint64, Callback PENUMSOURCEFILETOKENSCALLBACK) (r BOOL, err error) = dbghelp.SymEnumSourceFileTokens
+//sys	SymInitialize(hProcess HANDLE, UserSearchPath *PSTRElement, fInvadeProcess BOOL) (r BOOL, err error) = dbghelp.SymInitialize
+//sys	SymInitializeW(hProcess HANDLE, UserSearchPath *PWSTRElement, fInvadeProcess BOOL) (r BOOL, err error) = dbghelp.SymInitializeW
+//sys	SymGetSearchPath(hProcess HANDLE, SearchPathA *PSTRElement, SearchPathLength uint32) (r BOOL, err error) = dbghelp.SymGetSearchPath
+//sys	SymGetSearchPathW(hProcess HANDLE, SearchPathA *PWSTRElement, SearchPathLength uint32) (r BOOL, err error) = dbghelp.SymGetSearchPathW
+//sys	SymSetSearchPath(hProcess HANDLE, SearchPathA *PSTRElement) (r BOOL, err error) = dbghelp.SymSetSearchPath
+//sys	SymSetSearchPathW(hProcess HANDLE, SearchPathA *PWSTRElement) (r BOOL, err error) = dbghelp.SymSetSearchPathW
+//sys	SymLoadModuleEx(hProcess HANDLE, hFile HANDLE, ImageName *PSTRElement, ModuleName *PSTRElement, BaseOfDll uint64, DllSize uint32, Data *MODLOAD_DATA, Flags SYM_LOAD_FLAGS) (r uint64, err error) = dbghelp.SymLoadModuleEx
+//sys	SymLoadModuleExW(hProcess HANDLE, hFile HANDLE, ImageName *PWSTRElement, ModuleName *PWSTRElement, BaseOfDll uint64, DllSize uint32, Data *MODLOAD_DATA, Flags SYM_LOAD_FLAGS) (r uint64, err error) = dbghelp.SymLoadModuleExW
+//sys	SymUnloadModule64(hProcess HANDLE, BaseOfDll uint64) (r BOOL, err error) = dbghelp.SymUnloadModule64
+//sys	SymUnDName64(sym *IMAGEHLP_SYMBOL64, UnDecName *PSTRElement, UnDecNameLength uint32) (r BOOL, err error) = dbghelp.SymUnDName64
+//sys	SymRegisterCallback64(hProcess HANDLE, CallbackFunction PSYMBOL_REGISTERED_CALLBACK64, UserContext uint64) (r BOOL, err error) = dbghelp.SymRegisterCallback64
+//sys	SymRegisterCallbackW64(hProcess HANDLE, CallbackFunction PSYMBOL_REGISTERED_CALLBACK64, UserContext uint64) (r BOOL, err error) = dbghelp.SymRegisterCallbackW64
+//sys	SymRegisterFunctionEntryCallback64(hProcess HANDLE, CallbackFunction PSYMBOL_FUNCENTRY_CALLBACK64, UserContext uint64) (r BOOL, err error) = dbghelp.SymRegisterFunctionEntryCallback64
+//sys	SymSetContext(hProcess HANDLE, StackFrame *IMAGEHLP_STACK_FRAME, Context unsafe.Pointer) (r BOOL, err error) = dbghelp.SymSetContext
+//sys	SymSetScopeFromAddr(hProcess HANDLE, Address uint64) (r BOOL, err error) = dbghelp.SymSetScopeFromAddr
+//sys	SymSetScopeFromInlineContext(hProcess HANDLE, Address uint64, InlineContext uint32) (r BOOL, err error) = dbghelp.SymSetScopeFromInlineContext
+//sys	SymSetScopeFromIndex(hProcess HANDLE, BaseOfDll uint64, Index uint32) (r BOOL, err error) = dbghelp.SymSetScopeFromIndex
+//sys	SymEnumProcesses(EnumProcessesCallback PSYM_ENUMPROCESSES_CALLBACK, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.SymEnumProcesses
+//sys	SymFromAddr(hProcess HANDLE, Address uint64, Displacement *uint64, Symbol *SYMBOL_INFO) (r BOOL, err error) = dbghelp.SymFromAddr
+//sys	SymFromAddrW(hProcess HANDLE, Address uint64, Displacement *uint64, Symbol *SYMBOL_INFOW) (r BOOL, err error) = dbghelp.SymFromAddrW
+//sys	SymFromInlineContext(hProcess HANDLE, Address uint64, InlineContext uint32, Displacement *uint64, Symbol *SYMBOL_INFO) (r BOOL, err error) = dbghelp.SymFromInlineContext
+//sys	SymFromInlineContextW(hProcess HANDLE, Address uint64, InlineContext uint32, Displacement *uint64, Symbol *SYMBOL_INFOW) (r BOOL, err error) = dbghelp.SymFromInlineContextW
+//sys	SymFromToken(hProcess HANDLE, Base uint64, Token uint32, Symbol *SYMBOL_INFO) (r BOOL, err error) = dbghelp.SymFromToken
+//sys	SymFromTokenW(hProcess HANDLE, Base uint64, Token uint32, Symbol *SYMBOL_INFOW) (r BOOL, err error) = dbghelp.SymFromTokenW
+//sys	SymNext(hProcess HANDLE, si *SYMBOL_INFO) (r BOOL, err error) = dbghelp.SymNext
+//sys	SymNextW(hProcess HANDLE, siw *SYMBOL_INFOW) (r BOOL, err error) = dbghelp.SymNextW
+//sys	SymPrev(hProcess HANDLE, si *SYMBOL_INFO) (r BOOL, err error) = dbghelp.SymPrev
+//sys	SymPrevW(hProcess HANDLE, siw *SYMBOL_INFOW) (r BOOL, err error) = dbghelp.SymPrevW
+//sys	SymFromName(hProcess HANDLE, Name *PSTRElement, Symbol *SYMBOL_INFO) (r BOOL, err error) = dbghelp.SymFromName
+//sys	SymFromNameW(hProcess HANDLE, Name *PWSTRElement, Symbol *SYMBOL_INFOW) (r BOOL, err error) = dbghelp.SymFromNameW
+//sys	SymEnumSymbols(hProcess HANDLE, BaseOfDll uint64, Mask *PSTRElement, EnumSymbolsCallback PSYM_ENUMERATESYMBOLS_CALLBACK, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.SymEnumSymbols
+//sys	SymEnumSymbolsEx(hProcess HANDLE, BaseOfDll uint64, Mask *PSTRElement, EnumSymbolsCallback PSYM_ENUMERATESYMBOLS_CALLBACK, UserContext unsafe.Pointer, Options uint32) (r BOOL, err error) = dbghelp.SymEnumSymbolsEx
+//sys	SymEnumSymbolsW(hProcess HANDLE, BaseOfDll uint64, Mask *PWSTRElement, EnumSymbolsCallback PSYM_ENUMERATESYMBOLS_CALLBACKW, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.SymEnumSymbolsW
+//sys	SymEnumSymbolsExW(hProcess HANDLE, BaseOfDll uint64, Mask *PWSTRElement, EnumSymbolsCallback PSYM_ENUMERATESYMBOLS_CALLBACKW, UserContext unsafe.Pointer, Options uint32) (r BOOL, err error) = dbghelp.SymEnumSymbolsExW
+//sys	SymEnumSymbolsForAddr(hProcess HANDLE, Address uint64, EnumSymbolsCallback PSYM_ENUMERATESYMBOLS_CALLBACK, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.SymEnumSymbolsForAddr
+//sys	SymEnumSymbolsForAddrW(hProcess HANDLE, Address uint64, EnumSymbolsCallback PSYM_ENUMERATESYMBOLS_CALLBACKW, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.SymEnumSymbolsForAddrW
+//sys	SymSearch(hProcess HANDLE, BaseOfDll uint64, Index uint32, SymTag uint32, Mask *PSTRElement, Address uint64, EnumSymbolsCallback PSYM_ENUMERATESYMBOLS_CALLBACK, UserContext unsafe.Pointer, Options uint32) (r BOOL, err error) = dbghelp.SymSearch
+//sys	SymSearchW(hProcess HANDLE, BaseOfDll uint64, Index uint32, SymTag uint32, Mask *PWSTRElement, Address uint64, EnumSymbolsCallback PSYM_ENUMERATESYMBOLS_CALLBACKW, UserContext unsafe.Pointer, Options uint32) (r BOOL, err error) = dbghelp.SymSearchW
+//sys	SymGetScope(hProcess HANDLE, BaseOfDll uint64, Index uint32, Symbol *SYMBOL_INFO) (r BOOL, err error) = dbghelp.SymGetScope
+//sys	SymGetScopeW(hProcess HANDLE, BaseOfDll uint64, Index uint32, Symbol *SYMBOL_INFOW) (r BOOL, err error) = dbghelp.SymGetScopeW
+//sys	SymFromIndex(hProcess HANDLE, BaseOfDll uint64, Index uint32, Symbol *SYMBOL_INFO) (r BOOL, err error) = dbghelp.SymFromIndex
+//sys	SymFromIndexW(hProcess HANDLE, BaseOfDll uint64, Index uint32, Symbol *SYMBOL_INFOW) (r BOOL, err error) = dbghelp.SymFromIndexW
+//sys	SymGetTypeInfo(hProcess HANDLE, ModBase uint64, TypeId uint32, GetType IMAGEHLP_SYMBOL_TYPE_INFO, pInfo unsafe.Pointer) (r BOOL, err error) = dbghelp.SymGetTypeInfo
+//sys	SymGetTypeInfoEx(hProcess HANDLE, ModBase uint64, Params *IMAGEHLP_GET_TYPE_INFO_PARAMS) (r BOOL, err error) = dbghelp.SymGetTypeInfoEx
+//sys	SymEnumTypes(hProcess HANDLE, BaseOfDll uint64, EnumSymbolsCallback PSYM_ENUMERATESYMBOLS_CALLBACK, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.SymEnumTypes
+//sys	SymEnumTypesW(hProcess HANDLE, BaseOfDll uint64, EnumSymbolsCallback PSYM_ENUMERATESYMBOLS_CALLBACKW, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.SymEnumTypesW
+//sys	SymEnumTypesByName(hProcess HANDLE, BaseOfDll uint64, mask *PSTRElement, EnumSymbolsCallback PSYM_ENUMERATESYMBOLS_CALLBACK, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.SymEnumTypesByName
+//sys	SymEnumTypesByNameW(hProcess HANDLE, BaseOfDll uint64, mask *PWSTRElement, EnumSymbolsCallback PSYM_ENUMERATESYMBOLS_CALLBACKW, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.SymEnumTypesByNameW
+//sys	SymGetTypeFromName(hProcess HANDLE, BaseOfDll uint64, Name *PSTRElement, Symbol *SYMBOL_INFO) (r BOOL, err error) = dbghelp.SymGetTypeFromName
+//sys	SymGetTypeFromNameW(hProcess HANDLE, BaseOfDll uint64, Name *PWSTRElement, Symbol *SYMBOL_INFOW) (r BOOL, err error) = dbghelp.SymGetTypeFromNameW
+//sys	SymAddSymbol(hProcess HANDLE, BaseOfDll uint64, Name *PSTRElement, Address uint64, Size uint32, Flags uint32) (r BOOL, err error) = dbghelp.SymAddSymbol
+//sys	SymAddSymbolW(hProcess HANDLE, BaseOfDll uint64, Name *PWSTRElement, Address uint64, Size uint32, Flags uint32) (r BOOL, err error) = dbghelp.SymAddSymbolW
+//sys	SymDeleteSymbol(hProcess HANDLE, BaseOfDll uint64, Name *PSTRElement, Address uint64, Flags uint32) (r BOOL, err error) = dbghelp.SymDeleteSymbol
+//sys	SymDeleteSymbolW(hProcess HANDLE, BaseOfDll uint64, Name *PWSTRElement, Address uint64, Flags uint32) (r BOOL, err error) = dbghelp.SymDeleteSymbolW
+//sys	SymRefreshModuleList(hProcess HANDLE) (r BOOL, err error) = dbghelp.SymRefreshModuleList
+//sys	SymAddSourceStream(hProcess HANDLE, Base uint64, StreamFile *PSTRElement, Buffer *uint8, Size uintptr) (r BOOL, err error) = dbghelp.SymAddSourceStream
+//sys	SymAddSourceStreamA(hProcess HANDLE, Base uint64, StreamFile *PSTRElement, Buffer *uint8, Size uintptr) (r BOOL) = dbghelp.SymAddSourceStreamA
+//sys	SymAddSourceStreamW(hProcess HANDLE, Base uint64, FileSpec *PWSTRElement, Buffer *uint8, Size uintptr) (r BOOL, err error) = dbghelp.SymAddSourceStreamW
+//sys	SymSrvIsStoreW(hProcess HANDLE, path *PWSTRElement) (r BOOL, err error) = dbghelp.SymSrvIsStoreW
+//sys	SymSrvIsStore(hProcess HANDLE, path *PSTRElement) (r BOOL, err error) = dbghelp.SymSrvIsStore
+//sys	SymSrvDeltaName(hProcess HANDLE, SymPath *PSTRElement, Type *PSTRElement, File1 *PSTRElement, File2 *PSTRElement) (r *PSTRElement, err error) = dbghelp.SymSrvDeltaName
+//sys	SymSrvDeltaNameW(hProcess HANDLE, SymPath *PWSTRElement, Type *PWSTRElement, File1 *PWSTRElement, File2 *PWSTRElement) (r *PWSTRElement, err error) = dbghelp.SymSrvDeltaNameW
+//sys	SymSrvGetSupplement(hProcess HANDLE, SymPath *PSTRElement, Node *PSTRElement, File *PSTRElement) (r *PSTRElement, err error) = dbghelp.SymSrvGetSupplement
+//sys	SymSrvGetSupplementW(hProcess HANDLE, SymPath *PWSTRElement, Node *PWSTRElement, File *PWSTRElement) (r *PWSTRElement, err error) = dbghelp.SymSrvGetSupplementW
+//sys	SymSrvGetFileIndexes(File *PSTRElement, Id *Guid, Val1 *uint32, Val2 *uint32, Flags uint32) (r BOOL, err error) = dbghelp.SymSrvGetFileIndexes
+//sys	SymSrvGetFileIndexesW(File *PWSTRElement, Id *Guid, Val1 *uint32, Val2 *uint32, Flags uint32) (r BOOL, err error) = dbghelp.SymSrvGetFileIndexesW
+//sys	SymSrvGetFileIndexStringW(hProcess HANDLE, SrvPath *PWSTRElement, File *PWSTRElement, Index *PWSTRElement, Size uintptr, Flags uint32) (r BOOL, err error) = dbghelp.SymSrvGetFileIndexStringW
+//sys	SymSrvGetFileIndexString(hProcess HANDLE, SrvPath *PSTRElement, File *PSTRElement, Index *PSTRElement, Size uintptr, Flags uint32) (r BOOL, err error) = dbghelp.SymSrvGetFileIndexString
+//sys	SymSrvGetFileIndexInfo(File *PSTRElement, Info *SYMSRV_INDEX_INFO, Flags uint32) (r BOOL, err error) = dbghelp.SymSrvGetFileIndexInfo
+//sys	SymSrvGetFileIndexInfoW(File *PWSTRElement, Info *SYMSRV_INDEX_INFOW, Flags uint32) (r BOOL, err error) = dbghelp.SymSrvGetFileIndexInfoW
+//sys	SymSrvStoreSupplement(hProcess HANDLE, SrvPath *PSTRElement, Node *PSTRElement, File *PSTRElement, Flags uint32) (r *PSTRElement, err error) = dbghelp.SymSrvStoreSupplement
+//sys	SymSrvStoreSupplementW(hProcess HANDLE, SymPath *PWSTRElement, Node *PWSTRElement, File *PWSTRElement, Flags uint32) (r *PWSTRElement, err error) = dbghelp.SymSrvStoreSupplementW
+//sys	SymSrvStoreFile(hProcess HANDLE, SrvPath *PSTRElement, File *PSTRElement, Flags SYM_SRV_STORE_FILE_FLAGS) (r *PSTRElement, err error) = dbghelp.SymSrvStoreFile
+//sys	SymSrvStoreFileW(hProcess HANDLE, SrvPath *PWSTRElement, File *PWSTRElement, Flags SYM_SRV_STORE_FILE_FLAGS) (r *PWSTRElement, err error) = dbghelp.SymSrvStoreFileW
+//sys	SymGetSymbolFile(hProcess HANDLE, SymPath *PSTRElement, ImageFile *PSTRElement, Type uint32, SymbolFile *PSTRElement, cSymbolFile uintptr, DbgFile *PSTRElement, cDbgFile uintptr) (r BOOL, err error) = dbghelp.SymGetSymbolFile
+//sys	SymGetSymbolFileW(hProcess HANDLE, SymPath *PWSTRElement, ImageFile *PWSTRElement, Type uint32, SymbolFile *PWSTRElement, cSymbolFile uintptr, DbgFile *PWSTRElement, cDbgFile uintptr) (r BOOL, err error) = dbghelp.SymGetSymbolFileW
+//sys	DbgHelpCreateUserDump(FileName *PSTRElement, Callback PDBGHELP_CREATE_USER_DUMP_CALLBACK, UserData unsafe.Pointer) (r BOOL) = dbghelp.DbgHelpCreateUserDump
+//sys	DbgHelpCreateUserDumpW(FileName *PWSTRElement, Callback PDBGHELP_CREATE_USER_DUMP_CALLBACK, UserData unsafe.Pointer) (r BOOL) = dbghelp.DbgHelpCreateUserDumpW
+//sys	SymGetSymFromAddr64(hProcess HANDLE, qwAddr uint64, pdwDisplacement *uint64, Symbol *IMAGEHLP_SYMBOL64) (r BOOL, err error) = dbghelp.SymGetSymFromAddr64
+//sys	SymGetSymFromName64(hProcess HANDLE, Name *PSTRElement, Symbol *IMAGEHLP_SYMBOL64) (r BOOL, err error) = dbghelp.SymGetSymFromName64
+//sys	FindFileInPath(hprocess HANDLE, SearchPathA *PSTRElement, FileName *PSTRElement, id unsafe.Pointer, two uint32, three uint32, flags uint32, FilePath *PSTRElement) (r BOOL) = dbghelp.FindFileInPath
+//sys	FindFileInSearchPath(hprocess HANDLE, SearchPathA *PSTRElement, FileName *PSTRElement, one uint32, two uint32, three uint32, FilePath *PSTRElement) (r BOOL) = dbghelp.FindFileInSearchPath
+//sys	SymEnumSym(hProcess HANDLE, BaseOfDll uint64, EnumSymbolsCallback PSYM_ENUMERATESYMBOLS_CALLBACK, UserContext unsafe.Pointer) (r BOOL) = dbghelp.SymEnumSym
+//sys	SymEnumerateSymbols64(hProcess HANDLE, BaseOfDll uint64, EnumSymbolsCallback PSYM_ENUMSYMBOLS_CALLBACK64, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.SymEnumerateSymbols64
+//sys	SymEnumerateSymbolsW64(hProcess HANDLE, BaseOfDll uint64, EnumSymbolsCallback PSYM_ENUMSYMBOLS_CALLBACK64W, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.SymEnumerateSymbolsW64
+//sys	SymLoadModule64(hProcess HANDLE, hFile HANDLE, ImageName *PSTRElement, ModuleName *PSTRElement, BaseOfDll uint64, SizeOfDll uint32) (r uint64, err error) = dbghelp.SymLoadModule64
+//sys	SymGetSymNext64(hProcess HANDLE, Symbol *IMAGEHLP_SYMBOL64) (r BOOL, err error) = dbghelp.SymGetSymNext64
+//sys	SymGetSymPrev64(hProcess HANDLE, Symbol *IMAGEHLP_SYMBOL64) (r BOOL, err error) = dbghelp.SymGetSymPrev64
+//sys	SetCheckUserInterruptShared(lpStartAddress LPCALL_BACK_USER_INTERRUPT_ROUTINE) = dbghelp.SetCheckUserInterruptShared
+//sys	GetSymLoadError() (r uint32) = dbghelp.GetSymLoadError
+//sys	SetSymLoadError(error uint32) = dbghelp.SetSymLoadError
+//sys	ReportSymbolLoadSummary(hProcess HANDLE, pLoadModule *PWSTRElement, pSymbolData *DBGHELP_DATA_REPORT_STRUCT) (r BOOL) = dbghelp.ReportSymbolLoadSummary
+//sys	RemoveInvalidModuleList(hProcess HANDLE) = dbghelp.RemoveInvalidModuleList
+//sys	RangeMapCreate() (r unsafe.Pointer) = dbghelp.RangeMapCreate
+//sys	RangeMapFree(RmapHandle unsafe.Pointer) = dbghelp.RangeMapFree
+//sys	RangeMapAddPeImageSections(RmapHandle unsafe.Pointer, ImageName *PWSTRElement, MappedImage unsafe.Pointer, MappingBytes uint32, ImageBase uint64, UserTag uint64, MappingFlags uint32) (r BOOL) = dbghelp.RangeMapAddPeImageSections
+//sys	RangeMapRemove(RmapHandle unsafe.Pointer, UserTag uint64) (r BOOL) = dbghelp.RangeMapRemove
+//sys	RangeMapRead(RmapHandle unsafe.Pointer, Offset uint64, Buffer unsafe.Pointer, RequestBytes uint32, Flags uint32, DoneBytes *uint32) (r BOOL) = dbghelp.RangeMapRead
+//sys	RangeMapWrite(RmapHandle unsafe.Pointer, Offset uint64, Buffer unsafe.Pointer, RequestBytes uint32, Flags uint32, DoneBytes *uint32) (r BOOL) = dbghelp.RangeMapWrite
+//sys	MessageBeep(uType MESSAGEBOX_STYLE) (r BOOL, err error) = user32.MessageBeep
+//sys	FatalExit(ExitCode int32)
+//sys	GetThreadSelectorEntry(hThread HANDLE, dwSelector uint32, lpSelectorEntry *LDT_ENTRY) (r BOOL, err error)
+//sys	Wow64GetThreadSelectorEntry(hThread HANDLE, dwSelector uint32, lpSelectorEntry *WOW64_LDT_ENTRY) (r BOOL, err error)
+//sys	DebugSetProcessKillOnExit(KillOnExit BOOL) (r BOOL, err error)
+//sys	DebugBreakProcess(Process HANDLE) (r BOOL, err error)
+//sys	FormatMessageA(dwFlags FORMAT_MESSAGE_OPTIONS, lpSource unsafe.Pointer, dwMessageId uint32, dwLanguageId uint32, lpBuffer *PSTRElement, nSize uint32, Arguments **int8) (r uint32, err error)
+//sys	FormatMessageW(dwFlags FORMAT_MESSAGE_OPTIONS, lpSource unsafe.Pointer, dwMessageId uint32, dwLanguageId uint32, lpBuffer *PWSTRElement, nSize uint32, Arguments **int8) (r uint32, err error)
+//sys	CopyContext(Destination *CONTEXT, ContextFlags CONTEXT_FLAGS, Source *CONTEXT) (r BOOL, err error)
+//sys	InitializeContext(Buffer unsafe.Pointer, ContextFlags CONTEXT_FLAGS, Context **CONTEXT, ContextLength *uint32) (r BOOL, err error)
+//sys	InitializeContext2(Buffer unsafe.Pointer, ContextFlags CONTEXT_FLAGS, Context **CONTEXT, ContextLength *uint32, XStateCompactionMask uint64) (r BOOL, err error)
+//sys	GetEnabledXStateFeatures() (r uint64)
+//sys	GetXStateFeaturesMask(Context *CONTEXT, FeatureMask *uint64) (r BOOL)
+//sys	LocateXStateFeature(Context *CONTEXT, FeatureId uint32, Length *uint32) (r unsafe.Pointer)
+//sys	SetXStateFeaturesMask(Context *CONTEXT, FeatureMask uint64) (r BOOL)
 
 // APIs for Windows.Win32.Storage.FileSystem
-//sys	SearchPathW(lpPath *PWSTRElement, lpFileName *PWSTRElement, lpExtension *PWSTRElement, nBufferLength uint32, lpBuffer *PWSTRElement, lpFilePart **PWSTRElement) (r uint32, err error) = kernel32.dll.SearchPathW
-//sys	SearchPathA(lpPath *PSTRElement, lpFileName *PSTRElement, lpExtension *PSTRElement, nBufferLength uint32, lpBuffer *PSTRElement, lpFilePart **PSTRElement) (r uint32, err error) = kernel32.dll.SearchPathA
-//sys	CompareFileTime(lpFileTime1 *FILETIME, lpFileTime2 *FILETIME) (r int32) = kernel32.dll.CompareFileTime
-//sys	CreateDirectoryA(lpPathName *PSTRElement, lpSecurityAttributes *SECURITY_ATTRIBUTES) (r BOOL, err error) = kernel32.dll.CreateDirectoryA
-//sys	CreateDirectoryW(lpPathName *PWSTRElement, lpSecurityAttributes *SECURITY_ATTRIBUTES) (r BOOL, err error) = kernel32.dll.CreateDirectoryW
-//sys	CreateFileA(lpFileName *PSTRElement, dwDesiredAccess uint32, dwShareMode FILE_SHARE_MODE, lpSecurityAttributes *SECURITY_ATTRIBUTES, dwCreationDisposition FILE_CREATION_DISPOSITION, dwFlagsAndAttributes FILE_FLAGS_AND_ATTRIBUTES, hTemplateFile HANDLE) (r HANDLE, err error) = kernel32.dll.CreateFileA
-//sys	CreateFileW(lpFileName *PWSTRElement, dwDesiredAccess uint32, dwShareMode FILE_SHARE_MODE, lpSecurityAttributes *SECURITY_ATTRIBUTES, dwCreationDisposition FILE_CREATION_DISPOSITION, dwFlagsAndAttributes FILE_FLAGS_AND_ATTRIBUTES, hTemplateFile HANDLE) (r HANDLE, err error) = kernel32.dll.CreateFileW
-//sys	DefineDosDeviceW(dwFlags DEFINE_DOS_DEVICE_FLAGS, lpDeviceName *PWSTRElement, lpTargetPath *PWSTRElement) (r BOOL, err error) = kernel32.dll.DefineDosDeviceW
-//sys	DeleteFileA(lpFileName *PSTRElement) (r BOOL, err error) = kernel32.dll.DeleteFileA
-//sys	DeleteFileW(lpFileName *PWSTRElement) (r BOOL, err error) = kernel32.dll.DeleteFileW
-//sys	DeleteVolumeMountPointW(lpszVolumeMountPoint *PWSTRElement) (r BOOL, err error) = kernel32.dll.DeleteVolumeMountPointW
-//sys	FileTimeToLocalFileTime(lpFileTime *FILETIME, lpLocalFileTime *FILETIME) (r BOOL, err error) = kernel32.dll.FileTimeToLocalFileTime
-//sys	FindClose(hFindFile HANDLE) (r BOOL, err error) = kernel32.dll.FindClose
-//sys	FindCloseChangeNotification(hChangeHandle HANDLE) (r BOOL, err error) = kernel32.dll.FindCloseChangeNotification
-//sys	FindFirstChangeNotificationA(lpPathName *PSTRElement, bWatchSubtree BOOL, dwNotifyFilter FILE_NOTIFY_CHANGE) (r HANDLE, err error) = kernel32.dll.FindFirstChangeNotificationA
-//sys	FindFirstChangeNotificationW(lpPathName *PWSTRElement, bWatchSubtree BOOL, dwNotifyFilter FILE_NOTIFY_CHANGE) (r HANDLE, err error) = kernel32.dll.FindFirstChangeNotificationW
-//sys	FindFirstFileA(lpFileName *PSTRElement, lpFindFileData *WIN32_FIND_DATAA) (r HANDLE, err error) = kernel32.dll.FindFirstFileA
-//sys	FindFirstFileW(lpFileName *PWSTRElement, lpFindFileData *WIN32_FIND_DATAW) (r HANDLE, err error) = kernel32.dll.FindFirstFileW
-//sys	FindFirstFileExA(lpFileName *PSTRElement, fInfoLevelId FINDEX_INFO_LEVELS, lpFindFileData unsafe.Pointer, fSearchOp FINDEX_SEARCH_OPS, lpSearchFilter unsafe.Pointer, dwAdditionalFlags FIND_FIRST_EX_FLAGS) (r HANDLE, err error) = kernel32.dll.FindFirstFileExA
-//sys	FindFirstFileExW(lpFileName *PWSTRElement, fInfoLevelId FINDEX_INFO_LEVELS, lpFindFileData unsafe.Pointer, fSearchOp FINDEX_SEARCH_OPS, lpSearchFilter unsafe.Pointer, dwAdditionalFlags FIND_FIRST_EX_FLAGS) (r HANDLE, err error) = kernel32.dll.FindFirstFileExW
-//sys	FindFirstVolumeW(lpszVolumeName *PWSTRElement, cchBufferLength uint32) (r HANDLE, err error) = kernel32.dll.FindFirstVolumeW
-//sys	FindNextChangeNotification(hChangeHandle HANDLE) (r BOOL, err error) = kernel32.dll.FindNextChangeNotification
-//sys	FindNextFileA(hFindFile HANDLE, lpFindFileData *WIN32_FIND_DATAA) (r BOOL, err error) = kernel32.dll.FindNextFileA
-//sys	FindNextFileW(hFindFile HANDLE, lpFindFileData *WIN32_FIND_DATAW) (r BOOL, err error) = kernel32.dll.FindNextFileW
-//sys	FindNextVolumeW(hFindVolume HANDLE, lpszVolumeName *PWSTRElement, cchBufferLength uint32) (r BOOL, err error) = kernel32.dll.FindNextVolumeW
-//sys	FindVolumeClose(hFindVolume HANDLE) (r BOOL, err error) = kernel32.dll.FindVolumeClose
-//sys	FlushFileBuffers(hFile HANDLE) (r BOOL, err error) = kernel32.dll.FlushFileBuffers
-//sys	GetDiskFreeSpaceA(lpRootPathName *PSTRElement, lpSectorsPerCluster *uint32, lpBytesPerSector *uint32, lpNumberOfFreeClusters *uint32, lpTotalNumberOfClusters *uint32) (r BOOL, err error) = kernel32.dll.GetDiskFreeSpaceA
-//sys	GetDiskFreeSpaceW(lpRootPathName *PWSTRElement, lpSectorsPerCluster *uint32, lpBytesPerSector *uint32, lpNumberOfFreeClusters *uint32, lpTotalNumberOfClusters *uint32) (r BOOL, err error) = kernel32.dll.GetDiskFreeSpaceW
-//sys	GetDiskFreeSpaceExA(lpDirectoryName *PSTRElement, lpFreeBytesAvailableToCaller *uint64, lpTotalNumberOfBytes *uint64, lpTotalNumberOfFreeBytes *uint64) (r BOOL, err error) = kernel32.dll.GetDiskFreeSpaceExA
-//sys	GetDiskFreeSpaceExW(lpDirectoryName *PWSTRElement, lpFreeBytesAvailableToCaller *uint64, lpTotalNumberOfBytes *uint64, lpTotalNumberOfFreeBytes *uint64) (r BOOL, err error) = kernel32.dll.GetDiskFreeSpaceExW
-//sys	GetDiskSpaceInformationA(rootPath *PSTRElement, diskSpaceInfo *DISK_SPACE_INFORMATION) (r HRESULT) = kernel32.dll.GetDiskSpaceInformationA
-//sys	GetDiskSpaceInformationW(rootPath *PWSTRElement, diskSpaceInfo *DISK_SPACE_INFORMATION) (r HRESULT) = kernel32.dll.GetDiskSpaceInformationW
-//sys	GetDriveTypeA(lpRootPathName *PSTRElement) (r uint32) = kernel32.dll.GetDriveTypeA
-//sys	GetDriveTypeW(lpRootPathName *PWSTRElement) (r uint32) = kernel32.dll.GetDriveTypeW
-//sys	GetFileAttributesA(lpFileName *PSTRElement) (r uint32, err error) = kernel32.dll.GetFileAttributesA
-//sys	GetFileAttributesW(lpFileName *PWSTRElement) (r uint32, err error) = kernel32.dll.GetFileAttributesW
-//sys	GetFileAttributesExA(lpFileName *PSTRElement, fInfoLevelId GET_FILEEX_INFO_LEVELS, lpFileInformation unsafe.Pointer) (r BOOL, err error) = kernel32.dll.GetFileAttributesExA
-//sys	GetFileAttributesExW(lpFileName *PWSTRElement, fInfoLevelId GET_FILEEX_INFO_LEVELS, lpFileInformation unsafe.Pointer) (r BOOL, err error) = kernel32.dll.GetFileAttributesExW
-//sys	GetFileInformationByHandle(hFile HANDLE, lpFileInformation *BY_HANDLE_FILE_INFORMATION) (r BOOL, err error) = kernel32.dll.GetFileInformationByHandle
-//sys	GetFileSize(hFile HANDLE, lpFileSizeHigh *uint32) (r uint32, err error) = kernel32.dll.GetFileSize
-//sys	GetFileSizeEx(hFile HANDLE, lpFileSize *int64) (r BOOL, err error) = kernel32.dll.GetFileSizeEx
-//sys	GetFileType(hFile HANDLE) (r FILE_TYPE, err error) = kernel32.dll.GetFileType
-//sys	GetFinalPathNameByHandleA(hFile HANDLE, lpszFilePath *PSTRElement, cchFilePath uint32, dwFlags GETFINALPATHNAMEBYHANDLE_FLAGS) (r uint32, err error) = kernel32.dll.GetFinalPathNameByHandleA
-//sys	GetFinalPathNameByHandleW(hFile HANDLE, lpszFilePath *PWSTRElement, cchFilePath uint32, dwFlags GETFINALPATHNAMEBYHANDLE_FLAGS) (r uint32, err error) = kernel32.dll.GetFinalPathNameByHandleW
-//sys	GetFileTime(hFile HANDLE, lpCreationTime *FILETIME, lpLastAccessTime *FILETIME, lpLastWriteTime *FILETIME) (r BOOL, err error) = kernel32.dll.GetFileTime
-//sys	GetFullPathNameW(lpFileName *PWSTRElement, nBufferLength uint32, lpBuffer *PWSTRElement, lpFilePart **PWSTRElement) (r uint32, err error) = kernel32.dll.GetFullPathNameW
-//sys	GetFullPathNameA(lpFileName *PSTRElement, nBufferLength uint32, lpBuffer *PSTRElement, lpFilePart **PSTRElement) (r uint32, err error) = kernel32.dll.GetFullPathNameA
-//sys	GetLogicalDrives() (r uint32, err error) = kernel32.dll.GetLogicalDrives
-//sys	GetLogicalDriveStringsW(nBufferLength uint32, lpBuffer *PWSTRElement) (r uint32, err error) = kernel32.dll.GetLogicalDriveStringsW
-//sys	GetLongPathNameA(lpszShortPath *PSTRElement, lpszLongPath *PSTRElement, cchBuffer uint32) (r uint32, err error) = kernel32.dll.GetLongPathNameA
-//sys	GetLongPathNameW(lpszShortPath *PWSTRElement, lpszLongPath *PWSTRElement, cchBuffer uint32) (r uint32, err error) = kernel32.dll.GetLongPathNameW
-//sys	AreShortNamesEnabled(Handle HANDLE, Enabled *BOOL) (r BOOL) = kernel32.dll.AreShortNamesEnabled
-//sys	GetShortPathNameW(lpszLongPath *PWSTRElement, lpszShortPath *PWSTRElement, cchBuffer uint32) (r uint32, err error) = kernel32.dll.GetShortPathNameW
-//sys	GetTempFileNameW(lpPathName *PWSTRElement, lpPrefixString *PWSTRElement, uUnique uint32, lpTempFileName *PWSTRElement) (r uint32, err error) = kernel32.dll.GetTempFileNameW
-//sys	GetVolumeInformationByHandleW(hFile HANDLE, lpVolumeNameBuffer *PWSTRElement, nVolumeNameSize uint32, lpVolumeSerialNumber *uint32, lpMaximumComponentLength *uint32, lpFileSystemFlags *uint32, lpFileSystemNameBuffer *PWSTRElement, nFileSystemNameSize uint32) (r BOOL, err error) = kernel32.dll.GetVolumeInformationByHandleW
-//sys	GetVolumeInformationW(lpRootPathName *PWSTRElement, lpVolumeNameBuffer *PWSTRElement, nVolumeNameSize uint32, lpVolumeSerialNumber *uint32, lpMaximumComponentLength *uint32, lpFileSystemFlags *uint32, lpFileSystemNameBuffer *PWSTRElement, nFileSystemNameSize uint32) (r BOOL, err error) = kernel32.dll.GetVolumeInformationW
-//sys	GetVolumePathNameW(lpszFileName *PWSTRElement, lpszVolumePathName *PWSTRElement, cchBufferLength uint32) (r BOOL, err error) = kernel32.dll.GetVolumePathNameW
-//sys	LocalFileTimeToFileTime(lpLocalFileTime *FILETIME, lpFileTime *FILETIME) (r BOOL, err error) = kernel32.dll.LocalFileTimeToFileTime
-//sys	LockFile(hFile HANDLE, dwFileOffsetLow uint32, dwFileOffsetHigh uint32, nNumberOfBytesToLockLow uint32, nNumberOfBytesToLockHigh uint32) (r BOOL, err error) = kernel32.dll.LockFile
-//sys	LockFileEx(hFile HANDLE, dwFlags LOCK_FILE_FLAGS, dwReserved uint32, nNumberOfBytesToLockLow uint32, nNumberOfBytesToLockHigh uint32, lpOverlapped *OVERLAPPED) (r BOOL, err error) = kernel32.dll.LockFileEx
-//sys	QueryDosDeviceW(lpDeviceName *PWSTRElement, lpTargetPath *PWSTRElement, ucchMax uint32) (r uint32, err error) = kernel32.dll.QueryDosDeviceW
-//sys	ReadFile(hFile HANDLE, lpBuffer *uint8, nNumberOfBytesToRead uint32, lpNumberOfBytesRead *uint32, lpOverlapped *OVERLAPPED) (r BOOL, err error) = kernel32.dll.ReadFile
-//sys	ReadFileEx(hFile HANDLE, lpBuffer *uint8, nNumberOfBytesToRead uint32, lpOverlapped *OVERLAPPED, lpCompletionRoutine LPOVERLAPPED_COMPLETION_ROUTINE) (r BOOL, err error) = kernel32.dll.ReadFileEx
-//sys	ReadFileScatter(hFile HANDLE, aSegmentArray *FILE_SEGMENT_ELEMENT, nNumberOfBytesToRead uint32, lpReserved *uint32, lpOverlapped *OVERLAPPED) (r BOOL, err error) = kernel32.dll.ReadFileScatter
-//sys	RemoveDirectoryA(lpPathName *PSTRElement) (r BOOL, err error) = kernel32.dll.RemoveDirectoryA
-//sys	RemoveDirectoryW(lpPathName *PWSTRElement) (r BOOL, err error) = kernel32.dll.RemoveDirectoryW
-//sys	SetEndOfFile(hFile HANDLE) (r BOOL, err error) = kernel32.dll.SetEndOfFile
-//sys	SetFileAttributesA(lpFileName *PSTRElement, dwFileAttributes FILE_FLAGS_AND_ATTRIBUTES) (r BOOL, err error) = kernel32.dll.SetFileAttributesA
-//sys	SetFileAttributesW(lpFileName *PWSTRElement, dwFileAttributes FILE_FLAGS_AND_ATTRIBUTES) (r BOOL, err error) = kernel32.dll.SetFileAttributesW
-//sys	SetFileInformationByHandle(hFile HANDLE, FileInformationClass FILE_INFO_BY_HANDLE_CLASS, lpFileInformation unsafe.Pointer, dwBufferSize uint32) (r BOOL, err error) = kernel32.dll.SetFileInformationByHandle
-//sys	SetFilePointer(hFile HANDLE, lDistanceToMove int32, lpDistanceToMoveHigh *int32, dwMoveMethod SET_FILE_POINTER_MOVE_METHOD) (r uint32, err error) = kernel32.dll.SetFilePointer
-//sys	SetFilePointerEx(hFile HANDLE, liDistanceToMove int64, lpNewFilePointer *int64, dwMoveMethod SET_FILE_POINTER_MOVE_METHOD) (r BOOL, err error) = kernel32.dll.SetFilePointerEx
-//sys	SetFileTime(hFile HANDLE, lpCreationTime *FILETIME, lpLastAccessTime *FILETIME, lpLastWriteTime *FILETIME) (r BOOL, err error) = kernel32.dll.SetFileTime
-//sys	SetFileValidData(hFile HANDLE, ValidDataLength int64) (r BOOL, err error) = kernel32.dll.SetFileValidData
-//sys	UnlockFile(hFile HANDLE, dwFileOffsetLow uint32, dwFileOffsetHigh uint32, nNumberOfBytesToUnlockLow uint32, nNumberOfBytesToUnlockHigh uint32) (r BOOL, err error) = kernel32.dll.UnlockFile
-//sys	UnlockFileEx(hFile HANDLE, dwReserved uint32, nNumberOfBytesToUnlockLow uint32, nNumberOfBytesToUnlockHigh uint32, lpOverlapped *OVERLAPPED) (r BOOL, err error) = kernel32.dll.UnlockFileEx
-//sys	WriteFile(hFile HANDLE, lpBuffer *uint8, nNumberOfBytesToWrite uint32, lpNumberOfBytesWritten *uint32, lpOverlapped *OVERLAPPED) (r BOOL, err error) = kernel32.dll.WriteFile
-//sys	WriteFileEx(hFile HANDLE, lpBuffer *uint8, nNumberOfBytesToWrite uint32, lpOverlapped *OVERLAPPED, lpCompletionRoutine LPOVERLAPPED_COMPLETION_ROUTINE) (r BOOL, err error) = kernel32.dll.WriteFileEx
-//sys	WriteFileGather(hFile HANDLE, aSegmentArray *FILE_SEGMENT_ELEMENT, nNumberOfBytesToWrite uint32, lpReserved *uint32, lpOverlapped *OVERLAPPED) (r BOOL, err error) = kernel32.dll.WriteFileGather
-//sys	GetTempPathW(nBufferLength uint32, lpBuffer *PWSTRElement) (r uint32, err error) = kernel32.dll.GetTempPathW
-//sys	GetVolumeNameForVolumeMountPointW(lpszVolumeMountPoint *PWSTRElement, lpszVolumeName *PWSTRElement, cchBufferLength uint32) (r BOOL, err error) = kernel32.dll.GetVolumeNameForVolumeMountPointW
-//sys	GetVolumePathNamesForVolumeNameW(lpszVolumeName *PWSTRElement, lpszVolumePathNames *PWSTRElement, cchBufferLength uint32, lpcchReturnLength *uint32) (r BOOL, err error) = kernel32.dll.GetVolumePathNamesForVolumeNameW
-//sys	CreateFile2(lpFileName *PWSTRElement, dwDesiredAccess uint32, dwShareMode FILE_SHARE_MODE, dwCreationDisposition FILE_CREATION_DISPOSITION, pCreateExParams *CREATEFILE2_EXTENDED_PARAMETERS) (r HANDLE, err error) = kernel32.dll.CreateFile2
-//sys	SetFileIoOverlappedRange(FileHandle HANDLE, OverlappedRangeStart *uint8, Length uint32) (r BOOL, err error) = kernel32.dll.SetFileIoOverlappedRange
-//sys	GetCompressedFileSizeA(lpFileName *PSTRElement, lpFileSizeHigh *uint32) (r uint32, err error) = kernel32.dll.GetCompressedFileSizeA
-//sys	GetCompressedFileSizeW(lpFileName *PWSTRElement, lpFileSizeHigh *uint32) (r uint32, err error) = kernel32.dll.GetCompressedFileSizeW
-//sys	FindFirstStreamW(lpFileName *PWSTRElement, InfoLevel STREAM_INFO_LEVELS, lpFindStreamData unsafe.Pointer, dwFlags uint32) (r HANDLE, err error) = kernel32.dll.FindFirstStreamW
-//sys	FindNextStreamW(hFindStream HANDLE, lpFindStreamData unsafe.Pointer) (r BOOL, err error) = kernel32.dll.FindNextStreamW
-//sys	AreFileApisANSI() (r BOOL) = kernel32.dll.AreFileApisANSI
-//sys	GetTempPathA(nBufferLength uint32, lpBuffer *PSTRElement) (r uint32, err error) = kernel32.dll.GetTempPathA
-//sys	FindFirstFileNameW(lpFileName *PWSTRElement, dwFlags uint32, StringLength *uint32, LinkName *PWSTRElement) (r HANDLE, err error) = kernel32.dll.FindFirstFileNameW
-//sys	FindNextFileNameW(hFindStream HANDLE, StringLength *uint32, LinkName *PWSTRElement) (r BOOL, err error) = kernel32.dll.FindNextFileNameW
-//sys	GetVolumeInformationA(lpRootPathName *PSTRElement, lpVolumeNameBuffer *PSTRElement, nVolumeNameSize uint32, lpVolumeSerialNumber *uint32, lpMaximumComponentLength *uint32, lpFileSystemFlags *uint32, lpFileSystemNameBuffer *PSTRElement, nFileSystemNameSize uint32) (r BOOL, err error) = kernel32.dll.GetVolumeInformationA
-//sys	GetTempFileNameA(lpPathName *PSTRElement, lpPrefixString *PSTRElement, uUnique uint32, lpTempFileName *PSTRElement) (r uint32, err error) = kernel32.dll.GetTempFileNameA
-//sys	SetFileApisToOEM() = kernel32.dll.SetFileApisToOEM
-//sys	SetFileApisToANSI() = kernel32.dll.SetFileApisToANSI
-//sys	GetTempPath2W(BufferLength uint32, Buffer *PWSTRElement) (r uint32) = kernel32.dll.GetTempPath2W
-//sys	GetTempPath2A(BufferLength uint32, Buffer *PSTRElement) (r uint32) = kernel32.dll.GetTempPath2A
-//sys	CreateFile3(lpFileName *PWSTRElement, dwDesiredAccess uint32, dwShareMode uint32, dwCreationDisposition uint32, pCreateExParams *CREATEFILE3_EXTENDED_PARAMETERS) (r HANDLE) = kernel32.dll.CreateFile3
-//sys	CreateDirectory2A(lpPathName *PSTRElement, dwDesiredAccess uint32, dwShareMode uint32, DirectoryFlags DIRECTORY_FLAGS, lpSecurityAttributes *SECURITY_ATTRIBUTES) (r HANDLE) = kernel32.dll.CreateDirectory2A
-//sys	CreateDirectory2W(lpPathName *PWSTRElement, dwDesiredAccess uint32, dwShareMode uint32, DirectoryFlags DIRECTORY_FLAGS, lpSecurityAttributes *SECURITY_ATTRIBUTES) (r HANDLE) = kernel32.dll.CreateDirectory2W
-//sys	RemoveDirectory2A(lpPathName *PSTRElement, DirectoryFlags DIRECTORY_FLAGS) (r BOOL) = kernel32.dll.RemoveDirectory2A
-//sys	RemoveDirectory2W(lpPathName *PWSTRElement, DirectoryFlags DIRECTORY_FLAGS) (r BOOL) = kernel32.dll.RemoveDirectory2W
-//sys	DeleteFile2A(lpFileName *PSTRElement, Flags uint32) (r BOOL) = kernel32.dll.DeleteFile2A
-//sys	DeleteFile2W(lpFileName *PWSTRElement, Flags uint32) (r BOOL) = kernel32.dll.DeleteFile2W
-//sys	CopyFileFromAppW(lpExistingFileName *PWSTRElement, lpNewFileName *PWSTRElement, bFailIfExists BOOL) (r BOOL) = api-ms-win-core-file-fromapp-l1-1-0.dll.CopyFileFromAppW
-//sys	CreateDirectoryFromAppW(lpPathName *PWSTRElement, lpSecurityAttributes *SECURITY_ATTRIBUTES) (r BOOL) = api-ms-win-core-file-fromapp-l1-1-0.dll.CreateDirectoryFromAppW
-//sys	CreateFileFromAppW(lpFileName *PWSTRElement, dwDesiredAccess uint32, dwShareMode uint32, lpSecurityAttributes *SECURITY_ATTRIBUTES, dwCreationDisposition uint32, dwFlagsAndAttributes uint32, hTemplateFile HANDLE) (r HANDLE) = api-ms-win-core-file-fromapp-l1-1-0.dll.CreateFileFromAppW
-//sys	CreateFile2FromAppW(lpFileName *PWSTRElement, dwDesiredAccess uint32, dwShareMode uint32, dwCreationDisposition uint32, pCreateExParams *CREATEFILE2_EXTENDED_PARAMETERS) (r HANDLE) = api-ms-win-core-file-fromapp-l1-1-0.dll.CreateFile2FromAppW
-//sys	DeleteFileFromAppW(lpFileName *PWSTRElement) (r BOOL) = api-ms-win-core-file-fromapp-l1-1-0.dll.DeleteFileFromAppW
-//sys	FindFirstFileExFromAppW(lpFileName *PWSTRElement, fInfoLevelId FINDEX_INFO_LEVELS, lpFindFileData unsafe.Pointer, fSearchOp FINDEX_SEARCH_OPS, lpSearchFilter unsafe.Pointer, dwAdditionalFlags uint32) (r HANDLE) = api-ms-win-core-file-fromapp-l1-1-0.dll.FindFirstFileExFromAppW
-//sys	GetFileAttributesExFromAppW(lpFileName *PWSTRElement, fInfoLevelId GET_FILEEX_INFO_LEVELS, lpFileInformation unsafe.Pointer) (r BOOL) = api-ms-win-core-file-fromapp-l1-1-0.dll.GetFileAttributesExFromAppW
-//sys	MoveFileFromAppW(lpExistingFileName *PWSTRElement, lpNewFileName *PWSTRElement) (r BOOL) = api-ms-win-core-file-fromapp-l1-1-0.dll.MoveFileFromAppW
-//sys	RemoveDirectoryFromAppW(lpPathName *PWSTRElement) (r BOOL) = api-ms-win-core-file-fromapp-l1-1-0.dll.RemoveDirectoryFromAppW
-//sys	ReplaceFileFromAppW(lpReplacedFileName *PWSTRElement, lpReplacementFileName *PWSTRElement, lpBackupFileName *PWSTRElement, dwReplaceFlags uint32, lpExclude unsafe.Pointer, lpReserved unsafe.Pointer) (r BOOL) = api-ms-win-core-file-fromapp-l1-1-0.dll.ReplaceFileFromAppW
-//sys	SetFileAttributesFromAppW(lpFileName *PWSTRElement, dwFileAttributes uint32) (r BOOL) = api-ms-win-core-file-fromapp-l1-1-0.dll.SetFileAttributesFromAppW
-//sys	VerFindFileA(uFlags VER_FIND_FILE_FLAGS, szFileName *PSTRElement, szWinDir *PSTRElement, szAppDir *PSTRElement, szCurDir *PSTRElement, puCurDirLen *uint32, szDestDir *PSTRElement, puDestDirLen *uint32) (r VER_FIND_FILE_STATUS) = version.dll.VerFindFileA
-//sys	VerFindFileW(uFlags VER_FIND_FILE_FLAGS, szFileName *PWSTRElement, szWinDir *PWSTRElement, szAppDir *PWSTRElement, szCurDir *PWSTRElement, puCurDirLen *uint32, szDestDir *PWSTRElement, puDestDirLen *uint32) (r VER_FIND_FILE_STATUS) = version.dll.VerFindFileW
-//sys	VerInstallFileA(uFlags VER_INSTALL_FILE_FLAGS, szSrcFileName *PSTRElement, szDestFileName *PSTRElement, szSrcDir *PSTRElement, szDestDir *PSTRElement, szCurDir *PSTRElement, szTmpFile *PSTRElement, puTmpFileLen *uint32) (r VER_INSTALL_FILE_STATUS) = version.dll.VerInstallFileA
-//sys	VerInstallFileW(uFlags VER_INSTALL_FILE_FLAGS, szSrcFileName *PWSTRElement, szDestFileName *PWSTRElement, szSrcDir *PWSTRElement, szDestDir *PWSTRElement, szCurDir *PWSTRElement, szTmpFile *PWSTRElement, puTmpFileLen *uint32) (r VER_INSTALL_FILE_STATUS) = version.dll.VerInstallFileW
-//sys	GetFileVersionInfoSizeA(lptstrFilename *PSTRElement, lpdwHandle *uint32) (r uint32, err error) = version.dll.GetFileVersionInfoSizeA
-//sys	GetFileVersionInfoSizeW(lptstrFilename *PWSTRElement, lpdwHandle *uint32) (r uint32, err error) = version.dll.GetFileVersionInfoSizeW
-//sys	GetFileVersionInfoA(lptstrFilename *PSTRElement, dwHandle uint32, dwLen uint32, lpData unsafe.Pointer) (r BOOL, err error) = version.dll.GetFileVersionInfoA
-//sys	GetFileVersionInfoW(lptstrFilename *PWSTRElement, dwHandle uint32, dwLen uint32, lpData unsafe.Pointer) (r BOOL, err error) = version.dll.GetFileVersionInfoW
-//sys	GetFileVersionInfoSizeExA(dwFlags GET_FILE_VERSION_INFO_FLAGS, lpwstrFilename *PSTRElement, lpdwHandle *uint32) (r uint32, err error) = version.dll.GetFileVersionInfoSizeExA
-//sys	GetFileVersionInfoSizeExW(dwFlags GET_FILE_VERSION_INFO_FLAGS, lpwstrFilename *PWSTRElement, lpdwHandle *uint32) (r uint32, err error) = version.dll.GetFileVersionInfoSizeExW
-//sys	GetFileVersionInfoExA(dwFlags GET_FILE_VERSION_INFO_FLAGS, lpwstrFilename *PSTRElement, dwHandle uint32, dwLen uint32, lpData unsafe.Pointer) (r BOOL, err error) = version.dll.GetFileVersionInfoExA
-//sys	GetFileVersionInfoExW(dwFlags GET_FILE_VERSION_INFO_FLAGS, lpwstrFilename *PWSTRElement, dwHandle uint32, dwLen uint32, lpData unsafe.Pointer) (r BOOL, err error) = version.dll.GetFileVersionInfoExW
-//sys	VerLanguageNameA(wLang uint32, szLang *PSTRElement, cchLang uint32) (r uint32) = kernel32.dll.VerLanguageNameA
-//sys	VerLanguageNameW(wLang uint32, szLang *PWSTRElement, cchLang uint32) (r uint32) = kernel32.dll.VerLanguageNameW
-//sys	VerQueryValueA(pBlock unsafe.Pointer, lpSubBlock *PSTRElement, lplpBuffer *unsafe.Pointer, puLen *uint32) (r BOOL) = version.dll.VerQueryValueA
-//sys	VerQueryValueW(pBlock unsafe.Pointer, lpSubBlock *PWSTRElement, lplpBuffer *unsafe.Pointer, puLen *uint32) (r BOOL) = version.dll.VerQueryValueW
-//sys	LsnEqual(plsn1 *CLS_LSN, plsn2 *CLS_LSN) (r BOOLEAN) = clfsw32.dll.LsnEqual
-//sys	LsnLess(plsn1 *CLS_LSN, plsn2 *CLS_LSN) (r BOOLEAN) = clfsw32.dll.LsnLess
-//sys	LsnGreater(plsn1 *CLS_LSN, plsn2 *CLS_LSN) (r BOOLEAN) = clfsw32.dll.LsnGreater
-//sys	LsnNull(plsn *CLS_LSN) (r BOOLEAN) = clfsw32.dll.LsnNull
-//sys	LsnContainer(plsn *CLS_LSN) (r uint32) = clfsw32.dll.LsnContainer
-//sys	LsnCreate(cidContainer uint32, offBlock uint32, cRecord uint32) (r CLS_LSN) = clfsw32.dll.LsnCreate
-//sys	LsnBlockOffset(plsn *CLS_LSN) (r uint32) = clfsw32.dll.LsnBlockOffset
-//sys	LsnRecordSequence(plsn *CLS_LSN) (r uint32) = clfsw32.dll.LsnRecordSequence
-//sys	LsnInvalid(plsn *CLS_LSN) (r BOOLEAN) = clfsw32.dll.LsnInvalid
-//sys	LsnIncrement(plsn *CLS_LSN) (r CLS_LSN) = clfsw32.dll.LsnIncrement
-//sys	CreateLogFile(pszLogFileName *PWSTRElement, fDesiredAccess uint32, dwShareMode FILE_SHARE_MODE, psaLogFile *SECURITY_ATTRIBUTES, fCreateDisposition FILE_CREATION_DISPOSITION, fFlagsAndAttributes FILE_FLAGS_AND_ATTRIBUTES) (r HANDLE, err error) = clfsw32.dll.CreateLogFile
-//sys	DeleteLogByHandle(hLog HANDLE) (r BOOL, err error) = clfsw32.dll.DeleteLogByHandle
-//sys	DeleteLogFile(pszLogFileName *PWSTRElement, pvReserved unsafe.Pointer) (r BOOL, err error) = clfsw32.dll.DeleteLogFile
-//sys	AddLogContainer(hLog HANDLE, pcbContainer *uint64, pwszContainerPath *PWSTRElement, pReserved unsafe.Pointer) (r BOOL, err error) = clfsw32.dll.AddLogContainer
-//sys	AddLogContainerSet(hLog HANDLE, cContainer uint16, pcbContainer *uint64, rgwszContainerPath **PWSTRElement, pReserved unsafe.Pointer) (r BOOL, err error) = clfsw32.dll.AddLogContainerSet
-//sys	RemoveLogContainer(hLog HANDLE, pwszContainerPath *PWSTRElement, fForce BOOL, pReserved unsafe.Pointer) (r BOOL, err error) = clfsw32.dll.RemoveLogContainer
-//sys	RemoveLogContainerSet(hLog HANDLE, cContainer uint16, rgwszContainerPath **PWSTRElement, fForce BOOL, pReserved unsafe.Pointer) (r BOOL, err error) = clfsw32.dll.RemoveLogContainerSet
-//sys	SetLogArchiveTail(hLog HANDLE, plsnArchiveTail *CLS_LSN, pReserved unsafe.Pointer) (r BOOL, err error) = clfsw32.dll.SetLogArchiveTail
-//sys	SetEndOfLog(hLog HANDLE, plsnEnd *CLS_LSN, lpOverlapped *OVERLAPPED) (r BOOL, err error) = clfsw32.dll.SetEndOfLog
-//sys	TruncateLog(pvMarshal unsafe.Pointer, plsnEnd *CLS_LSN, lpOverlapped *OVERLAPPED) (r BOOL, err error) = clfsw32.dll.TruncateLog
-//sys	CreateLogContainerScanContext(hLog HANDLE, cFromContainer uint32, cContainers uint32, eScanMode uint8, pcxScan *CLS_SCAN_CONTEXT, pOverlapped *OVERLAPPED) (r BOOL, err error) = clfsw32.dll.CreateLogContainerScanContext
-//sys	ScanLogContainers(pcxScan *CLS_SCAN_CONTEXT, eScanMode uint8, pReserved unsafe.Pointer) (r BOOL, err error) = clfsw32.dll.ScanLogContainers
-//sys	AlignReservedLog(pvMarshal unsafe.Pointer, cReservedRecords uint32, rgcbReservation *int64, pcbAlignReservation *int64) (r BOOL, err error) = clfsw32.dll.AlignReservedLog
-//sys	AllocReservedLog(pvMarshal unsafe.Pointer, cReservedRecords uint32, pcbAdjustment *int64) (r BOOL, err error) = clfsw32.dll.AllocReservedLog
-//sys	FreeReservedLog(pvMarshal unsafe.Pointer, cReservedRecords uint32, pcbAdjustment *int64) (r BOOL, err error) = clfsw32.dll.FreeReservedLog
-//sys	GetLogFileInformation(hLog HANDLE, pinfoBuffer *CLS_INFORMATION, cbBuffer *uint32) (r BOOL, err error) = clfsw32.dll.GetLogFileInformation
-//sys	SetLogArchiveMode(hLog HANDLE, eMode CLFS_LOG_ARCHIVE_MODE) (r BOOL, err error) = clfsw32.dll.SetLogArchiveMode
-//sys	ReadLogRestartArea(pvMarshal unsafe.Pointer, ppvRestartBuffer *unsafe.Pointer, pcbRestartBuffer *uint32, plsn *CLS_LSN, ppvContext *unsafe.Pointer, pOverlapped *OVERLAPPED) (r BOOL, err error) = clfsw32.dll.ReadLogRestartArea
-//sys	ReadPreviousLogRestartArea(pvReadContext unsafe.Pointer, ppvRestartBuffer *unsafe.Pointer, pcbRestartBuffer *uint32, plsnRestart *CLS_LSN, pOverlapped *OVERLAPPED) (r BOOL, err error) = clfsw32.dll.ReadPreviousLogRestartArea
-//sys	WriteLogRestartArea(pvMarshal unsafe.Pointer, pvRestartBuffer unsafe.Pointer, cbRestartBuffer uint32, plsnBase *CLS_LSN, fFlags CLFS_FLAG, pcbWritten *uint32, plsnNext *CLS_LSN, pOverlapped *OVERLAPPED) (r BOOL, err error) = clfsw32.dll.WriteLogRestartArea
-//sys	GetLogReservationInfo(pvMarshal unsafe.Pointer, pcbRecordNumber *uint32, pcbUserReservation *int64, pcbCommitReservation *int64) (r BOOL) = clfsw32.dll.GetLogReservationInfo
-//sys	AdvanceLogBase(pvMarshal unsafe.Pointer, plsnBase *CLS_LSN, fFlags uint32, pOverlapped *OVERLAPPED) (r BOOL, err error) = clfsw32.dll.AdvanceLogBase
-//sys	CloseAndResetLogFile(hLog HANDLE) (r BOOL, err error) = clfsw32.dll.CloseAndResetLogFile
-//sys	CreateLogMarshallingArea(hLog HANDLE, pfnAllocBuffer CLFS_BLOCK_ALLOCATION, pfnFreeBuffer CLFS_BLOCK_DEALLOCATION, pvBlockAllocContext unsafe.Pointer, cbMarshallingBuffer uint32, cMaxWriteBuffers uint32, cMaxReadBuffers uint32, ppvMarshal *unsafe.Pointer) (r BOOL, err error) = clfsw32.dll.CreateLogMarshallingArea
-//sys	DeleteLogMarshallingArea(pvMarshal unsafe.Pointer) (r BOOL, err error) = clfsw32.dll.DeleteLogMarshallingArea
-//sys	ReserveAndAppendLog(pvMarshal unsafe.Pointer, rgWriteEntries *CLS_WRITE_ENTRY, cWriteEntries uint32, plsnUndoNext *CLS_LSN, plsnPrevious *CLS_LSN, cReserveRecords uint32, rgcbReservation *int64, fFlags CLFS_FLAG, plsn *CLS_LSN, pOverlapped *OVERLAPPED) (r BOOL, err error) = clfsw32.dll.ReserveAndAppendLog
-//sys	ReserveAndAppendLogAligned(pvMarshal unsafe.Pointer, rgWriteEntries *CLS_WRITE_ENTRY, cWriteEntries uint32, cbEntryAlignment uint32, plsnUndoNext *CLS_LSN, plsnPrevious *CLS_LSN, cReserveRecords uint32, rgcbReservation *int64, fFlags CLFS_FLAG, plsn *CLS_LSN, pOverlapped *OVERLAPPED) (r BOOL, err error) = clfsw32.dll.ReserveAndAppendLogAligned
-//sys	FlushLogBuffers(pvMarshal unsafe.Pointer, pOverlapped *OVERLAPPED) (r BOOL, err error) = clfsw32.dll.FlushLogBuffers
-//sys	FlushLogToLsn(pvMarshalContext unsafe.Pointer, plsnFlush *CLS_LSN, plsnLastFlushed *CLS_LSN, pOverlapped *OVERLAPPED) (r BOOL, err error) = clfsw32.dll.FlushLogToLsn
-//sys	ReadLogRecord(pvMarshal unsafe.Pointer, plsnFirst *CLS_LSN, eContextMode CLFS_CONTEXT_MODE, ppvReadBuffer *unsafe.Pointer, pcbReadBuffer *uint32, peRecordType *uint8, plsnUndoNext *CLS_LSN, plsnPrevious *CLS_LSN, ppvReadContext *unsafe.Pointer, pOverlapped *OVERLAPPED) (r BOOL, err error) = clfsw32.dll.ReadLogRecord
-//sys	ReadNextLogRecord(pvReadContext unsafe.Pointer, ppvBuffer *unsafe.Pointer, pcbBuffer *uint32, peRecordType *uint8, plsnUser *CLS_LSN, plsnUndoNext *CLS_LSN, plsnPrevious *CLS_LSN, plsnRecord *CLS_LSN, pOverlapped *OVERLAPPED) (r BOOL, err error) = clfsw32.dll.ReadNextLogRecord
-//sys	TerminateReadLog(pvCursorContext unsafe.Pointer) (r BOOL, err error) = clfsw32.dll.TerminateReadLog
-//sys	PrepareLogArchive(hLog HANDLE, pszBaseLogFileName *PWSTRElement, cLen uint32, plsnLow *CLS_LSN, plsnHigh *CLS_LSN, pcActualLength *uint32, poffBaseLogFileData *uint64, pcbBaseLogFileLength *uint64, plsnBase *CLS_LSN, plsnLast *CLS_LSN, plsnCurrentArchiveTail *CLS_LSN, ppvArchiveContext *unsafe.Pointer) (r BOOL, err error) = clfsw32.dll.PrepareLogArchive
-//sys	ReadLogArchiveMetadata(pvArchiveContext unsafe.Pointer, cbOffset uint32, cbBytesToRead uint32, pbReadBuffer *uint8, pcbBytesRead *uint32) (r BOOL, err error) = clfsw32.dll.ReadLogArchiveMetadata
-//sys	GetNextLogArchiveExtent(pvArchiveContext unsafe.Pointer, rgadExtent *CLS_ARCHIVE_DESCRIPTOR, cDescriptors uint32, pcDescriptorsReturned *uint32) (r BOOL, err error) = clfsw32.dll.GetNextLogArchiveExtent
-//sys	TerminateLogArchive(pvArchiveContext unsafe.Pointer) (r BOOL, err error) = clfsw32.dll.TerminateLogArchive
-//sys	ValidateLog(pszLogFileName *PWSTRElement, psaLogFile *SECURITY_ATTRIBUTES, pinfoBuffer *CLS_INFORMATION, pcbBuffer *uint32) (r BOOL, err error) = clfsw32.dll.ValidateLog
-//sys	GetLogContainerName(hLog HANDLE, cidLogicalContainer uint32, pwstrContainerName *PWSTRElement, cLenContainerName uint32, pcActualLenContainerName *uint32) (r BOOL, err error) = clfsw32.dll.GetLogContainerName
-//sys	GetLogIoStatistics(hLog HANDLE, pvStatsBuffer unsafe.Pointer, cbStatsBuffer uint32, eStatsClass CLFS_IOSTATS_CLASS, pcbStatsWritten *uint32) (r BOOL, err error) = clfsw32.dll.GetLogIoStatistics
-//sys	RegisterManageableLogClient(hLog HANDLE, pCallbacks *LOG_MANAGEMENT_CALLBACKS) (r BOOL, err error) = clfsw32.dll.RegisterManageableLogClient
-//sys	DeregisterManageableLogClient(hLog HANDLE) (r BOOL, err error) = clfsw32.dll.DeregisterManageableLogClient
-//sys	ReadLogNotification(hLog HANDLE, pNotification *CLFS_MGMT_NOTIFICATION, lpOverlapped *OVERLAPPED) (r BOOL, err error) = clfsw32.dll.ReadLogNotification
-//sys	InstallLogPolicy(hLog HANDLE, pPolicy *CLFS_MGMT_POLICY) (r BOOL, err error) = clfsw32.dll.InstallLogPolicy
-//sys	RemoveLogPolicy(hLog HANDLE, ePolicyType CLFS_MGMT_POLICY_TYPE) (r BOOL, err error) = clfsw32.dll.RemoveLogPolicy
-//sys	QueryLogPolicy(hLog HANDLE, ePolicyType CLFS_MGMT_POLICY_TYPE, pPolicyBuffer *CLFS_MGMT_POLICY, pcbPolicyBuffer *uint32) (r BOOL, err error) = clfsw32.dll.QueryLogPolicy
-//sys	SetLogFileSizeWithPolicy(hLog HANDLE, pDesiredSize *uint64, pResultingSize *uint64) (r BOOL, err error) = clfsw32.dll.SetLogFileSizeWithPolicy
-//sys	HandleLogFull(hLog HANDLE) (r BOOL, err error) = clfsw32.dll.HandleLogFull
-//sys	LogTailAdvanceFailure(hLog HANDLE, dwReason uint32) (r BOOL, err error) = clfsw32.dll.LogTailAdvanceFailure
-//sys	RegisterForLogWriteNotification(hLog HANDLE, cbThreshold uint32, fEnable BOOL) (r BOOL, err error) = clfsw32.dll.RegisterForLogWriteNotification
-//sys	QueryUsersOnEncryptedFile(lpFileName *PWSTRElement, pUsers **ENCRYPTION_CERTIFICATE_HASH_LIST) (r uint32) = advapi32.dll.QueryUsersOnEncryptedFile
-//sys	QueryRecoveryAgentsOnEncryptedFile(lpFileName *PWSTRElement, pRecoveryAgents **ENCRYPTION_CERTIFICATE_HASH_LIST) (r uint32) = advapi32.dll.QueryRecoveryAgentsOnEncryptedFile
-//sys	RemoveUsersFromEncryptedFile(lpFileName *PWSTRElement, pHashes *ENCRYPTION_CERTIFICATE_HASH_LIST) (r uint32) = advapi32.dll.RemoveUsersFromEncryptedFile
-//sys	AddUsersToEncryptedFile(lpFileName *PWSTRElement, pEncryptionCertificates *ENCRYPTION_CERTIFICATE_LIST) (r uint32) = advapi32.dll.AddUsersToEncryptedFile
-//sys	SetUserFileEncryptionKey(pEncryptionCertificate *ENCRYPTION_CERTIFICATE) (r uint32) = advapi32.dll.SetUserFileEncryptionKey
-//sys	SetUserFileEncryptionKeyEx(pEncryptionCertificate *ENCRYPTION_CERTIFICATE, dwCapabilities uint32, dwFlags uint32, pvReserved unsafe.Pointer) (r uint32) = advapi32.dll.SetUserFileEncryptionKeyEx
-//sys	FreeEncryptionCertificateHashList(pUsers *ENCRYPTION_CERTIFICATE_HASH_LIST) = advapi32.dll.FreeEncryptionCertificateHashList
-//sys	EncryptionDisable(DirPath *PWSTRElement, Disable BOOL) (r BOOL, err error) = advapi32.dll.EncryptionDisable
-//sys	DuplicateEncryptionInfoFile(SrcFileName *PWSTRElement, DstFileName *PWSTRElement, dwCreationDistribution uint32, dwAttributes uint32, lpSecurityAttributes *SECURITY_ATTRIBUTES) (r uint32) = advapi32.dll.DuplicateEncryptionInfoFile
-//sys	GetEncryptedFileMetadata(lpFileName *PWSTRElement, pcbMetadata *uint32, ppbMetadata **uint8) (r uint32) = advapi32.dll.GetEncryptedFileMetadata
-//sys	SetEncryptedFileMetadata(lpFileName *PWSTRElement, pbOldMetadata *uint8, pbNewMetadata *uint8, pOwnerHash *ENCRYPTION_CERTIFICATE_HASH, dwOperation uint32, pCertificatesAdded *ENCRYPTION_CERTIFICATE_HASH_LIST) (r uint32) = advapi32.dll.SetEncryptedFileMetadata
-//sys	FreeEncryptedFileMetadata(pbMetadata *uint8) = advapi32.dll.FreeEncryptedFileMetadata
-//sys	LZStart() (r int32) = kernel32.dll.LZStart
-//sys	LZDone() = kernel32.dll.LZDone
-//sys	CopyLZFile(hfSource int32, hfDest int32) (r int32) = kernel32.dll.CopyLZFile
-//sys	LZCopy(hfSource int32, hfDest int32) (r int32) = kernel32.dll.LZCopy
-//sys	LZInit(hfSource int32) (r int32) = kernel32.dll.LZInit
-//sys	GetExpandedNameA(lpszSource *PSTRElement, lpszBuffer *PSTRElement) (r int32, err error) = kernel32.dll.GetExpandedNameA
-//sys	GetExpandedNameW(lpszSource *PWSTRElement, lpszBuffer *PWSTRElement) (r int32, err error) = kernel32.dll.GetExpandedNameW
-//sys	LZOpenFileA(lpFileName *PSTRElement, lpReOpenBuf *OFSTRUCT, wStyle LZOPENFILE_STYLE) (r int32) = kernel32.dll.LZOpenFileA
-//sys	LZOpenFileW(lpFileName *PWSTRElement, lpReOpenBuf *OFSTRUCT, wStyle LZOPENFILE_STYLE) (r int32) = kernel32.dll.LZOpenFileW
-//sys	LZSeek(hFile int32, lOffset int32, iOrigin int32) (r int32) = kernel32.dll.LZSeek
-//sys	LZRead(hFile int32, lpBuffer *PSTRElement, cbRead int32) (r int32) = kernel32.dll.LZRead
-//sys	LZClose(hFile int32) = kernel32.dll.LZClose
-//sys	WofShouldCompressBinaries(Volume *PWSTRElement, Algorithm *uint32) (r BOOL) = wofutil.dll.WofShouldCompressBinaries
-//sys	WofGetDriverVersion(FileOrVolumeHandle HANDLE, Provider uint32, WofVersion *uint32) (r HRESULT) = wofutil.dll.WofGetDriverVersion
-//sys	WofSetFileDataLocation(FileHandle HANDLE, Provider uint32, ExternalFileInfo unsafe.Pointer, Length uint32) (r HRESULT) = wofutil.dll.WofSetFileDataLocation
-//sys	WofIsExternalFile(FilePath *PWSTRElement, IsExternalFile *BOOL, Provider *uint32, ExternalFileInfo unsafe.Pointer, BufferLength *uint32) (r HRESULT) = wofutil.dll.WofIsExternalFile
-//sys	WofEnumEntries(VolumeName *PWSTRElement, Provider uint32, EnumProc WofEnumEntryProc, UserData unsafe.Pointer) (r HRESULT) = wofutil.dll.WofEnumEntries
-//sys	WofWimAddEntry(VolumeName *PWSTRElement, WimPath *PWSTRElement, WimType uint32, WimIndex uint32, DataSourceId *int64) (r HRESULT) = wofutil.dll.WofWimAddEntry
-//sys	WofWimEnumFiles(VolumeName *PWSTRElement, DataSourceId int64, EnumProc WofEnumFilesProc, UserData unsafe.Pointer) (r HRESULT) = wofutil.dll.WofWimEnumFiles
-//sys	WofWimSuspendEntry(VolumeName *PWSTRElement, DataSourceId int64) (r HRESULT) = wofutil.dll.WofWimSuspendEntry
-//sys	WofWimRemoveEntry(VolumeName *PWSTRElement, DataSourceId int64) (r HRESULT) = wofutil.dll.WofWimRemoveEntry
-//sys	WofWimUpdateEntry(VolumeName *PWSTRElement, DataSourceId int64, NewWimPath *PWSTRElement) (r HRESULT) = wofutil.dll.WofWimUpdateEntry
-//sys	WofFileEnumFiles(VolumeName *PWSTRElement, Algorithm uint32, EnumProc WofEnumFilesProc, UserData unsafe.Pointer) (r HRESULT) = wofutil.dll.WofFileEnumFiles
-//sys	TxfLogCreateFileReadContext(LogPath *PWSTRElement, BeginningLsn CLS_LSN, EndingLsn CLS_LSN, TxfFileId *TXF_ID, TxfLogContext *unsafe.Pointer) (r BOOL, err error) = txfw32.dll.TxfLogCreateFileReadContext
-//sys	TxfLogCreateRangeReadContext(LogPath *PWSTRElement, BeginningLsn CLS_LSN, EndingLsn CLS_LSN, BeginningVirtualClock *int64, EndingVirtualClock *int64, RecordTypeMask uint32, TxfLogContext *unsafe.Pointer) (r BOOL) = txfw32.dll.TxfLogCreateRangeReadContext
-//sys	TxfLogDestroyReadContext(TxfLogContext unsafe.Pointer) (r BOOL, err error) = txfw32.dll.TxfLogDestroyReadContext
-//sys	TxfLogReadRecords(TxfLogContext unsafe.Pointer, BufferLength uint32, Buffer unsafe.Pointer, BytesUsed *uint32, RecordCount *uint32) (r BOOL, err error) = txfw32.dll.TxfLogReadRecords
-//sys	TxfReadMetadataInfo(FileHandle HANDLE, TxfFileId *TXF_ID, LastLsn *CLS_LSN, TransactionState *uint32, LockingTransaction *Guid) (r BOOL) = txfw32.dll.TxfReadMetadataInfo
-//sys	TxfLogRecordGetFileName(RecordBuffer unsafe.Pointer, RecordBufferLengthInBytes uint32, NameBuffer *PWSTRElement, NameBufferLengthInBytes *uint32, TxfId *TXF_ID) (r BOOL) = txfw32.dll.TxfLogRecordGetFileName
-//sys	TxfLogRecordGetGenericType(RecordBuffer unsafe.Pointer, RecordBufferLengthInBytes uint32, GenericType *uint32, VirtualClock *int64) (r BOOL) = txfw32.dll.TxfLogRecordGetGenericType
-//sys	TxfSetThreadMiniVersionForCreate(MiniVersion uint16) = txfw32.dll.TxfSetThreadMiniVersionForCreate
-//sys	TxfGetThreadMiniVersionForCreate(MiniVersion *uint16) = txfw32.dll.TxfGetThreadMiniVersionForCreate
-//sys	CreateTransaction(lpTransactionAttributes *SECURITY_ATTRIBUTES, UOW *Guid, CreateOptions uint32, IsolationLevel uint32, IsolationFlags uint32, Timeout uint32, Description *PWSTRElement) (r HANDLE, err error) = ktmw32.dll.CreateTransaction
-//sys	OpenTransaction(dwDesiredAccess uint32, TransactionId *Guid) (r HANDLE, err error) = ktmw32.dll.OpenTransaction
-//sys	CommitTransaction(TransactionHandle HANDLE) (r BOOL, err error) = ktmw32.dll.CommitTransaction
-//sys	CommitTransactionAsync(TransactionHandle HANDLE) (r BOOL, err error) = ktmw32.dll.CommitTransactionAsync
-//sys	RollbackTransaction(TransactionHandle HANDLE) (r BOOL, err error) = ktmw32.dll.RollbackTransaction
-//sys	RollbackTransactionAsync(TransactionHandle HANDLE) (r BOOL, err error) = ktmw32.dll.RollbackTransactionAsync
-//sys	GetTransactionId(TransactionHandle HANDLE, TransactionId *Guid) (r BOOL, err error) = ktmw32.dll.GetTransactionId
-//sys	GetTransactionInformation(TransactionHandle HANDLE, Outcome *uint32, IsolationLevel *uint32, IsolationFlags *uint32, Timeout *uint32, BufferLength uint32, Description *PWSTRElement) (r BOOL, err error) = ktmw32.dll.GetTransactionInformation
-//sys	SetTransactionInformation(TransactionHandle HANDLE, IsolationLevel uint32, IsolationFlags uint32, Timeout uint32, Description *PWSTRElement) (r BOOL, err error) = ktmw32.dll.SetTransactionInformation
-//sys	CreateTransactionManager(lpTransactionAttributes *SECURITY_ATTRIBUTES, LogFileName *PWSTRElement, CreateOptions uint32, CommitStrength uint32) (r HANDLE, err error) = ktmw32.dll.CreateTransactionManager
-//sys	OpenTransactionManager(LogFileName *PWSTRElement, DesiredAccess uint32, OpenOptions uint32) (r HANDLE, err error) = ktmw32.dll.OpenTransactionManager
-//sys	OpenTransactionManagerById(TransactionManagerId *Guid, DesiredAccess uint32, OpenOptions uint32) (r HANDLE, err error) = ktmw32.dll.OpenTransactionManagerById
-//sys	RenameTransactionManager(LogFileName *PWSTRElement, ExistingTransactionManagerGuid *Guid) (r BOOL, err error) = ktmw32.dll.RenameTransactionManager
-//sys	RollforwardTransactionManager(TransactionManagerHandle HANDLE, TmVirtualClock *int64) (r BOOL, err error) = ktmw32.dll.RollforwardTransactionManager
-//sys	RecoverTransactionManager(TransactionManagerHandle HANDLE) (r BOOL, err error) = ktmw32.dll.RecoverTransactionManager
-//sys	GetCurrentClockTransactionManager(TransactionManagerHandle HANDLE, TmVirtualClock *int64) (r BOOL, err error) = ktmw32.dll.GetCurrentClockTransactionManager
-//sys	GetTransactionManagerId(TransactionManagerHandle HANDLE, TransactionManagerId *Guid) (r BOOL, err error) = ktmw32.dll.GetTransactionManagerId
-//sys	CreateResourceManager(lpResourceManagerAttributes *SECURITY_ATTRIBUTES, ResourceManagerId *Guid, CreateOptions uint32, TmHandle HANDLE, Description *PWSTRElement) (r HANDLE, err error) = ktmw32.dll.CreateResourceManager
-//sys	OpenResourceManager(dwDesiredAccess uint32, TmHandle HANDLE, ResourceManagerId *Guid) (r HANDLE, err error) = ktmw32.dll.OpenResourceManager
-//sys	RecoverResourceManager(ResourceManagerHandle HANDLE) (r BOOL, err error) = ktmw32.dll.RecoverResourceManager
-//sys	GetNotificationResourceManager(ResourceManagerHandle HANDLE, TransactionNotification *TRANSACTION_NOTIFICATION, NotificationLength uint32, dwMilliseconds uint32, ReturnLength *uint32) (r BOOL, err error) = ktmw32.dll.GetNotificationResourceManager
-//sys	GetNotificationResourceManagerAsync(ResourceManagerHandle HANDLE, TransactionNotification *TRANSACTION_NOTIFICATION, TransactionNotificationLength uint32, ReturnLength *uint32, lpOverlapped *OVERLAPPED) (r BOOL, err error) = ktmw32.dll.GetNotificationResourceManagerAsync
-//sys	SetResourceManagerCompletionPort(ResourceManagerHandle HANDLE, IoCompletionPortHandle HANDLE, CompletionKey uintptr) (r BOOL, err error) = ktmw32.dll.SetResourceManagerCompletionPort
-//sys	CreateEnlistment(lpEnlistmentAttributes *SECURITY_ATTRIBUTES, ResourceManagerHandle HANDLE, TransactionHandle HANDLE, NotificationMask uint32, CreateOptions uint32, EnlistmentKey unsafe.Pointer) (r HANDLE, err error) = ktmw32.dll.CreateEnlistment
-//sys	OpenEnlistment(dwDesiredAccess uint32, ResourceManagerHandle HANDLE, EnlistmentId *Guid) (r HANDLE, err error) = ktmw32.dll.OpenEnlistment
-//sys	RecoverEnlistment(EnlistmentHandle HANDLE, EnlistmentKey unsafe.Pointer) (r BOOL, err error) = ktmw32.dll.RecoverEnlistment
-//sys	GetEnlistmentRecoveryInformation(EnlistmentHandle HANDLE, BufferSize uint32, Buffer unsafe.Pointer, BufferUsed *uint32) (r BOOL, err error) = ktmw32.dll.GetEnlistmentRecoveryInformation
-//sys	GetEnlistmentId(EnlistmentHandle HANDLE, EnlistmentId *Guid) (r BOOL, err error) = ktmw32.dll.GetEnlistmentId
-//sys	SetEnlistmentRecoveryInformation(EnlistmentHandle HANDLE, BufferSize uint32, Buffer unsafe.Pointer) (r BOOL, err error) = ktmw32.dll.SetEnlistmentRecoveryInformation
-//sys	PrepareEnlistment(EnlistmentHandle HANDLE, TmVirtualClock *int64) (r BOOL, err error) = ktmw32.dll.PrepareEnlistment
-//sys	PrePrepareEnlistment(EnlistmentHandle HANDLE, TmVirtualClock *int64) (r BOOL, err error) = ktmw32.dll.PrePrepareEnlistment
-//sys	CommitEnlistment(EnlistmentHandle HANDLE, TmVirtualClock *int64) (r BOOL, err error) = ktmw32.dll.CommitEnlistment
-//sys	RollbackEnlistment(EnlistmentHandle HANDLE, TmVirtualClock *int64) (r BOOL, err error) = ktmw32.dll.RollbackEnlistment
-//sys	PrePrepareComplete(EnlistmentHandle HANDLE, TmVirtualClock *int64) (r BOOL, err error) = ktmw32.dll.PrePrepareComplete
-//sys	PrepareComplete(EnlistmentHandle HANDLE, TmVirtualClock *int64) (r BOOL, err error) = ktmw32.dll.PrepareComplete
-//sys	ReadOnlyEnlistment(EnlistmentHandle HANDLE, TmVirtualClock *int64) (r BOOL, err error) = ktmw32.dll.ReadOnlyEnlistment
-//sys	CommitComplete(EnlistmentHandle HANDLE, TmVirtualClock *int64) (r BOOL, err error) = ktmw32.dll.CommitComplete
-//sys	RollbackComplete(EnlistmentHandle HANDLE, TmVirtualClock *int64) (r BOOL, err error) = ktmw32.dll.RollbackComplete
-//sys	SinglePhaseReject(EnlistmentHandle HANDLE, TmVirtualClock *int64) (r BOOL, err error) = ktmw32.dll.SinglePhaseReject
-//sys	NetShareAdd(servername *PWSTRElement, level uint32, buf *uint8, parm_err *uint32) (r uint32) = netapi32.dll.NetShareAdd
-//sys	NetShareEnum(servername *PWSTRElement, level uint32, bufptr **uint8, prefmaxlen uint32, entriesread *uint32, totalentries *uint32, resume_handle *uint32) (r uint32) = netapi32.dll.NetShareEnum
-//sys	NetShareEnumSticky(servername *PWSTRElement, level uint32, bufptr **uint8, prefmaxlen uint32, entriesread *uint32, totalentries *uint32, resume_handle *uint32) (r uint32) = netapi32.dll.NetShareEnumSticky
-//sys	NetShareGetInfo(servername *PWSTRElement, netname *PWSTRElement, level uint32, bufptr **uint8) (r uint32) = netapi32.dll.NetShareGetInfo
-//sys	NetShareSetInfo(servername *PWSTRElement, netname *PWSTRElement, level uint32, buf *uint8, parm_err *uint32) (r uint32) = netapi32.dll.NetShareSetInfo
-//sys	NetShareDel(servername *PWSTRElement, netname *PWSTRElement, reserved uint32) (r uint32) = netapi32.dll.NetShareDel
-//sys	NetShareDelSticky(servername *PWSTRElement, netname *PWSTRElement, reserved uint32) (r uint32) = netapi32.dll.NetShareDelSticky
-//sys	NetShareCheck(servername *PWSTRElement, device *PWSTRElement, typeParam *uint32) (r uint32) = netapi32.dll.NetShareCheck
-//sys	NetShareDelEx(servername *PWSTRElement, level uint32, buf *uint8) (r uint32) = netapi32.dll.NetShareDelEx
-//sys	NetServerAliasAdd(servername *PWSTRElement, level uint32, buf *uint8) (r uint32) = netapi32.dll.NetServerAliasAdd
-//sys	NetServerAliasDel(servername *PWSTRElement, level uint32, buf *uint8) (r uint32) = netapi32.dll.NetServerAliasDel
-//sys	NetServerAliasEnum(servername *PWSTRElement, level uint32, bufptr **uint8, prefmaxlen uint32, entriesread *uint32, totalentries *uint32, resumehandle *uint32) (r uint32) = netapi32.dll.NetServerAliasEnum
-//sys	NetSessionEnum(servername *PWSTRElement, UncClientName *PWSTRElement, username *PWSTRElement, level uint32, bufptr **uint8, prefmaxlen uint32, entriesread *uint32, totalentries *uint32, resume_handle *uint32) (r uint32) = netapi32.dll.NetSessionEnum
-//sys	NetSessionDel(servername *PWSTRElement, UncClientName *PWSTRElement, username *PWSTRElement) (r uint32) = netapi32.dll.NetSessionDel
-//sys	NetSessionGetInfo(servername *PWSTRElement, UncClientName *PWSTRElement, username *PWSTRElement, level uint32, bufptr **uint8) (r uint32) = netapi32.dll.NetSessionGetInfo
-//sys	NetConnectionEnum(servername *PWSTRElement, qualifier *PWSTRElement, level uint32, bufptr **uint8, prefmaxlen uint32, entriesread *uint32, totalentries *uint32, resume_handle *uint32) (r uint32) = netapi32.dll.NetConnectionEnum
-//sys	NetFileClose(servername *PWSTRElement, fileid uint32) (r uint32) = netapi32.dll.NetFileClose
-//sys	NetFileEnum(servername *PWSTRElement, basepath *PWSTRElement, username *PWSTRElement, level uint32, bufptr **uint8, prefmaxlen uint32, entriesread *uint32, totalentries *uint32, resume_handle *uintptr) (r uint32) = netapi32.dll.NetFileEnum
-//sys	NetFileGetInfo(servername *PWSTRElement, fileid uint32, level uint32, bufptr **uint8) (r uint32) = netapi32.dll.NetFileGetInfo
-//sys	NetStatisticsGet(ServerName *int8, Service *int8, Level uint32, Options uint32, Buffer **uint8) (r uint32) = netapi32.dll.NetStatisticsGet
-//sys	QueryIoRingCapabilities(capabilities *IORING_CAPABILITIES) (r HRESULT) = api-ms-win-core-ioring-l1-1-0.dll.QueryIoRingCapabilities
-//sys	IsIoRingOpSupported(ioRing HIORING, op IORING_OP_CODE) (r BOOL) = api-ms-win-core-ioring-l1-1-0.dll.IsIoRingOpSupported
-//sys	CreateIoRing(ioringVersion IORING_VERSION, flags IORING_CREATE_FLAGS, submissionQueueSize uint32, completionQueueSize uint32, h *HIORING) (r HRESULT) = api-ms-win-core-ioring-l1-1-0.dll.CreateIoRing
-//sys	GetIoRingInfo(ioRing HIORING, info *IORING_INFO) (r HRESULT) = api-ms-win-core-ioring-l1-1-0.dll.GetIoRingInfo
-//sys	SubmitIoRing(ioRing HIORING, waitOperations uint32, milliseconds uint32, submittedEntries *uint32) (r HRESULT) = api-ms-win-core-ioring-l1-1-0.dll.SubmitIoRing
-//sys	CloseIoRing(ioRing HIORING) (r HRESULT) = api-ms-win-core-ioring-l1-1-0.dll.CloseIoRing
-//sys	PopIoRingCompletion(ioRing HIORING, cqe *IORING_CQE) (r HRESULT) = api-ms-win-core-ioring-l1-1-0.dll.PopIoRingCompletion
-//sys	SetIoRingCompletionEvent(ioRing HIORING, hEvent HANDLE) (r HRESULT) = api-ms-win-core-ioring-l1-1-0.dll.SetIoRingCompletionEvent
-//sys	BuildIoRingCancelRequest(ioRing HIORING, file IORING_HANDLE_REF, opToCancel uintptr, userData uintptr) (r HRESULT) = api-ms-win-core-ioring-l1-1-0.dll.BuildIoRingCancelRequest
-//sys	BuildIoRingReadFile(ioRing HIORING, fileRef IORING_HANDLE_REF, dataRef IORING_BUFFER_REF, numberOfBytesToRead uint32, fileOffset uint64, userData uintptr, sqeFlags IORING_SQE_FLAGS) (r HRESULT) = api-ms-win-core-ioring-l1-1-0.dll.BuildIoRingReadFile
-//sys	BuildIoRingRegisterFileHandles(ioRing HIORING, count uint32, handles *HANDLE, userData uintptr) (r HRESULT) = api-ms-win-core-ioring-l1-1-0.dll.BuildIoRingRegisterFileHandles
-//sys	BuildIoRingRegisterBuffers(ioRing HIORING, count uint32, buffers *IORING_BUFFER_INFO, userData uintptr) (r HRESULT) = api-ms-win-core-ioring-l1-1-0.dll.BuildIoRingRegisterBuffers
-//sys	BuildIoRingWriteFile(ioRing HIORING, fileRef IORING_HANDLE_REF, bufferRef IORING_BUFFER_REF, numberOfBytesToWrite uint32, fileOffset uint64, writeFlags FILE_WRITE_FLAGS, userData uintptr, sqeFlags IORING_SQE_FLAGS) (r HRESULT) = kernel32.dll.BuildIoRingWriteFile
-//sys	BuildIoRingFlushFile(ioRing HIORING, fileRef IORING_HANDLE_REF, flushMode FILE_FLUSH_MODE, userData uintptr, sqeFlags IORING_SQE_FLAGS) (r HRESULT) = kernel32.dll.BuildIoRingFlushFile
-//sys	BuildIoRingReadFileScatter(ioRing HIORING, fileRef IORING_HANDLE_REF, segmentCount uint32, segmentArray *FILE_SEGMENT_ELEMENT, numberOfBytesToRead uint32, fileOffset uint64, userData uintptr, sqeFlags IORING_SQE_FLAGS) (r HRESULT) = kernel32.dll.BuildIoRingReadFileScatter
-//sys	BuildIoRingWriteFileGather(ioRing HIORING, fileRef IORING_HANDLE_REF, segmentCount uint32, segmentArray *FILE_SEGMENT_ELEMENT, numberOfBytesToWrite uint32, fileOffset uint64, writeFlags FILE_WRITE_FLAGS, userData uintptr, sqeFlags IORING_SQE_FLAGS) (r HRESULT) = kernel32.dll.BuildIoRingWriteFileGather
-//sys	CreateBindLink(virtualPath *PWSTRElement, backingPath *PWSTRElement, createBindLinkFlags CREATE_BIND_LINK_FLAGS, exceptionCount uint32, exceptionPaths **PWSTRElement) (r HRESULT) = bindfltapi.dll.CreateBindLink
-//sys	RemoveBindLink(virtualPath *PWSTRElement) (r HRESULT) = bindfltapi.dll.RemoveBindLink
-//sys	Wow64EnableWow64FsRedirection(Wow64FsEnableRedirection BOOLEAN) (r BOOLEAN) = kernel32.dll.Wow64EnableWow64FsRedirection
-//sys	Wow64DisableWow64FsRedirection(OldValue *unsafe.Pointer) (r BOOL, err error) = kernel32.dll.Wow64DisableWow64FsRedirection
-//sys	Wow64RevertWow64FsRedirection(OlValue unsafe.Pointer) (r BOOL, err error) = kernel32.dll.Wow64RevertWow64FsRedirection
-//sys	GetBinaryTypeA(lpApplicationName *PSTRElement, lpBinaryType *uint32) (r BOOL, err error) = kernel32.dll.GetBinaryTypeA
-//sys	GetBinaryTypeW(lpApplicationName *PWSTRElement, lpBinaryType *uint32) (r BOOL, err error) = kernel32.dll.GetBinaryTypeW
-//sys	GetShortPathNameA(lpszLongPath *PSTRElement, lpszShortPath *PSTRElement, cchBuffer uint32) (r uint32, err error) = kernel32.dll.GetShortPathNameA
-//sys	GetLongPathNameTransactedA(lpszShortPath *PSTRElement, lpszLongPath *PSTRElement, cchBuffer uint32, hTransaction HANDLE) (r uint32, err error) = kernel32.dll.GetLongPathNameTransactedA
-//sys	GetLongPathNameTransactedW(lpszShortPath *PWSTRElement, lpszLongPath *PWSTRElement, cchBuffer uint32, hTransaction HANDLE) (r uint32, err error) = kernel32.dll.GetLongPathNameTransactedW
-//sys	SetFileCompletionNotificationModes(FileHandle HANDLE, Flags uint8) (r BOOL, err error) = kernel32.dll.SetFileCompletionNotificationModes
-//sys	SetFileShortNameA(hFile HANDLE, lpShortName *PSTRElement) (r BOOL, err error) = kernel32.dll.SetFileShortNameA
-//sys	SetFileShortNameW(hFile HANDLE, lpShortName *PWSTRElement) (r BOOL, err error) = kernel32.dll.SetFileShortNameW
-//sys	SetTapePosition(hDevice HANDLE, dwPositionMethod TAPE_POSITION_METHOD, dwPartition uint32, dwOffsetLow uint32, dwOffsetHigh uint32, bImmediate BOOL) (r uint32) = kernel32.dll.SetTapePosition
-//sys	GetTapePosition(hDevice HANDLE, dwPositionType TAPE_POSITION_TYPE, lpdwPartition *uint32, lpdwOffsetLow *uint32, lpdwOffsetHigh *uint32) (r uint32) = kernel32.dll.GetTapePosition
-//sys	PrepareTape(hDevice HANDLE, dwOperation PREPARE_TAPE_OPERATION, bImmediate BOOL) (r uint32) = kernel32.dll.PrepareTape
-//sys	EraseTape(hDevice HANDLE, dwEraseType ERASE_TAPE_TYPE, bImmediate BOOL) (r uint32) = kernel32.dll.EraseTape
-//sys	CreateTapePartition(hDevice HANDLE, dwPartitionMethod CREATE_TAPE_PARTITION_METHOD, dwCount uint32, dwSize uint32) (r uint32) = kernel32.dll.CreateTapePartition
-//sys	WriteTapemark(hDevice HANDLE, dwTapemarkType TAPEMARK_TYPE, dwTapemarkCount uint32, bImmediate BOOL) (r uint32) = kernel32.dll.WriteTapemark
-//sys	GetTapeStatus(hDevice HANDLE) (r uint32) = kernel32.dll.GetTapeStatus
-//sys	GetTapeParameters(hDevice HANDLE, dwOperation GET_TAPE_DRIVE_PARAMETERS_OPERATION, lpdwSize *uint32, lpTapeInformation unsafe.Pointer) (r uint32) = kernel32.dll.GetTapeParameters
-//sys	SetTapeParameters(hDevice HANDLE, dwOperation TAPE_INFORMATION_TYPE, lpTapeInformation unsafe.Pointer) (r uint32) = kernel32.dll.SetTapeParameters
-//sys	EncryptFileA(lpFileName *PSTRElement) (r BOOL, err error) = advapi32.dll.EncryptFileA
-//sys	EncryptFileW(lpFileName *PWSTRElement) (r BOOL, err error) = advapi32.dll.EncryptFileW
-//sys	DecryptFileA(lpFileName *PSTRElement, dwReserved uint32) (r BOOL, err error) = advapi32.dll.DecryptFileA
-//sys	DecryptFileW(lpFileName *PWSTRElement, dwReserved uint32) (r BOOL, err error) = advapi32.dll.DecryptFileW
-//sys	FileEncryptionStatusA(lpFileName *PSTRElement, lpStatus *uint32) (r BOOL, err error) = advapi32.dll.FileEncryptionStatusA
-//sys	FileEncryptionStatusW(lpFileName *PWSTRElement, lpStatus *uint32) (r BOOL, err error) = advapi32.dll.FileEncryptionStatusW
-//sys	OpenEncryptedFileRawA(lpFileName *PSTRElement, ulFlags uint32, pvContext *unsafe.Pointer) (r uint32) = advapi32.dll.OpenEncryptedFileRawA
-//sys	OpenEncryptedFileRawW(lpFileName *PWSTRElement, ulFlags uint32, pvContext *unsafe.Pointer) (r uint32) = advapi32.dll.OpenEncryptedFileRawW
-//sys	ReadEncryptedFileRaw(pfExportCallback PFE_EXPORT_FUNC, pvCallbackContext unsafe.Pointer, pvContext unsafe.Pointer) (r uint32) = advapi32.dll.ReadEncryptedFileRaw
-//sys	WriteEncryptedFileRaw(pfImportCallback PFE_IMPORT_FUNC, pvCallbackContext unsafe.Pointer, pvContext unsafe.Pointer) (r uint32) = advapi32.dll.WriteEncryptedFileRaw
-//sys	CloseEncryptedFileRaw(pvContext unsafe.Pointer) = advapi32.dll.CloseEncryptedFileRaw
-//sys	OpenFile(lpFileName *PSTRElement, lpReOpenBuff *OFSTRUCT, uStyle uint32) (r int32, err error) = kernel32.dll.OpenFile
-//sys	BackupRead(hFile HANDLE, lpBuffer *uint8, nNumberOfBytesToRead uint32, lpNumberOfBytesRead *uint32, bAbort BOOL, bProcessSecurity BOOL, lpContext *unsafe.Pointer) (r BOOL, err error) = kernel32.dll.BackupRead
-//sys	BackupSeek(hFile HANDLE, dwLowBytesToSeek uint32, dwHighBytesToSeek uint32, lpdwLowByteSeeked *uint32, lpdwHighByteSeeked *uint32, lpContext *unsafe.Pointer) (r BOOL, err error) = kernel32.dll.BackupSeek
-//sys	BackupWrite(hFile HANDLE, lpBuffer *uint8, nNumberOfBytesToWrite uint32, lpNumberOfBytesWritten *uint32, bAbort BOOL, bProcessSecurity BOOL, lpContext *unsafe.Pointer) (r BOOL, err error) = kernel32.dll.BackupWrite
-//sys	GetLogicalDriveStringsA(nBufferLength uint32, lpBuffer *PSTRElement) (r uint32, err error) = kernel32.dll.GetLogicalDriveStringsA
-//sys	SetSearchPathMode(Flags uint32) (r BOOL, err error) = kernel32.dll.SetSearchPathMode
-//sys	CreateDirectoryExA(lpTemplateDirectory *PSTRElement, lpNewDirectory *PSTRElement, lpSecurityAttributes *SECURITY_ATTRIBUTES) (r BOOL, err error) = kernel32.dll.CreateDirectoryExA
-//sys	CreateDirectoryExW(lpTemplateDirectory *PWSTRElement, lpNewDirectory *PWSTRElement, lpSecurityAttributes *SECURITY_ATTRIBUTES) (r BOOL, err error) = kernel32.dll.CreateDirectoryExW
-//sys	CreateDirectoryTransactedA(lpTemplateDirectory *PSTRElement, lpNewDirectory *PSTRElement, lpSecurityAttributes *SECURITY_ATTRIBUTES, hTransaction HANDLE) (r BOOL, err error) = kernel32.dll.CreateDirectoryTransactedA
-//sys	CreateDirectoryTransactedW(lpTemplateDirectory *PWSTRElement, lpNewDirectory *PWSTRElement, lpSecurityAttributes *SECURITY_ATTRIBUTES, hTransaction HANDLE) (r BOOL, err error) = kernel32.dll.CreateDirectoryTransactedW
-//sys	RemoveDirectoryTransactedA(lpPathName *PSTRElement, hTransaction HANDLE) (r BOOL, err error) = kernel32.dll.RemoveDirectoryTransactedA
-//sys	RemoveDirectoryTransactedW(lpPathName *PWSTRElement, hTransaction HANDLE) (r BOOL, err error) = kernel32.dll.RemoveDirectoryTransactedW
-//sys	GetFullPathNameTransactedA(lpFileName *PSTRElement, nBufferLength uint32, lpBuffer *PSTRElement, lpFilePart **PSTRElement, hTransaction HANDLE) (r uint32, err error) = kernel32.dll.GetFullPathNameTransactedA
-//sys	GetFullPathNameTransactedW(lpFileName *PWSTRElement, nBufferLength uint32, lpBuffer *PWSTRElement, lpFilePart **PWSTRElement, hTransaction HANDLE) (r uint32, err error) = kernel32.dll.GetFullPathNameTransactedW
-//sys	DefineDosDeviceA(dwFlags DEFINE_DOS_DEVICE_FLAGS, lpDeviceName *PSTRElement, lpTargetPath *PSTRElement) (r BOOL, err error) = kernel32.dll.DefineDosDeviceA
-//sys	QueryDosDeviceA(lpDeviceName *PSTRElement, lpTargetPath *PSTRElement, ucchMax uint32) (r uint32, err error) = kernel32.dll.QueryDosDeviceA
-//sys	CreateFileTransactedA(lpFileName *PSTRElement, dwDesiredAccess uint32, dwShareMode FILE_SHARE_MODE, lpSecurityAttributes *SECURITY_ATTRIBUTES, dwCreationDisposition FILE_CREATION_DISPOSITION, dwFlagsAndAttributes FILE_FLAGS_AND_ATTRIBUTES, hTemplateFile HANDLE, hTransaction HANDLE, pusMiniVersion *TXFS_MINIVERSION, lpExtendedParameter unsafe.Pointer) (r HANDLE, err error) = kernel32.dll.CreateFileTransactedA
-//sys	CreateFileTransactedW(lpFileName *PWSTRElement, dwDesiredAccess uint32, dwShareMode FILE_SHARE_MODE, lpSecurityAttributes *SECURITY_ATTRIBUTES, dwCreationDisposition FILE_CREATION_DISPOSITION, dwFlagsAndAttributes FILE_FLAGS_AND_ATTRIBUTES, hTemplateFile HANDLE, hTransaction HANDLE, pusMiniVersion *TXFS_MINIVERSION, lpExtendedParameter unsafe.Pointer) (r HANDLE, err error) = kernel32.dll.CreateFileTransactedW
-//sys	ReOpenFile(hOriginalFile HANDLE, dwDesiredAccess uint32, dwShareMode FILE_SHARE_MODE, dwFlagsAndAttributes FILE_FLAGS_AND_ATTRIBUTES) (r HANDLE, err error) = kernel32.dll.ReOpenFile
-//sys	SetFileAttributesTransactedA(lpFileName *PSTRElement, dwFileAttributes uint32, hTransaction HANDLE) (r BOOL, err error) = kernel32.dll.SetFileAttributesTransactedA
-//sys	SetFileAttributesTransactedW(lpFileName *PWSTRElement, dwFileAttributes uint32, hTransaction HANDLE) (r BOOL, err error) = kernel32.dll.SetFileAttributesTransactedW
-//sys	GetFileAttributesTransactedA(lpFileName *PSTRElement, fInfoLevelId GET_FILEEX_INFO_LEVELS, lpFileInformation unsafe.Pointer, hTransaction HANDLE) (r BOOL, err error) = kernel32.dll.GetFileAttributesTransactedA
-//sys	GetFileAttributesTransactedW(lpFileName *PWSTRElement, fInfoLevelId GET_FILEEX_INFO_LEVELS, lpFileInformation unsafe.Pointer, hTransaction HANDLE) (r BOOL, err error) = kernel32.dll.GetFileAttributesTransactedW
-//sys	GetCompressedFileSizeTransactedA(lpFileName *PSTRElement, lpFileSizeHigh *uint32, hTransaction HANDLE) (r uint32, err error) = kernel32.dll.GetCompressedFileSizeTransactedA
-//sys	GetCompressedFileSizeTransactedW(lpFileName *PWSTRElement, lpFileSizeHigh *uint32, hTransaction HANDLE) (r uint32, err error) = kernel32.dll.GetCompressedFileSizeTransactedW
-//sys	DeleteFileTransactedA(lpFileName *PSTRElement, hTransaction HANDLE) (r BOOL, err error) = kernel32.dll.DeleteFileTransactedA
-//sys	DeleteFileTransactedW(lpFileName *PWSTRElement, hTransaction HANDLE) (r BOOL, err error) = kernel32.dll.DeleteFileTransactedW
-//sys	CheckNameLegalDOS8Dot3A(lpName *PSTRElement, lpOemName *PSTRElement, OemNameSize uint32, pbNameContainsSpaces *BOOL, pbNameLegal *BOOL) (r BOOL, err error) = kernel32.dll.CheckNameLegalDOS8Dot3A
-//sys	CheckNameLegalDOS8Dot3W(lpName *PWSTRElement, lpOemName *PSTRElement, OemNameSize uint32, pbNameContainsSpaces *BOOL, pbNameLegal *BOOL) (r BOOL, err error) = kernel32.dll.CheckNameLegalDOS8Dot3W
-//sys	FindFirstFileTransactedA(lpFileName *PSTRElement, fInfoLevelId FINDEX_INFO_LEVELS, lpFindFileData unsafe.Pointer, fSearchOp FINDEX_SEARCH_OPS, lpSearchFilter unsafe.Pointer, dwAdditionalFlags uint32, hTransaction HANDLE) (r HANDLE, err error) = kernel32.dll.FindFirstFileTransactedA
-//sys	FindFirstFileTransactedW(lpFileName *PWSTRElement, fInfoLevelId FINDEX_INFO_LEVELS, lpFindFileData unsafe.Pointer, fSearchOp FINDEX_SEARCH_OPS, lpSearchFilter unsafe.Pointer, dwAdditionalFlags uint32, hTransaction HANDLE) (r HANDLE, err error) = kernel32.dll.FindFirstFileTransactedW
-//sys	CopyFileA(lpExistingFileName *PSTRElement, lpNewFileName *PSTRElement, bFailIfExists BOOL) (r BOOL, err error) = kernel32.dll.CopyFileA
-//sys	CopyFileW(lpExistingFileName *PWSTRElement, lpNewFileName *PWSTRElement, bFailIfExists BOOL) (r BOOL, err error) = kernel32.dll.CopyFileW
-//sys	CopyFileExA(lpExistingFileName *PSTRElement, lpNewFileName *PSTRElement, lpProgressRoutine LPPROGRESS_ROUTINE, lpData unsafe.Pointer, pbCancel *BOOL, dwCopyFlags COPYFILE_FLAGS) (r BOOL, err error) = kernel32.dll.CopyFileExA
-//sys	CopyFileExW(lpExistingFileName *PWSTRElement, lpNewFileName *PWSTRElement, lpProgressRoutine LPPROGRESS_ROUTINE, lpData unsafe.Pointer, pbCancel *BOOL, dwCopyFlags COPYFILE_FLAGS) (r BOOL, err error) = kernel32.dll.CopyFileExW
-//sys	CopyFileTransactedA(lpExistingFileName *PSTRElement, lpNewFileName *PSTRElement, lpProgressRoutine LPPROGRESS_ROUTINE, lpData unsafe.Pointer, pbCancel *BOOL, dwCopyFlags uint32, hTransaction HANDLE) (r BOOL, err error) = kernel32.dll.CopyFileTransactedA
-//sys	CopyFileTransactedW(lpExistingFileName *PWSTRElement, lpNewFileName *PWSTRElement, lpProgressRoutine LPPROGRESS_ROUTINE, lpData unsafe.Pointer, pbCancel *BOOL, dwCopyFlags uint32, hTransaction HANDLE) (r BOOL, err error) = kernel32.dll.CopyFileTransactedW
-//sys	CopyFile2(pwszExistingFileName *PWSTRElement, pwszNewFileName *PWSTRElement, pExtendedParameters *COPYFILE2_EXTENDED_PARAMETERS) (r HRESULT) = kernel32.dll.CopyFile2
-//sys	MoveFileA(lpExistingFileName *PSTRElement, lpNewFileName *PSTRElement) (r BOOL, err error) = kernel32.dll.MoveFileA
-//sys	MoveFileW(lpExistingFileName *PWSTRElement, lpNewFileName *PWSTRElement) (r BOOL, err error) = kernel32.dll.MoveFileW
-//sys	MoveFileExA(lpExistingFileName *PSTRElement, lpNewFileName *PSTRElement, dwFlags MOVE_FILE_FLAGS) (r BOOL, err error) = kernel32.dll.MoveFileExA
-//sys	MoveFileExW(lpExistingFileName *PWSTRElement, lpNewFileName *PWSTRElement, dwFlags MOVE_FILE_FLAGS) (r BOOL, err error) = kernel32.dll.MoveFileExW
-//sys	MoveFileWithProgressA(lpExistingFileName *PSTRElement, lpNewFileName *PSTRElement, lpProgressRoutine LPPROGRESS_ROUTINE, lpData unsafe.Pointer, dwFlags MOVE_FILE_FLAGS) (r BOOL, err error) = kernel32.dll.MoveFileWithProgressA
-//sys	MoveFileWithProgressW(lpExistingFileName *PWSTRElement, lpNewFileName *PWSTRElement, lpProgressRoutine LPPROGRESS_ROUTINE, lpData unsafe.Pointer, dwFlags MOVE_FILE_FLAGS) (r BOOL, err error) = kernel32.dll.MoveFileWithProgressW
-//sys	MoveFileTransactedA(lpExistingFileName *PSTRElement, lpNewFileName *PSTRElement, lpProgressRoutine LPPROGRESS_ROUTINE, lpData unsafe.Pointer, dwFlags MOVE_FILE_FLAGS, hTransaction HANDLE) (r BOOL, err error) = kernel32.dll.MoveFileTransactedA
-//sys	MoveFileTransactedW(lpExistingFileName *PWSTRElement, lpNewFileName *PWSTRElement, lpProgressRoutine LPPROGRESS_ROUTINE, lpData unsafe.Pointer, dwFlags MOVE_FILE_FLAGS, hTransaction HANDLE) (r BOOL, err error) = kernel32.dll.MoveFileTransactedW
-//sys	ReplaceFileA(lpReplacedFileName *PSTRElement, lpReplacementFileName *PSTRElement, lpBackupFileName *PSTRElement, dwReplaceFlags REPLACE_FILE_FLAGS, lpExclude unsafe.Pointer, lpReserved unsafe.Pointer) (r BOOL, err error) = kernel32.dll.ReplaceFileA
-//sys	ReplaceFileW(lpReplacedFileName *PWSTRElement, lpReplacementFileName *PWSTRElement, lpBackupFileName *PWSTRElement, dwReplaceFlags REPLACE_FILE_FLAGS, lpExclude unsafe.Pointer, lpReserved unsafe.Pointer) (r BOOL, err error) = kernel32.dll.ReplaceFileW
-//sys	CreateHardLinkA(lpFileName *PSTRElement, lpExistingFileName *PSTRElement, lpSecurityAttributes *SECURITY_ATTRIBUTES) (r BOOL, err error) = kernel32.dll.CreateHardLinkA
-//sys	CreateHardLinkW(lpFileName *PWSTRElement, lpExistingFileName *PWSTRElement, lpSecurityAttributes *SECURITY_ATTRIBUTES) (r BOOL, err error) = kernel32.dll.CreateHardLinkW
-//sys	CreateHardLinkTransactedA(lpFileName *PSTRElement, lpExistingFileName *PSTRElement, lpSecurityAttributes *SECURITY_ATTRIBUTES, hTransaction HANDLE) (r BOOL, err error) = kernel32.dll.CreateHardLinkTransactedA
-//sys	CreateHardLinkTransactedW(lpFileName *PWSTRElement, lpExistingFileName *PWSTRElement, lpSecurityAttributes *SECURITY_ATTRIBUTES, hTransaction HANDLE) (r BOOL, err error) = kernel32.dll.CreateHardLinkTransactedW
-//sys	FindFirstStreamTransactedW(lpFileName *PWSTRElement, InfoLevel STREAM_INFO_LEVELS, lpFindStreamData unsafe.Pointer, dwFlags uint32, hTransaction HANDLE) (r HANDLE, err error) = kernel32.dll.FindFirstStreamTransactedW
-//sys	FindFirstFileNameTransactedW(lpFileName *PWSTRElement, dwFlags uint32, StringLength *uint32, LinkName *PWSTRElement, hTransaction HANDLE) (r HANDLE, err error) = kernel32.dll.FindFirstFileNameTransactedW
-//sys	SetVolumeLabelA(lpRootPathName *PSTRElement, lpVolumeName *PSTRElement) (r BOOL, err error) = kernel32.dll.SetVolumeLabelA
-//sys	SetVolumeLabelW(lpRootPathName *PWSTRElement, lpVolumeName *PWSTRElement) (r BOOL, err error) = kernel32.dll.SetVolumeLabelW
-//sys	SetFileBandwidthReservation(hFile HANDLE, nPeriodMilliseconds uint32, nBytesPerPeriod uint32, bDiscardable BOOL, lpTransferSize *uint32, lpNumOutstandingRequests *uint32) (r BOOL, err error) = kernel32.dll.SetFileBandwidthReservation
-//sys	GetFileBandwidthReservation(hFile HANDLE, lpPeriodMilliseconds *uint32, lpBytesPerPeriod *uint32, pDiscardable *BOOL, lpTransferSize *uint32, lpNumOutstandingRequests *uint32) (r BOOL, err error) = kernel32.dll.GetFileBandwidthReservation
-//sys	ReadDirectoryChangesW(hDirectory HANDLE, lpBuffer unsafe.Pointer, nBufferLength uint32, bWatchSubtree BOOL, dwNotifyFilter FILE_NOTIFY_CHANGE, lpBytesReturned *uint32, lpOverlapped *OVERLAPPED, lpCompletionRoutine LPOVERLAPPED_COMPLETION_ROUTINE) (r BOOL, err error) = kernel32.dll.ReadDirectoryChangesW
-//sys	ReadDirectoryChangesExW(hDirectory HANDLE, lpBuffer unsafe.Pointer, nBufferLength uint32, bWatchSubtree BOOL, dwNotifyFilter FILE_NOTIFY_CHANGE, lpBytesReturned *uint32, lpOverlapped *OVERLAPPED, lpCompletionRoutine LPOVERLAPPED_COMPLETION_ROUTINE, ReadDirectoryNotifyInformationClass READ_DIRECTORY_NOTIFY_INFORMATION_CLASS) (r BOOL, err error) = kernel32.dll.ReadDirectoryChangesExW
-//sys	FindFirstVolumeA(lpszVolumeName *PSTRElement, cchBufferLength uint32) (r HANDLE, err error) = kernel32.dll.FindFirstVolumeA
-//sys	FindNextVolumeA(hFindVolume HANDLE, lpszVolumeName *PSTRElement, cchBufferLength uint32) (r BOOL, err error) = kernel32.dll.FindNextVolumeA
-//sys	FindFirstVolumeMountPointA(lpszRootPathName *PSTRElement, lpszVolumeMountPoint *PSTRElement, cchBufferLength uint32) (r HANDLE, err error) = kernel32.dll.FindFirstVolumeMountPointA
-//sys	FindFirstVolumeMountPointW(lpszRootPathName *PWSTRElement, lpszVolumeMountPoint *PWSTRElement, cchBufferLength uint32) (r HANDLE, err error) = kernel32.dll.FindFirstVolumeMountPointW
-//sys	FindNextVolumeMountPointA(hFindVolumeMountPoint HANDLE, lpszVolumeMountPoint *PSTRElement, cchBufferLength uint32) (r BOOL, err error) = kernel32.dll.FindNextVolumeMountPointA
-//sys	FindNextVolumeMountPointW(hFindVolumeMountPoint HANDLE, lpszVolumeMountPoint *PWSTRElement, cchBufferLength uint32) (r BOOL, err error) = kernel32.dll.FindNextVolumeMountPointW
-//sys	FindVolumeMountPointClose(hFindVolumeMountPoint HANDLE) (r BOOL, err error) = kernel32.dll.FindVolumeMountPointClose
-//sys	SetVolumeMountPointA(lpszVolumeMountPoint *PSTRElement, lpszVolumeName *PSTRElement) (r BOOL, err error) = kernel32.dll.SetVolumeMountPointA
-//sys	SetVolumeMountPointW(lpszVolumeMountPoint *PWSTRElement, lpszVolumeName *PWSTRElement) (r BOOL, err error) = kernel32.dll.SetVolumeMountPointW
-//sys	DeleteVolumeMountPointA(lpszVolumeMountPoint *PSTRElement) (r BOOL, err error) = kernel32.dll.DeleteVolumeMountPointA
-//sys	GetVolumeNameForVolumeMountPointA(lpszVolumeMountPoint *PSTRElement, lpszVolumeName *PSTRElement, cchBufferLength uint32) (r BOOL, err error) = kernel32.dll.GetVolumeNameForVolumeMountPointA
-//sys	GetVolumePathNameA(lpszFileName *PSTRElement, lpszVolumePathName *PSTRElement, cchBufferLength uint32) (r BOOL, err error) = kernel32.dll.GetVolumePathNameA
-//sys	GetVolumePathNamesForVolumeNameA(lpszVolumeName *PSTRElement, lpszVolumePathNames *PSTRElement, cchBufferLength uint32, lpcchReturnLength *uint32) (r BOOL, err error) = kernel32.dll.GetVolumePathNamesForVolumeNameA
-//sys	GetFileInformationByHandleEx(hFile HANDLE, FileInformationClass FILE_INFO_BY_HANDLE_CLASS, lpFileInformation unsafe.Pointer, dwBufferSize uint32) (r BOOL, err error) = kernel32.dll.GetFileInformationByHandleEx
-//sys	GetFileInformationByName(FileName *PWSTRElement, FileInformationClass FILE_INFO_BY_NAME_CLASS, FileInfoBuffer unsafe.Pointer, FileInfoBufferSize uint32) (r BOOL) = kernel32.dll.GetFileInformationByName
-//sys	OpenFileById(hVolumeHint HANDLE, lpFileId *FILE_ID_DESCRIPTOR, dwDesiredAccess uint32, dwShareMode FILE_SHARE_MODE, lpSecurityAttributes *SECURITY_ATTRIBUTES, dwFlagsAndAttributes FILE_FLAGS_AND_ATTRIBUTES) (r HANDLE, err error) = kernel32.dll.OpenFileById
-//sys	CreateSymbolicLinkA(lpSymlinkFileName *PSTRElement, lpTargetFileName *PSTRElement, dwFlags SYMBOLIC_LINK_FLAGS) (r BOOLEAN, err error) = kernel32.dll.CreateSymbolicLinkA
-//sys	CreateSymbolicLinkW(lpSymlinkFileName *PWSTRElement, lpTargetFileName *PWSTRElement, dwFlags SYMBOLIC_LINK_FLAGS) (r BOOLEAN, err error) = kernel32.dll.CreateSymbolicLinkW
-//sys	CreateSymbolicLinkTransactedA(lpSymlinkFileName *PSTRElement, lpTargetFileName *PSTRElement, dwFlags SYMBOLIC_LINK_FLAGS, hTransaction HANDLE) (r BOOLEAN, err error) = kernel32.dll.CreateSymbolicLinkTransactedA
-//sys	CreateSymbolicLinkTransactedW(lpSymlinkFileName *PWSTRElement, lpTargetFileName *PWSTRElement, dwFlags SYMBOLIC_LINK_FLAGS, hTransaction HANDLE) (r BOOLEAN, err error) = kernel32.dll.CreateSymbolicLinkTransactedW
+//sys	SearchPathW(lpPath *PWSTRElement, lpFileName *PWSTRElement, lpExtension *PWSTRElement, nBufferLength uint32, lpBuffer *PWSTRElement, lpFilePart **PWSTRElement) (r uint32, err error)
+//sys	SearchPathA(lpPath *PSTRElement, lpFileName *PSTRElement, lpExtension *PSTRElement, nBufferLength uint32, lpBuffer *PSTRElement, lpFilePart **PSTRElement) (r uint32, err error)
+//sys	CompareFileTime(lpFileTime1 *FILETIME, lpFileTime2 *FILETIME) (r int32)
+//sys	CreateDirectoryA(lpPathName *PSTRElement, lpSecurityAttributes *SECURITY_ATTRIBUTES) (r BOOL, err error)
+//sys	CreateDirectoryW(lpPathName *PWSTRElement, lpSecurityAttributes *SECURITY_ATTRIBUTES) (r BOOL, err error)
+//sys	CreateFileA(lpFileName *PSTRElement, dwDesiredAccess uint32, dwShareMode FILE_SHARE_MODE, lpSecurityAttributes *SECURITY_ATTRIBUTES, dwCreationDisposition FILE_CREATION_DISPOSITION, dwFlagsAndAttributes FILE_FLAGS_AND_ATTRIBUTES, hTemplateFile HANDLE) (r HANDLE, err error)
+//sys	CreateFileW(lpFileName *PWSTRElement, dwDesiredAccess uint32, dwShareMode FILE_SHARE_MODE, lpSecurityAttributes *SECURITY_ATTRIBUTES, dwCreationDisposition FILE_CREATION_DISPOSITION, dwFlagsAndAttributes FILE_FLAGS_AND_ATTRIBUTES, hTemplateFile HANDLE) (r HANDLE, err error)
+//sys	DefineDosDeviceW(dwFlags DEFINE_DOS_DEVICE_FLAGS, lpDeviceName *PWSTRElement, lpTargetPath *PWSTRElement) (r BOOL, err error)
+//sys	DeleteFileA(lpFileName *PSTRElement) (r BOOL, err error)
+//sys	DeleteFileW(lpFileName *PWSTRElement) (r BOOL, err error)
+//sys	DeleteVolumeMountPointW(lpszVolumeMountPoint *PWSTRElement) (r BOOL, err error)
+//sys	FileTimeToLocalFileTime(lpFileTime *FILETIME, lpLocalFileTime *FILETIME) (r BOOL, err error)
+//sys	FindClose(hFindFile HANDLE) (r BOOL, err error)
+//sys	FindCloseChangeNotification(hChangeHandle HANDLE) (r BOOL, err error)
+//sys	FindFirstChangeNotificationA(lpPathName *PSTRElement, bWatchSubtree BOOL, dwNotifyFilter FILE_NOTIFY_CHANGE) (r HANDLE, err error)
+//sys	FindFirstChangeNotificationW(lpPathName *PWSTRElement, bWatchSubtree BOOL, dwNotifyFilter FILE_NOTIFY_CHANGE) (r HANDLE, err error)
+//sys	FindFirstFileA(lpFileName *PSTRElement, lpFindFileData *WIN32_FIND_DATAA) (r HANDLE, err error)
+//sys	FindFirstFileW(lpFileName *PWSTRElement, lpFindFileData *WIN32_FIND_DATAW) (r HANDLE, err error)
+//sys	FindFirstFileExA(lpFileName *PSTRElement, fInfoLevelId FINDEX_INFO_LEVELS, lpFindFileData unsafe.Pointer, fSearchOp FINDEX_SEARCH_OPS, lpSearchFilter unsafe.Pointer, dwAdditionalFlags FIND_FIRST_EX_FLAGS) (r HANDLE, err error)
+//sys	FindFirstFileExW(lpFileName *PWSTRElement, fInfoLevelId FINDEX_INFO_LEVELS, lpFindFileData unsafe.Pointer, fSearchOp FINDEX_SEARCH_OPS, lpSearchFilter unsafe.Pointer, dwAdditionalFlags FIND_FIRST_EX_FLAGS) (r HANDLE, err error)
+//sys	FindFirstVolumeW(lpszVolumeName *PWSTRElement, cchBufferLength uint32) (r HANDLE, err error)
+//sys	FindNextChangeNotification(hChangeHandle HANDLE) (r BOOL, err error)
+//sys	FindNextFileA(hFindFile HANDLE, lpFindFileData *WIN32_FIND_DATAA) (r BOOL, err error)
+//sys	FindNextFileW(hFindFile HANDLE, lpFindFileData *WIN32_FIND_DATAW) (r BOOL, err error)
+//sys	FindNextVolumeW(hFindVolume HANDLE, lpszVolumeName *PWSTRElement, cchBufferLength uint32) (r BOOL, err error)
+//sys	FindVolumeClose(hFindVolume HANDLE) (r BOOL, err error)
+//sys	FlushFileBuffers(hFile HANDLE) (r BOOL, err error)
+//sys	GetDiskFreeSpaceA(lpRootPathName *PSTRElement, lpSectorsPerCluster *uint32, lpBytesPerSector *uint32, lpNumberOfFreeClusters *uint32, lpTotalNumberOfClusters *uint32) (r BOOL, err error)
+//sys	GetDiskFreeSpaceW(lpRootPathName *PWSTRElement, lpSectorsPerCluster *uint32, lpBytesPerSector *uint32, lpNumberOfFreeClusters *uint32, lpTotalNumberOfClusters *uint32) (r BOOL, err error)
+//sys	GetDiskFreeSpaceExA(lpDirectoryName *PSTRElement, lpFreeBytesAvailableToCaller *uint64, lpTotalNumberOfBytes *uint64, lpTotalNumberOfFreeBytes *uint64) (r BOOL, err error)
+//sys	GetDiskFreeSpaceExW(lpDirectoryName *PWSTRElement, lpFreeBytesAvailableToCaller *uint64, lpTotalNumberOfBytes *uint64, lpTotalNumberOfFreeBytes *uint64) (r BOOL, err error)
+//sys	GetDiskSpaceInformationA(rootPath *PSTRElement, diskSpaceInfo *DISK_SPACE_INFORMATION) (r HRESULT)
+//sys	GetDiskSpaceInformationW(rootPath *PWSTRElement, diskSpaceInfo *DISK_SPACE_INFORMATION) (r HRESULT)
+//sys	GetDriveTypeA(lpRootPathName *PSTRElement) (r uint32)
+//sys	GetDriveTypeW(lpRootPathName *PWSTRElement) (r uint32)
+//sys	GetFileAttributesA(lpFileName *PSTRElement) (r uint32, err error)
+//sys	GetFileAttributesW(lpFileName *PWSTRElement) (r uint32, err error)
+//sys	GetFileAttributesExA(lpFileName *PSTRElement, fInfoLevelId GET_FILEEX_INFO_LEVELS, lpFileInformation unsafe.Pointer) (r BOOL, err error)
+//sys	GetFileAttributesExW(lpFileName *PWSTRElement, fInfoLevelId GET_FILEEX_INFO_LEVELS, lpFileInformation unsafe.Pointer) (r BOOL, err error)
+//sys	GetFileInformationByHandle(hFile HANDLE, lpFileInformation *BY_HANDLE_FILE_INFORMATION) (r BOOL, err error)
+//sys	GetFileSize(hFile HANDLE, lpFileSizeHigh *uint32) (r uint32, err error)
+//sys	GetFileSizeEx(hFile HANDLE, lpFileSize *int64) (r BOOL, err error)
+//sys	GetFileType(hFile HANDLE) (r FILE_TYPE, err error)
+//sys	GetFinalPathNameByHandleA(hFile HANDLE, lpszFilePath *PSTRElement, cchFilePath uint32, dwFlags GETFINALPATHNAMEBYHANDLE_FLAGS) (r uint32, err error)
+//sys	GetFinalPathNameByHandleW(hFile HANDLE, lpszFilePath *PWSTRElement, cchFilePath uint32, dwFlags GETFINALPATHNAMEBYHANDLE_FLAGS) (r uint32, err error)
+//sys	GetFileTime(hFile HANDLE, lpCreationTime *FILETIME, lpLastAccessTime *FILETIME, lpLastWriteTime *FILETIME) (r BOOL, err error)
+//sys	GetFullPathNameW(lpFileName *PWSTRElement, nBufferLength uint32, lpBuffer *PWSTRElement, lpFilePart **PWSTRElement) (r uint32, err error)
+//sys	GetFullPathNameA(lpFileName *PSTRElement, nBufferLength uint32, lpBuffer *PSTRElement, lpFilePart **PSTRElement) (r uint32, err error)
+//sys	GetLogicalDrives() (r uint32, err error)
+//sys	GetLogicalDriveStringsW(nBufferLength uint32, lpBuffer *PWSTRElement) (r uint32, err error)
+//sys	GetLongPathNameA(lpszShortPath *PSTRElement, lpszLongPath *PSTRElement, cchBuffer uint32) (r uint32, err error)
+//sys	GetLongPathNameW(lpszShortPath *PWSTRElement, lpszLongPath *PWSTRElement, cchBuffer uint32) (r uint32, err error)
+//sys	AreShortNamesEnabled(Handle HANDLE, Enabled *BOOL) (r BOOL)
+//sys	GetShortPathNameW(lpszLongPath *PWSTRElement, lpszShortPath *PWSTRElement, cchBuffer uint32) (r uint32, err error)
+//sys	GetTempFileNameW(lpPathName *PWSTRElement, lpPrefixString *PWSTRElement, uUnique uint32, lpTempFileName *PWSTRElement) (r uint32, err error)
+//sys	GetVolumeInformationByHandleW(hFile HANDLE, lpVolumeNameBuffer *PWSTRElement, nVolumeNameSize uint32, lpVolumeSerialNumber *uint32, lpMaximumComponentLength *uint32, lpFileSystemFlags *uint32, lpFileSystemNameBuffer *PWSTRElement, nFileSystemNameSize uint32) (r BOOL, err error)
+//sys	GetVolumeInformationW(lpRootPathName *PWSTRElement, lpVolumeNameBuffer *PWSTRElement, nVolumeNameSize uint32, lpVolumeSerialNumber *uint32, lpMaximumComponentLength *uint32, lpFileSystemFlags *uint32, lpFileSystemNameBuffer *PWSTRElement, nFileSystemNameSize uint32) (r BOOL, err error)
+//sys	GetVolumePathNameW(lpszFileName *PWSTRElement, lpszVolumePathName *PWSTRElement, cchBufferLength uint32) (r BOOL, err error)
+//sys	LocalFileTimeToFileTime(lpLocalFileTime *FILETIME, lpFileTime *FILETIME) (r BOOL, err error)
+//sys	LockFile(hFile HANDLE, dwFileOffsetLow uint32, dwFileOffsetHigh uint32, nNumberOfBytesToLockLow uint32, nNumberOfBytesToLockHigh uint32) (r BOOL, err error)
+//sys	LockFileEx(hFile HANDLE, dwFlags LOCK_FILE_FLAGS, dwReserved uint32, nNumberOfBytesToLockLow uint32, nNumberOfBytesToLockHigh uint32, lpOverlapped *OVERLAPPED) (r BOOL, err error)
+//sys	QueryDosDeviceW(lpDeviceName *PWSTRElement, lpTargetPath *PWSTRElement, ucchMax uint32) (r uint32, err error)
+//sys	ReadFile(hFile HANDLE, lpBuffer *uint8, nNumberOfBytesToRead uint32, lpNumberOfBytesRead *uint32, lpOverlapped *OVERLAPPED) (r BOOL, err error)
+//sys	ReadFileEx(hFile HANDLE, lpBuffer *uint8, nNumberOfBytesToRead uint32, lpOverlapped *OVERLAPPED, lpCompletionRoutine LPOVERLAPPED_COMPLETION_ROUTINE) (r BOOL, err error)
+//sys	ReadFileScatter(hFile HANDLE, aSegmentArray *FILE_SEGMENT_ELEMENT, nNumberOfBytesToRead uint32, lpReserved *uint32, lpOverlapped *OVERLAPPED) (r BOOL, err error)
+//sys	RemoveDirectoryA(lpPathName *PSTRElement) (r BOOL, err error)
+//sys	RemoveDirectoryW(lpPathName *PWSTRElement) (r BOOL, err error)
+//sys	SetEndOfFile(hFile HANDLE) (r BOOL, err error)
+//sys	SetFileAttributesA(lpFileName *PSTRElement, dwFileAttributes FILE_FLAGS_AND_ATTRIBUTES) (r BOOL, err error)
+//sys	SetFileAttributesW(lpFileName *PWSTRElement, dwFileAttributes FILE_FLAGS_AND_ATTRIBUTES) (r BOOL, err error)
+//sys	SetFileInformationByHandle(hFile HANDLE, FileInformationClass FILE_INFO_BY_HANDLE_CLASS, lpFileInformation unsafe.Pointer, dwBufferSize uint32) (r BOOL, err error)
+//sys	SetFilePointer(hFile HANDLE, lDistanceToMove int32, lpDistanceToMoveHigh *int32, dwMoveMethod SET_FILE_POINTER_MOVE_METHOD) (r uint32, err error)
+//sys	SetFilePointerEx(hFile HANDLE, liDistanceToMove int64, lpNewFilePointer *int64, dwMoveMethod SET_FILE_POINTER_MOVE_METHOD) (r BOOL, err error)
+//sys	SetFileTime(hFile HANDLE, lpCreationTime *FILETIME, lpLastAccessTime *FILETIME, lpLastWriteTime *FILETIME) (r BOOL, err error)
+//sys	SetFileValidData(hFile HANDLE, ValidDataLength int64) (r BOOL, err error)
+//sys	UnlockFile(hFile HANDLE, dwFileOffsetLow uint32, dwFileOffsetHigh uint32, nNumberOfBytesToUnlockLow uint32, nNumberOfBytesToUnlockHigh uint32) (r BOOL, err error)
+//sys	UnlockFileEx(hFile HANDLE, dwReserved uint32, nNumberOfBytesToUnlockLow uint32, nNumberOfBytesToUnlockHigh uint32, lpOverlapped *OVERLAPPED) (r BOOL, err error)
+//sys	WriteFile(hFile HANDLE, lpBuffer *uint8, nNumberOfBytesToWrite uint32, lpNumberOfBytesWritten *uint32, lpOverlapped *OVERLAPPED) (r BOOL, err error)
+//sys	WriteFileEx(hFile HANDLE, lpBuffer *uint8, nNumberOfBytesToWrite uint32, lpOverlapped *OVERLAPPED, lpCompletionRoutine LPOVERLAPPED_COMPLETION_ROUTINE) (r BOOL, err error)
+//sys	WriteFileGather(hFile HANDLE, aSegmentArray *FILE_SEGMENT_ELEMENT, nNumberOfBytesToWrite uint32, lpReserved *uint32, lpOverlapped *OVERLAPPED) (r BOOL, err error)
+//sys	GetTempPathW(nBufferLength uint32, lpBuffer *PWSTRElement) (r uint32, err error)
+//sys	GetVolumeNameForVolumeMountPointW(lpszVolumeMountPoint *PWSTRElement, lpszVolumeName *PWSTRElement, cchBufferLength uint32) (r BOOL, err error)
+//sys	GetVolumePathNamesForVolumeNameW(lpszVolumeName *PWSTRElement, lpszVolumePathNames *PWSTRElement, cchBufferLength uint32, lpcchReturnLength *uint32) (r BOOL, err error)
+//sys	CreateFile2(lpFileName *PWSTRElement, dwDesiredAccess uint32, dwShareMode FILE_SHARE_MODE, dwCreationDisposition FILE_CREATION_DISPOSITION, pCreateExParams *CREATEFILE2_EXTENDED_PARAMETERS) (r HANDLE, err error)
+//sys	SetFileIoOverlappedRange(FileHandle HANDLE, OverlappedRangeStart *uint8, Length uint32) (r BOOL, err error)
+//sys	GetCompressedFileSizeA(lpFileName *PSTRElement, lpFileSizeHigh *uint32) (r uint32, err error)
+//sys	GetCompressedFileSizeW(lpFileName *PWSTRElement, lpFileSizeHigh *uint32) (r uint32, err error)
+//sys	FindFirstStreamW(lpFileName *PWSTRElement, InfoLevel STREAM_INFO_LEVELS, lpFindStreamData unsafe.Pointer, dwFlags uint32) (r HANDLE, err error)
+//sys	FindNextStreamW(hFindStream HANDLE, lpFindStreamData unsafe.Pointer) (r BOOL, err error)
+//sys	AreFileApisANSI() (r BOOL)
+//sys	GetTempPathA(nBufferLength uint32, lpBuffer *PSTRElement) (r uint32, err error)
+//sys	FindFirstFileNameW(lpFileName *PWSTRElement, dwFlags uint32, StringLength *uint32, LinkName *PWSTRElement) (r HANDLE, err error)
+//sys	FindNextFileNameW(hFindStream HANDLE, StringLength *uint32, LinkName *PWSTRElement) (r BOOL, err error)
+//sys	GetVolumeInformationA(lpRootPathName *PSTRElement, lpVolumeNameBuffer *PSTRElement, nVolumeNameSize uint32, lpVolumeSerialNumber *uint32, lpMaximumComponentLength *uint32, lpFileSystemFlags *uint32, lpFileSystemNameBuffer *PSTRElement, nFileSystemNameSize uint32) (r BOOL, err error)
+//sys	GetTempFileNameA(lpPathName *PSTRElement, lpPrefixString *PSTRElement, uUnique uint32, lpTempFileName *PSTRElement) (r uint32, err error)
+//sys	SetFileApisToOEM()
+//sys	SetFileApisToANSI()
+//sys	GetTempPath2W(BufferLength uint32, Buffer *PWSTRElement) (r uint32)
+//sys	GetTempPath2A(BufferLength uint32, Buffer *PSTRElement) (r uint32)
+//sys	CreateFile3(lpFileName *PWSTRElement, dwDesiredAccess uint32, dwShareMode uint32, dwCreationDisposition uint32, pCreateExParams *CREATEFILE3_EXTENDED_PARAMETERS) (r HANDLE)
+//sys	CreateDirectory2A(lpPathName *PSTRElement, dwDesiredAccess uint32, dwShareMode uint32, DirectoryFlags DIRECTORY_FLAGS, lpSecurityAttributes *SECURITY_ATTRIBUTES) (r HANDLE)
+//sys	CreateDirectory2W(lpPathName *PWSTRElement, dwDesiredAccess uint32, dwShareMode uint32, DirectoryFlags DIRECTORY_FLAGS, lpSecurityAttributes *SECURITY_ATTRIBUTES) (r HANDLE)
+//sys	RemoveDirectory2A(lpPathName *PSTRElement, DirectoryFlags DIRECTORY_FLAGS) (r BOOL)
+//sys	RemoveDirectory2W(lpPathName *PWSTRElement, DirectoryFlags DIRECTORY_FLAGS) (r BOOL)
+//sys	DeleteFile2A(lpFileName *PSTRElement, Flags uint32) (r BOOL)
+//sys	DeleteFile2W(lpFileName *PWSTRElement, Flags uint32) (r BOOL)
+//sys	CopyFileFromAppW(lpExistingFileName *PWSTRElement, lpNewFileName *PWSTRElement, bFailIfExists BOOL) (r BOOL) = api-ms-win-core-file-fromapp-l1-1-0.CopyFileFromAppW
+//sys	CreateDirectoryFromAppW(lpPathName *PWSTRElement, lpSecurityAttributes *SECURITY_ATTRIBUTES) (r BOOL) = api-ms-win-core-file-fromapp-l1-1-0.CreateDirectoryFromAppW
+//sys	CreateFileFromAppW(lpFileName *PWSTRElement, dwDesiredAccess uint32, dwShareMode uint32, lpSecurityAttributes *SECURITY_ATTRIBUTES, dwCreationDisposition uint32, dwFlagsAndAttributes uint32, hTemplateFile HANDLE) (r HANDLE) = api-ms-win-core-file-fromapp-l1-1-0.CreateFileFromAppW
+//sys	CreateFile2FromAppW(lpFileName *PWSTRElement, dwDesiredAccess uint32, dwShareMode uint32, dwCreationDisposition uint32, pCreateExParams *CREATEFILE2_EXTENDED_PARAMETERS) (r HANDLE) = api-ms-win-core-file-fromapp-l1-1-0.CreateFile2FromAppW
+//sys	DeleteFileFromAppW(lpFileName *PWSTRElement) (r BOOL) = api-ms-win-core-file-fromapp-l1-1-0.DeleteFileFromAppW
+//sys	FindFirstFileExFromAppW(lpFileName *PWSTRElement, fInfoLevelId FINDEX_INFO_LEVELS, lpFindFileData unsafe.Pointer, fSearchOp FINDEX_SEARCH_OPS, lpSearchFilter unsafe.Pointer, dwAdditionalFlags uint32) (r HANDLE) = api-ms-win-core-file-fromapp-l1-1-0.FindFirstFileExFromAppW
+//sys	GetFileAttributesExFromAppW(lpFileName *PWSTRElement, fInfoLevelId GET_FILEEX_INFO_LEVELS, lpFileInformation unsafe.Pointer) (r BOOL) = api-ms-win-core-file-fromapp-l1-1-0.GetFileAttributesExFromAppW
+//sys	MoveFileFromAppW(lpExistingFileName *PWSTRElement, lpNewFileName *PWSTRElement) (r BOOL) = api-ms-win-core-file-fromapp-l1-1-0.MoveFileFromAppW
+//sys	RemoveDirectoryFromAppW(lpPathName *PWSTRElement) (r BOOL) = api-ms-win-core-file-fromapp-l1-1-0.RemoveDirectoryFromAppW
+//sys	ReplaceFileFromAppW(lpReplacedFileName *PWSTRElement, lpReplacementFileName *PWSTRElement, lpBackupFileName *PWSTRElement, dwReplaceFlags uint32, lpExclude unsafe.Pointer, lpReserved unsafe.Pointer) (r BOOL) = api-ms-win-core-file-fromapp-l1-1-0.ReplaceFileFromAppW
+//sys	SetFileAttributesFromAppW(lpFileName *PWSTRElement, dwFileAttributes uint32) (r BOOL) = api-ms-win-core-file-fromapp-l1-1-0.SetFileAttributesFromAppW
+//sys	VerFindFileA(uFlags VER_FIND_FILE_FLAGS, szFileName *PSTRElement, szWinDir *PSTRElement, szAppDir *PSTRElement, szCurDir *PSTRElement, puCurDirLen *uint32, szDestDir *PSTRElement, puDestDirLen *uint32) (r VER_FIND_FILE_STATUS) = version.VerFindFileA
+//sys	VerFindFileW(uFlags VER_FIND_FILE_FLAGS, szFileName *PWSTRElement, szWinDir *PWSTRElement, szAppDir *PWSTRElement, szCurDir *PWSTRElement, puCurDirLen *uint32, szDestDir *PWSTRElement, puDestDirLen *uint32) (r VER_FIND_FILE_STATUS) = version.VerFindFileW
+//sys	VerInstallFileA(uFlags VER_INSTALL_FILE_FLAGS, szSrcFileName *PSTRElement, szDestFileName *PSTRElement, szSrcDir *PSTRElement, szDestDir *PSTRElement, szCurDir *PSTRElement, szTmpFile *PSTRElement, puTmpFileLen *uint32) (r VER_INSTALL_FILE_STATUS) = version.VerInstallFileA
+//sys	VerInstallFileW(uFlags VER_INSTALL_FILE_FLAGS, szSrcFileName *PWSTRElement, szDestFileName *PWSTRElement, szSrcDir *PWSTRElement, szDestDir *PWSTRElement, szCurDir *PWSTRElement, szTmpFile *PWSTRElement, puTmpFileLen *uint32) (r VER_INSTALL_FILE_STATUS) = version.VerInstallFileW
+//sys	GetFileVersionInfoSizeA(lptstrFilename *PSTRElement, lpdwHandle *uint32) (r uint32, err error) = version.GetFileVersionInfoSizeA
+//sys	GetFileVersionInfoSizeW(lptstrFilename *PWSTRElement, lpdwHandle *uint32) (r uint32, err error) = version.GetFileVersionInfoSizeW
+//sys	GetFileVersionInfoA(lptstrFilename *PSTRElement, dwHandle uint32, dwLen uint32, lpData unsafe.Pointer) (r BOOL, err error) = version.GetFileVersionInfoA
+//sys	GetFileVersionInfoW(lptstrFilename *PWSTRElement, dwHandle uint32, dwLen uint32, lpData unsafe.Pointer) (r BOOL, err error) = version.GetFileVersionInfoW
+//sys	GetFileVersionInfoSizeExA(dwFlags GET_FILE_VERSION_INFO_FLAGS, lpwstrFilename *PSTRElement, lpdwHandle *uint32) (r uint32, err error) = version.GetFileVersionInfoSizeExA
+//sys	GetFileVersionInfoSizeExW(dwFlags GET_FILE_VERSION_INFO_FLAGS, lpwstrFilename *PWSTRElement, lpdwHandle *uint32) (r uint32, err error) = version.GetFileVersionInfoSizeExW
+//sys	GetFileVersionInfoExA(dwFlags GET_FILE_VERSION_INFO_FLAGS, lpwstrFilename *PSTRElement, dwHandle uint32, dwLen uint32, lpData unsafe.Pointer) (r BOOL, err error) = version.GetFileVersionInfoExA
+//sys	GetFileVersionInfoExW(dwFlags GET_FILE_VERSION_INFO_FLAGS, lpwstrFilename *PWSTRElement, dwHandle uint32, dwLen uint32, lpData unsafe.Pointer) (r BOOL, err error) = version.GetFileVersionInfoExW
+//sys	VerLanguageNameA(wLang uint32, szLang *PSTRElement, cchLang uint32) (r uint32)
+//sys	VerLanguageNameW(wLang uint32, szLang *PWSTRElement, cchLang uint32) (r uint32)
+//sys	VerQueryValueA(pBlock unsafe.Pointer, lpSubBlock *PSTRElement, lplpBuffer *unsafe.Pointer, puLen *uint32) (r BOOL) = version.VerQueryValueA
+//sys	VerQueryValueW(pBlock unsafe.Pointer, lpSubBlock *PWSTRElement, lplpBuffer *unsafe.Pointer, puLen *uint32) (r BOOL) = version.VerQueryValueW
+//sys	LsnEqual(plsn1 *CLS_LSN, plsn2 *CLS_LSN) (r BOOLEAN) = clfsw32.LsnEqual
+//sys	LsnLess(plsn1 *CLS_LSN, plsn2 *CLS_LSN) (r BOOLEAN) = clfsw32.LsnLess
+//sys	LsnGreater(plsn1 *CLS_LSN, plsn2 *CLS_LSN) (r BOOLEAN) = clfsw32.LsnGreater
+//sys	LsnNull(plsn *CLS_LSN) (r BOOLEAN) = clfsw32.LsnNull
+//sys	LsnContainer(plsn *CLS_LSN) (r uint32) = clfsw32.LsnContainer
+//sys	LsnCreate(cidContainer uint32, offBlock uint32, cRecord uint32) (r CLS_LSN) = clfsw32.LsnCreate
+//sys	LsnBlockOffset(plsn *CLS_LSN) (r uint32) = clfsw32.LsnBlockOffset
+//sys	LsnRecordSequence(plsn *CLS_LSN) (r uint32) = clfsw32.LsnRecordSequence
+//sys	LsnInvalid(plsn *CLS_LSN) (r BOOLEAN) = clfsw32.LsnInvalid
+//sys	LsnIncrement(plsn *CLS_LSN) (r CLS_LSN) = clfsw32.LsnIncrement
+//sys	CreateLogFile(pszLogFileName *PWSTRElement, fDesiredAccess uint32, dwShareMode FILE_SHARE_MODE, psaLogFile *SECURITY_ATTRIBUTES, fCreateDisposition FILE_CREATION_DISPOSITION, fFlagsAndAttributes FILE_FLAGS_AND_ATTRIBUTES) (r HANDLE, err error) = clfsw32.CreateLogFile
+//sys	DeleteLogByHandle(hLog HANDLE) (r BOOL, err error) = clfsw32.DeleteLogByHandle
+//sys	DeleteLogFile(pszLogFileName *PWSTRElement, pvReserved unsafe.Pointer) (r BOOL, err error) = clfsw32.DeleteLogFile
+//sys	AddLogContainer(hLog HANDLE, pcbContainer *uint64, pwszContainerPath *PWSTRElement, pReserved unsafe.Pointer) (r BOOL, err error) = clfsw32.AddLogContainer
+//sys	AddLogContainerSet(hLog HANDLE, cContainer uint16, pcbContainer *uint64, rgwszContainerPath **PWSTRElement, pReserved unsafe.Pointer) (r BOOL, err error) = clfsw32.AddLogContainerSet
+//sys	RemoveLogContainer(hLog HANDLE, pwszContainerPath *PWSTRElement, fForce BOOL, pReserved unsafe.Pointer) (r BOOL, err error) = clfsw32.RemoveLogContainer
+//sys	RemoveLogContainerSet(hLog HANDLE, cContainer uint16, rgwszContainerPath **PWSTRElement, fForce BOOL, pReserved unsafe.Pointer) (r BOOL, err error) = clfsw32.RemoveLogContainerSet
+//sys	SetLogArchiveTail(hLog HANDLE, plsnArchiveTail *CLS_LSN, pReserved unsafe.Pointer) (r BOOL, err error) = clfsw32.SetLogArchiveTail
+//sys	SetEndOfLog(hLog HANDLE, plsnEnd *CLS_LSN, lpOverlapped *OVERLAPPED) (r BOOL, err error) = clfsw32.SetEndOfLog
+//sys	TruncateLog(pvMarshal unsafe.Pointer, plsnEnd *CLS_LSN, lpOverlapped *OVERLAPPED) (r BOOL, err error) = clfsw32.TruncateLog
+//sys	CreateLogContainerScanContext(hLog HANDLE, cFromContainer uint32, cContainers uint32, eScanMode uint8, pcxScan *CLS_SCAN_CONTEXT, pOverlapped *OVERLAPPED) (r BOOL, err error) = clfsw32.CreateLogContainerScanContext
+//sys	ScanLogContainers(pcxScan *CLS_SCAN_CONTEXT, eScanMode uint8, pReserved unsafe.Pointer) (r BOOL, err error) = clfsw32.ScanLogContainers
+//sys	AlignReservedLog(pvMarshal unsafe.Pointer, cReservedRecords uint32, rgcbReservation *int64, pcbAlignReservation *int64) (r BOOL, err error) = clfsw32.AlignReservedLog
+//sys	AllocReservedLog(pvMarshal unsafe.Pointer, cReservedRecords uint32, pcbAdjustment *int64) (r BOOL, err error) = clfsw32.AllocReservedLog
+//sys	FreeReservedLog(pvMarshal unsafe.Pointer, cReservedRecords uint32, pcbAdjustment *int64) (r BOOL, err error) = clfsw32.FreeReservedLog
+//sys	GetLogFileInformation(hLog HANDLE, pinfoBuffer *CLS_INFORMATION, cbBuffer *uint32) (r BOOL, err error) = clfsw32.GetLogFileInformation
+//sys	SetLogArchiveMode(hLog HANDLE, eMode CLFS_LOG_ARCHIVE_MODE) (r BOOL, err error) = clfsw32.SetLogArchiveMode
+//sys	ReadLogRestartArea(pvMarshal unsafe.Pointer, ppvRestartBuffer *unsafe.Pointer, pcbRestartBuffer *uint32, plsn *CLS_LSN, ppvContext *unsafe.Pointer, pOverlapped *OVERLAPPED) (r BOOL, err error) = clfsw32.ReadLogRestartArea
+//sys	ReadPreviousLogRestartArea(pvReadContext unsafe.Pointer, ppvRestartBuffer *unsafe.Pointer, pcbRestartBuffer *uint32, plsnRestart *CLS_LSN, pOverlapped *OVERLAPPED) (r BOOL, err error) = clfsw32.ReadPreviousLogRestartArea
+//sys	WriteLogRestartArea(pvMarshal unsafe.Pointer, pvRestartBuffer unsafe.Pointer, cbRestartBuffer uint32, plsnBase *CLS_LSN, fFlags CLFS_FLAG, pcbWritten *uint32, plsnNext *CLS_LSN, pOverlapped *OVERLAPPED) (r BOOL, err error) = clfsw32.WriteLogRestartArea
+//sys	GetLogReservationInfo(pvMarshal unsafe.Pointer, pcbRecordNumber *uint32, pcbUserReservation *int64, pcbCommitReservation *int64) (r BOOL) = clfsw32.GetLogReservationInfo
+//sys	AdvanceLogBase(pvMarshal unsafe.Pointer, plsnBase *CLS_LSN, fFlags uint32, pOverlapped *OVERLAPPED) (r BOOL, err error) = clfsw32.AdvanceLogBase
+//sys	CloseAndResetLogFile(hLog HANDLE) (r BOOL, err error) = clfsw32.CloseAndResetLogFile
+//sys	CreateLogMarshallingArea(hLog HANDLE, pfnAllocBuffer CLFS_BLOCK_ALLOCATION, pfnFreeBuffer CLFS_BLOCK_DEALLOCATION, pvBlockAllocContext unsafe.Pointer, cbMarshallingBuffer uint32, cMaxWriteBuffers uint32, cMaxReadBuffers uint32, ppvMarshal *unsafe.Pointer) (r BOOL, err error) = clfsw32.CreateLogMarshallingArea
+//sys	DeleteLogMarshallingArea(pvMarshal unsafe.Pointer) (r BOOL, err error) = clfsw32.DeleteLogMarshallingArea
+//sys	ReserveAndAppendLog(pvMarshal unsafe.Pointer, rgWriteEntries *CLS_WRITE_ENTRY, cWriteEntries uint32, plsnUndoNext *CLS_LSN, plsnPrevious *CLS_LSN, cReserveRecords uint32, rgcbReservation *int64, fFlags CLFS_FLAG, plsn *CLS_LSN, pOverlapped *OVERLAPPED) (r BOOL, err error) = clfsw32.ReserveAndAppendLog
+//sys	ReserveAndAppendLogAligned(pvMarshal unsafe.Pointer, rgWriteEntries *CLS_WRITE_ENTRY, cWriteEntries uint32, cbEntryAlignment uint32, plsnUndoNext *CLS_LSN, plsnPrevious *CLS_LSN, cReserveRecords uint32, rgcbReservation *int64, fFlags CLFS_FLAG, plsn *CLS_LSN, pOverlapped *OVERLAPPED) (r BOOL, err error) = clfsw32.ReserveAndAppendLogAligned
+//sys	FlushLogBuffers(pvMarshal unsafe.Pointer, pOverlapped *OVERLAPPED) (r BOOL, err error) = clfsw32.FlushLogBuffers
+//sys	FlushLogToLsn(pvMarshalContext unsafe.Pointer, plsnFlush *CLS_LSN, plsnLastFlushed *CLS_LSN, pOverlapped *OVERLAPPED) (r BOOL, err error) = clfsw32.FlushLogToLsn
+//sys	ReadLogRecord(pvMarshal unsafe.Pointer, plsnFirst *CLS_LSN, eContextMode CLFS_CONTEXT_MODE, ppvReadBuffer *unsafe.Pointer, pcbReadBuffer *uint32, peRecordType *uint8, plsnUndoNext *CLS_LSN, plsnPrevious *CLS_LSN, ppvReadContext *unsafe.Pointer, pOverlapped *OVERLAPPED) (r BOOL, err error) = clfsw32.ReadLogRecord
+//sys	ReadNextLogRecord(pvReadContext unsafe.Pointer, ppvBuffer *unsafe.Pointer, pcbBuffer *uint32, peRecordType *uint8, plsnUser *CLS_LSN, plsnUndoNext *CLS_LSN, plsnPrevious *CLS_LSN, plsnRecord *CLS_LSN, pOverlapped *OVERLAPPED) (r BOOL, err error) = clfsw32.ReadNextLogRecord
+//sys	TerminateReadLog(pvCursorContext unsafe.Pointer) (r BOOL, err error) = clfsw32.TerminateReadLog
+//sys	PrepareLogArchive(hLog HANDLE, pszBaseLogFileName *PWSTRElement, cLen uint32, plsnLow *CLS_LSN, plsnHigh *CLS_LSN, pcActualLength *uint32, poffBaseLogFileData *uint64, pcbBaseLogFileLength *uint64, plsnBase *CLS_LSN, plsnLast *CLS_LSN, plsnCurrentArchiveTail *CLS_LSN, ppvArchiveContext *unsafe.Pointer) (r BOOL, err error) = clfsw32.PrepareLogArchive
+//sys	ReadLogArchiveMetadata(pvArchiveContext unsafe.Pointer, cbOffset uint32, cbBytesToRead uint32, pbReadBuffer *uint8, pcbBytesRead *uint32) (r BOOL, err error) = clfsw32.ReadLogArchiveMetadata
+//sys	GetNextLogArchiveExtent(pvArchiveContext unsafe.Pointer, rgadExtent *CLS_ARCHIVE_DESCRIPTOR, cDescriptors uint32, pcDescriptorsReturned *uint32) (r BOOL, err error) = clfsw32.GetNextLogArchiveExtent
+//sys	TerminateLogArchive(pvArchiveContext unsafe.Pointer) (r BOOL, err error) = clfsw32.TerminateLogArchive
+//sys	ValidateLog(pszLogFileName *PWSTRElement, psaLogFile *SECURITY_ATTRIBUTES, pinfoBuffer *CLS_INFORMATION, pcbBuffer *uint32) (r BOOL, err error) = clfsw32.ValidateLog
+//sys	GetLogContainerName(hLog HANDLE, cidLogicalContainer uint32, pwstrContainerName *PWSTRElement, cLenContainerName uint32, pcActualLenContainerName *uint32) (r BOOL, err error) = clfsw32.GetLogContainerName
+//sys	GetLogIoStatistics(hLog HANDLE, pvStatsBuffer unsafe.Pointer, cbStatsBuffer uint32, eStatsClass CLFS_IOSTATS_CLASS, pcbStatsWritten *uint32) (r BOOL, err error) = clfsw32.GetLogIoStatistics
+//sys	RegisterManageableLogClient(hLog HANDLE, pCallbacks *LOG_MANAGEMENT_CALLBACKS) (r BOOL, err error) = clfsw32.RegisterManageableLogClient
+//sys	DeregisterManageableLogClient(hLog HANDLE) (r BOOL, err error) = clfsw32.DeregisterManageableLogClient
+//sys	ReadLogNotification(hLog HANDLE, pNotification *CLFS_MGMT_NOTIFICATION, lpOverlapped *OVERLAPPED) (r BOOL, err error) = clfsw32.ReadLogNotification
+//sys	InstallLogPolicy(hLog HANDLE, pPolicy *CLFS_MGMT_POLICY) (r BOOL, err error) = clfsw32.InstallLogPolicy
+//sys	RemoveLogPolicy(hLog HANDLE, ePolicyType CLFS_MGMT_POLICY_TYPE) (r BOOL, err error) = clfsw32.RemoveLogPolicy
+//sys	QueryLogPolicy(hLog HANDLE, ePolicyType CLFS_MGMT_POLICY_TYPE, pPolicyBuffer *CLFS_MGMT_POLICY, pcbPolicyBuffer *uint32) (r BOOL, err error) = clfsw32.QueryLogPolicy
+//sys	SetLogFileSizeWithPolicy(hLog HANDLE, pDesiredSize *uint64, pResultingSize *uint64) (r BOOL, err error) = clfsw32.SetLogFileSizeWithPolicy
+//sys	HandleLogFull(hLog HANDLE) (r BOOL, err error) = clfsw32.HandleLogFull
+//sys	LogTailAdvanceFailure(hLog HANDLE, dwReason uint32) (r BOOL, err error) = clfsw32.LogTailAdvanceFailure
+//sys	RegisterForLogWriteNotification(hLog HANDLE, cbThreshold uint32, fEnable BOOL) (r BOOL, err error) = clfsw32.RegisterForLogWriteNotification
+//sys	QueryUsersOnEncryptedFile(lpFileName *PWSTRElement, pUsers **ENCRYPTION_CERTIFICATE_HASH_LIST) (r uint32) = advapi32.QueryUsersOnEncryptedFile
+//sys	QueryRecoveryAgentsOnEncryptedFile(lpFileName *PWSTRElement, pRecoveryAgents **ENCRYPTION_CERTIFICATE_HASH_LIST) (r uint32) = advapi32.QueryRecoveryAgentsOnEncryptedFile
+//sys	RemoveUsersFromEncryptedFile(lpFileName *PWSTRElement, pHashes *ENCRYPTION_CERTIFICATE_HASH_LIST) (r uint32) = advapi32.RemoveUsersFromEncryptedFile
+//sys	AddUsersToEncryptedFile(lpFileName *PWSTRElement, pEncryptionCertificates *ENCRYPTION_CERTIFICATE_LIST) (r uint32) = advapi32.AddUsersToEncryptedFile
+//sys	SetUserFileEncryptionKey(pEncryptionCertificate *ENCRYPTION_CERTIFICATE) (r uint32) = advapi32.SetUserFileEncryptionKey
+//sys	SetUserFileEncryptionKeyEx(pEncryptionCertificate *ENCRYPTION_CERTIFICATE, dwCapabilities uint32, dwFlags uint32, pvReserved unsafe.Pointer) (r uint32) = advapi32.SetUserFileEncryptionKeyEx
+//sys	FreeEncryptionCertificateHashList(pUsers *ENCRYPTION_CERTIFICATE_HASH_LIST) = advapi32.FreeEncryptionCertificateHashList
+//sys	EncryptionDisable(DirPath *PWSTRElement, Disable BOOL) (r BOOL, err error) = advapi32.EncryptionDisable
+//sys	DuplicateEncryptionInfoFile(SrcFileName *PWSTRElement, DstFileName *PWSTRElement, dwCreationDistribution uint32, dwAttributes uint32, lpSecurityAttributes *SECURITY_ATTRIBUTES) (r uint32) = advapi32.DuplicateEncryptionInfoFile
+//sys	GetEncryptedFileMetadata(lpFileName *PWSTRElement, pcbMetadata *uint32, ppbMetadata **uint8) (r uint32) = advapi32.GetEncryptedFileMetadata
+//sys	SetEncryptedFileMetadata(lpFileName *PWSTRElement, pbOldMetadata *uint8, pbNewMetadata *uint8, pOwnerHash *ENCRYPTION_CERTIFICATE_HASH, dwOperation uint32, pCertificatesAdded *ENCRYPTION_CERTIFICATE_HASH_LIST) (r uint32) = advapi32.SetEncryptedFileMetadata
+//sys	FreeEncryptedFileMetadata(pbMetadata *uint8) = advapi32.FreeEncryptedFileMetadata
+//sys	LZStart() (r int32)
+//sys	LZDone()
+//sys	CopyLZFile(hfSource int32, hfDest int32) (r int32)
+//sys	LZCopy(hfSource int32, hfDest int32) (r int32)
+//sys	LZInit(hfSource int32) (r int32)
+//sys	GetExpandedNameA(lpszSource *PSTRElement, lpszBuffer *PSTRElement) (r int32, err error)
+//sys	GetExpandedNameW(lpszSource *PWSTRElement, lpszBuffer *PWSTRElement) (r int32, err error)
+//sys	LZOpenFileA(lpFileName *PSTRElement, lpReOpenBuf *OFSTRUCT, wStyle LZOPENFILE_STYLE) (r int32)
+//sys	LZOpenFileW(lpFileName *PWSTRElement, lpReOpenBuf *OFSTRUCT, wStyle LZOPENFILE_STYLE) (r int32)
+//sys	LZSeek(hFile int32, lOffset int32, iOrigin int32) (r int32)
+//sys	LZRead(hFile int32, lpBuffer *PSTRElement, cbRead int32) (r int32)
+//sys	LZClose(hFile int32)
+//sys	WofShouldCompressBinaries(Volume *PWSTRElement, Algorithm *uint32) (r BOOL) = wofutil.WofShouldCompressBinaries
+//sys	WofGetDriverVersion(FileOrVolumeHandle HANDLE, Provider uint32, WofVersion *uint32) (r HRESULT) = wofutil.WofGetDriverVersion
+//sys	WofSetFileDataLocation(FileHandle HANDLE, Provider uint32, ExternalFileInfo unsafe.Pointer, Length uint32) (r HRESULT) = wofutil.WofSetFileDataLocation
+//sys	WofIsExternalFile(FilePath *PWSTRElement, IsExternalFile *BOOL, Provider *uint32, ExternalFileInfo unsafe.Pointer, BufferLength *uint32) (r HRESULT) = wofutil.WofIsExternalFile
+//sys	WofEnumEntries(VolumeName *PWSTRElement, Provider uint32, EnumProc WofEnumEntryProc, UserData unsafe.Pointer) (r HRESULT) = wofutil.WofEnumEntries
+//sys	WofWimAddEntry(VolumeName *PWSTRElement, WimPath *PWSTRElement, WimType uint32, WimIndex uint32, DataSourceId *int64) (r HRESULT) = wofutil.WofWimAddEntry
+//sys	WofWimEnumFiles(VolumeName *PWSTRElement, DataSourceId int64, EnumProc WofEnumFilesProc, UserData unsafe.Pointer) (r HRESULT) = wofutil.WofWimEnumFiles
+//sys	WofWimSuspendEntry(VolumeName *PWSTRElement, DataSourceId int64) (r HRESULT) = wofutil.WofWimSuspendEntry
+//sys	WofWimRemoveEntry(VolumeName *PWSTRElement, DataSourceId int64) (r HRESULT) = wofutil.WofWimRemoveEntry
+//sys	WofWimUpdateEntry(VolumeName *PWSTRElement, DataSourceId int64, NewWimPath *PWSTRElement) (r HRESULT) = wofutil.WofWimUpdateEntry
+//sys	WofFileEnumFiles(VolumeName *PWSTRElement, Algorithm uint32, EnumProc WofEnumFilesProc, UserData unsafe.Pointer) (r HRESULT) = wofutil.WofFileEnumFiles
+//sys	TxfLogCreateFileReadContext(LogPath *PWSTRElement, BeginningLsn CLS_LSN, EndingLsn CLS_LSN, TxfFileId *TXF_ID, TxfLogContext *unsafe.Pointer) (r BOOL, err error) = txfw32.TxfLogCreateFileReadContext
+//sys	TxfLogCreateRangeReadContext(LogPath *PWSTRElement, BeginningLsn CLS_LSN, EndingLsn CLS_LSN, BeginningVirtualClock *int64, EndingVirtualClock *int64, RecordTypeMask uint32, TxfLogContext *unsafe.Pointer) (r BOOL) = txfw32.TxfLogCreateRangeReadContext
+//sys	TxfLogDestroyReadContext(TxfLogContext unsafe.Pointer) (r BOOL, err error) = txfw32.TxfLogDestroyReadContext
+//sys	TxfLogReadRecords(TxfLogContext unsafe.Pointer, BufferLength uint32, Buffer unsafe.Pointer, BytesUsed *uint32, RecordCount *uint32) (r BOOL, err error) = txfw32.TxfLogReadRecords
+//sys	TxfReadMetadataInfo(FileHandle HANDLE, TxfFileId *TXF_ID, LastLsn *CLS_LSN, TransactionState *uint32, LockingTransaction *Guid) (r BOOL) = txfw32.TxfReadMetadataInfo
+//sys	TxfLogRecordGetFileName(RecordBuffer unsafe.Pointer, RecordBufferLengthInBytes uint32, NameBuffer *PWSTRElement, NameBufferLengthInBytes *uint32, TxfId *TXF_ID) (r BOOL) = txfw32.TxfLogRecordGetFileName
+//sys	TxfLogRecordGetGenericType(RecordBuffer unsafe.Pointer, RecordBufferLengthInBytes uint32, GenericType *uint32, VirtualClock *int64) (r BOOL) = txfw32.TxfLogRecordGetGenericType
+//sys	TxfSetThreadMiniVersionForCreate(MiniVersion uint16) = txfw32.TxfSetThreadMiniVersionForCreate
+//sys	TxfGetThreadMiniVersionForCreate(MiniVersion *uint16) = txfw32.TxfGetThreadMiniVersionForCreate
+//sys	CreateTransaction(lpTransactionAttributes *SECURITY_ATTRIBUTES, UOW *Guid, CreateOptions uint32, IsolationLevel uint32, IsolationFlags uint32, Timeout uint32, Description *PWSTRElement) (r HANDLE, err error) = ktmw32.CreateTransaction
+//sys	OpenTransaction(dwDesiredAccess uint32, TransactionId *Guid) (r HANDLE, err error) = ktmw32.OpenTransaction
+//sys	CommitTransaction(TransactionHandle HANDLE) (r BOOL, err error) = ktmw32.CommitTransaction
+//sys	CommitTransactionAsync(TransactionHandle HANDLE) (r BOOL, err error) = ktmw32.CommitTransactionAsync
+//sys	RollbackTransaction(TransactionHandle HANDLE) (r BOOL, err error) = ktmw32.RollbackTransaction
+//sys	RollbackTransactionAsync(TransactionHandle HANDLE) (r BOOL, err error) = ktmw32.RollbackTransactionAsync
+//sys	GetTransactionId(TransactionHandle HANDLE, TransactionId *Guid) (r BOOL, err error) = ktmw32.GetTransactionId
+//sys	GetTransactionInformation(TransactionHandle HANDLE, Outcome *uint32, IsolationLevel *uint32, IsolationFlags *uint32, Timeout *uint32, BufferLength uint32, Description *PWSTRElement) (r BOOL, err error) = ktmw32.GetTransactionInformation
+//sys	SetTransactionInformation(TransactionHandle HANDLE, IsolationLevel uint32, IsolationFlags uint32, Timeout uint32, Description *PWSTRElement) (r BOOL, err error) = ktmw32.SetTransactionInformation
+//sys	CreateTransactionManager(lpTransactionAttributes *SECURITY_ATTRIBUTES, LogFileName *PWSTRElement, CreateOptions uint32, CommitStrength uint32) (r HANDLE, err error) = ktmw32.CreateTransactionManager
+//sys	OpenTransactionManager(LogFileName *PWSTRElement, DesiredAccess uint32, OpenOptions uint32) (r HANDLE, err error) = ktmw32.OpenTransactionManager
+//sys	OpenTransactionManagerById(TransactionManagerId *Guid, DesiredAccess uint32, OpenOptions uint32) (r HANDLE, err error) = ktmw32.OpenTransactionManagerById
+//sys	RenameTransactionManager(LogFileName *PWSTRElement, ExistingTransactionManagerGuid *Guid) (r BOOL, err error) = ktmw32.RenameTransactionManager
+//sys	RollforwardTransactionManager(TransactionManagerHandle HANDLE, TmVirtualClock *int64) (r BOOL, err error) = ktmw32.RollforwardTransactionManager
+//sys	RecoverTransactionManager(TransactionManagerHandle HANDLE) (r BOOL, err error) = ktmw32.RecoverTransactionManager
+//sys	GetCurrentClockTransactionManager(TransactionManagerHandle HANDLE, TmVirtualClock *int64) (r BOOL, err error) = ktmw32.GetCurrentClockTransactionManager
+//sys	GetTransactionManagerId(TransactionManagerHandle HANDLE, TransactionManagerId *Guid) (r BOOL, err error) = ktmw32.GetTransactionManagerId
+//sys	CreateResourceManager(lpResourceManagerAttributes *SECURITY_ATTRIBUTES, ResourceManagerId *Guid, CreateOptions uint32, TmHandle HANDLE, Description *PWSTRElement) (r HANDLE, err error) = ktmw32.CreateResourceManager
+//sys	OpenResourceManager(dwDesiredAccess uint32, TmHandle HANDLE, ResourceManagerId *Guid) (r HANDLE, err error) = ktmw32.OpenResourceManager
+//sys	RecoverResourceManager(ResourceManagerHandle HANDLE) (r BOOL, err error) = ktmw32.RecoverResourceManager
+//sys	GetNotificationResourceManager(ResourceManagerHandle HANDLE, TransactionNotification *TRANSACTION_NOTIFICATION, NotificationLength uint32, dwMilliseconds uint32, ReturnLength *uint32) (r BOOL, err error) = ktmw32.GetNotificationResourceManager
+//sys	GetNotificationResourceManagerAsync(ResourceManagerHandle HANDLE, TransactionNotification *TRANSACTION_NOTIFICATION, TransactionNotificationLength uint32, ReturnLength *uint32, lpOverlapped *OVERLAPPED) (r BOOL, err error) = ktmw32.GetNotificationResourceManagerAsync
+//sys	SetResourceManagerCompletionPort(ResourceManagerHandle HANDLE, IoCompletionPortHandle HANDLE, CompletionKey uintptr) (r BOOL, err error) = ktmw32.SetResourceManagerCompletionPort
+//sys	CreateEnlistment(lpEnlistmentAttributes *SECURITY_ATTRIBUTES, ResourceManagerHandle HANDLE, TransactionHandle HANDLE, NotificationMask uint32, CreateOptions uint32, EnlistmentKey unsafe.Pointer) (r HANDLE, err error) = ktmw32.CreateEnlistment
+//sys	OpenEnlistment(dwDesiredAccess uint32, ResourceManagerHandle HANDLE, EnlistmentId *Guid) (r HANDLE, err error) = ktmw32.OpenEnlistment
+//sys	RecoverEnlistment(EnlistmentHandle HANDLE, EnlistmentKey unsafe.Pointer) (r BOOL, err error) = ktmw32.RecoverEnlistment
+//sys	GetEnlistmentRecoveryInformation(EnlistmentHandle HANDLE, BufferSize uint32, Buffer unsafe.Pointer, BufferUsed *uint32) (r BOOL, err error) = ktmw32.GetEnlistmentRecoveryInformation
+//sys	GetEnlistmentId(EnlistmentHandle HANDLE, EnlistmentId *Guid) (r BOOL, err error) = ktmw32.GetEnlistmentId
+//sys	SetEnlistmentRecoveryInformation(EnlistmentHandle HANDLE, BufferSize uint32, Buffer unsafe.Pointer) (r BOOL, err error) = ktmw32.SetEnlistmentRecoveryInformation
+//sys	PrepareEnlistment(EnlistmentHandle HANDLE, TmVirtualClock *int64) (r BOOL, err error) = ktmw32.PrepareEnlistment
+//sys	PrePrepareEnlistment(EnlistmentHandle HANDLE, TmVirtualClock *int64) (r BOOL, err error) = ktmw32.PrePrepareEnlistment
+//sys	CommitEnlistment(EnlistmentHandle HANDLE, TmVirtualClock *int64) (r BOOL, err error) = ktmw32.CommitEnlistment
+//sys	RollbackEnlistment(EnlistmentHandle HANDLE, TmVirtualClock *int64) (r BOOL, err error) = ktmw32.RollbackEnlistment
+//sys	PrePrepareComplete(EnlistmentHandle HANDLE, TmVirtualClock *int64) (r BOOL, err error) = ktmw32.PrePrepareComplete
+//sys	PrepareComplete(EnlistmentHandle HANDLE, TmVirtualClock *int64) (r BOOL, err error) = ktmw32.PrepareComplete
+//sys	ReadOnlyEnlistment(EnlistmentHandle HANDLE, TmVirtualClock *int64) (r BOOL, err error) = ktmw32.ReadOnlyEnlistment
+//sys	CommitComplete(EnlistmentHandle HANDLE, TmVirtualClock *int64) (r BOOL, err error) = ktmw32.CommitComplete
+//sys	RollbackComplete(EnlistmentHandle HANDLE, TmVirtualClock *int64) (r BOOL, err error) = ktmw32.RollbackComplete
+//sys	SinglePhaseReject(EnlistmentHandle HANDLE, TmVirtualClock *int64) (r BOOL, err error) = ktmw32.SinglePhaseReject
+//sys	NetShareAdd(servername *PWSTRElement, level uint32, buf *uint8, parm_err *uint32) (r uint32) = netapi32.NetShareAdd
+//sys	NetShareEnum(servername *PWSTRElement, level uint32, bufptr **uint8, prefmaxlen uint32, entriesread *uint32, totalentries *uint32, resume_handle *uint32) (r uint32) = netapi32.NetShareEnum
+//sys	NetShareEnumSticky(servername *PWSTRElement, level uint32, bufptr **uint8, prefmaxlen uint32, entriesread *uint32, totalentries *uint32, resume_handle *uint32) (r uint32) = netapi32.NetShareEnumSticky
+//sys	NetShareGetInfo(servername *PWSTRElement, netname *PWSTRElement, level uint32, bufptr **uint8) (r uint32) = netapi32.NetShareGetInfo
+//sys	NetShareSetInfo(servername *PWSTRElement, netname *PWSTRElement, level uint32, buf *uint8, parm_err *uint32) (r uint32) = netapi32.NetShareSetInfo
+//sys	NetShareDel(servername *PWSTRElement, netname *PWSTRElement, reserved uint32) (r uint32) = netapi32.NetShareDel
+//sys	NetShareDelSticky(servername *PWSTRElement, netname *PWSTRElement, reserved uint32) (r uint32) = netapi32.NetShareDelSticky
+//sys	NetShareCheck(servername *PWSTRElement, device *PWSTRElement, typeParam *uint32) (r uint32) = netapi32.NetShareCheck
+//sys	NetShareDelEx(servername *PWSTRElement, level uint32, buf *uint8) (r uint32) = netapi32.NetShareDelEx
+//sys	NetServerAliasAdd(servername *PWSTRElement, level uint32, buf *uint8) (r uint32) = netapi32.NetServerAliasAdd
+//sys	NetServerAliasDel(servername *PWSTRElement, level uint32, buf *uint8) (r uint32) = netapi32.NetServerAliasDel
+//sys	NetServerAliasEnum(servername *PWSTRElement, level uint32, bufptr **uint8, prefmaxlen uint32, entriesread *uint32, totalentries *uint32, resumehandle *uint32) (r uint32) = netapi32.NetServerAliasEnum
+//sys	NetSessionEnum(servername *PWSTRElement, UncClientName *PWSTRElement, username *PWSTRElement, level uint32, bufptr **uint8, prefmaxlen uint32, entriesread *uint32, totalentries *uint32, resume_handle *uint32) (r uint32) = netapi32.NetSessionEnum
+//sys	NetSessionDel(servername *PWSTRElement, UncClientName *PWSTRElement, username *PWSTRElement) (r uint32) = netapi32.NetSessionDel
+//sys	NetSessionGetInfo(servername *PWSTRElement, UncClientName *PWSTRElement, username *PWSTRElement, level uint32, bufptr **uint8) (r uint32) = netapi32.NetSessionGetInfo
+//sys	NetConnectionEnum(servername *PWSTRElement, qualifier *PWSTRElement, level uint32, bufptr **uint8, prefmaxlen uint32, entriesread *uint32, totalentries *uint32, resume_handle *uint32) (r uint32) = netapi32.NetConnectionEnum
+//sys	NetFileClose(servername *PWSTRElement, fileid uint32) (r uint32) = netapi32.NetFileClose
+//sys	NetFileEnum(servername *PWSTRElement, basepath *PWSTRElement, username *PWSTRElement, level uint32, bufptr **uint8, prefmaxlen uint32, entriesread *uint32, totalentries *uint32, resume_handle *uintptr) (r uint32) = netapi32.NetFileEnum
+//sys	NetFileGetInfo(servername *PWSTRElement, fileid uint32, level uint32, bufptr **uint8) (r uint32) = netapi32.NetFileGetInfo
+//sys	NetStatisticsGet(ServerName *int8, Service *int8, Level uint32, Options uint32, Buffer **uint8) (r uint32) = netapi32.NetStatisticsGet
+//sys	QueryIoRingCapabilities(capabilities *IORING_CAPABILITIES) (r HRESULT) = api-ms-win-core-ioring-l1-1-0.QueryIoRingCapabilities
+//sys	IsIoRingOpSupported(ioRing HIORING, op IORING_OP_CODE) (r BOOL) = api-ms-win-core-ioring-l1-1-0.IsIoRingOpSupported
+//sys	CreateIoRing(ioringVersion IORING_VERSION, flags IORING_CREATE_FLAGS, submissionQueueSize uint32, completionQueueSize uint32, h *HIORING) (r HRESULT) = api-ms-win-core-ioring-l1-1-0.CreateIoRing
+//sys	GetIoRingInfo(ioRing HIORING, info *IORING_INFO) (r HRESULT) = api-ms-win-core-ioring-l1-1-0.GetIoRingInfo
+//sys	SubmitIoRing(ioRing HIORING, waitOperations uint32, milliseconds uint32, submittedEntries *uint32) (r HRESULT) = api-ms-win-core-ioring-l1-1-0.SubmitIoRing
+//sys	CloseIoRing(ioRing HIORING) (r HRESULT) = api-ms-win-core-ioring-l1-1-0.CloseIoRing
+//sys	PopIoRingCompletion(ioRing HIORING, cqe *IORING_CQE) (r HRESULT) = api-ms-win-core-ioring-l1-1-0.PopIoRingCompletion
+//sys	SetIoRingCompletionEvent(ioRing HIORING, hEvent HANDLE) (r HRESULT) = api-ms-win-core-ioring-l1-1-0.SetIoRingCompletionEvent
+//sys	BuildIoRingCancelRequest(ioRing HIORING, file IORING_HANDLE_REF, opToCancel uintptr, userData uintptr) (r HRESULT) = api-ms-win-core-ioring-l1-1-0.BuildIoRingCancelRequest
+//sys	BuildIoRingReadFile(ioRing HIORING, fileRef IORING_HANDLE_REF, dataRef IORING_BUFFER_REF, numberOfBytesToRead uint32, fileOffset uint64, userData uintptr, sqeFlags IORING_SQE_FLAGS) (r HRESULT) = api-ms-win-core-ioring-l1-1-0.BuildIoRingReadFile
+//sys	BuildIoRingRegisterFileHandles(ioRing HIORING, count uint32, handles *HANDLE, userData uintptr) (r HRESULT) = api-ms-win-core-ioring-l1-1-0.BuildIoRingRegisterFileHandles
+//sys	BuildIoRingRegisterBuffers(ioRing HIORING, count uint32, buffers *IORING_BUFFER_INFO, userData uintptr) (r HRESULT) = api-ms-win-core-ioring-l1-1-0.BuildIoRingRegisterBuffers
+//sys	BuildIoRingWriteFile(ioRing HIORING, fileRef IORING_HANDLE_REF, bufferRef IORING_BUFFER_REF, numberOfBytesToWrite uint32, fileOffset uint64, writeFlags FILE_WRITE_FLAGS, userData uintptr, sqeFlags IORING_SQE_FLAGS) (r HRESULT)
+//sys	BuildIoRingFlushFile(ioRing HIORING, fileRef IORING_HANDLE_REF, flushMode FILE_FLUSH_MODE, userData uintptr, sqeFlags IORING_SQE_FLAGS) (r HRESULT)
+//sys	BuildIoRingReadFileScatter(ioRing HIORING, fileRef IORING_HANDLE_REF, segmentCount uint32, segmentArray *FILE_SEGMENT_ELEMENT, numberOfBytesToRead uint32, fileOffset uint64, userData uintptr, sqeFlags IORING_SQE_FLAGS) (r HRESULT)
+//sys	BuildIoRingWriteFileGather(ioRing HIORING, fileRef IORING_HANDLE_REF, segmentCount uint32, segmentArray *FILE_SEGMENT_ELEMENT, numberOfBytesToWrite uint32, fileOffset uint64, writeFlags FILE_WRITE_FLAGS, userData uintptr, sqeFlags IORING_SQE_FLAGS) (r HRESULT)
+//sys	CreateBindLink(virtualPath *PWSTRElement, backingPath *PWSTRElement, createBindLinkFlags CREATE_BIND_LINK_FLAGS, exceptionCount uint32, exceptionPaths **PWSTRElement) (r HRESULT) = bindfltapi.CreateBindLink
+//sys	RemoveBindLink(virtualPath *PWSTRElement) (r HRESULT) = bindfltapi.RemoveBindLink
+//sys	Wow64EnableWow64FsRedirection(Wow64FsEnableRedirection BOOLEAN) (r BOOLEAN)
+//sys	Wow64DisableWow64FsRedirection(OldValue *unsafe.Pointer) (r BOOL, err error)
+//sys	Wow64RevertWow64FsRedirection(OlValue unsafe.Pointer) (r BOOL, err error)
+//sys	GetBinaryTypeA(lpApplicationName *PSTRElement, lpBinaryType *uint32) (r BOOL, err error)
+//sys	GetBinaryTypeW(lpApplicationName *PWSTRElement, lpBinaryType *uint32) (r BOOL, err error)
+//sys	GetShortPathNameA(lpszLongPath *PSTRElement, lpszShortPath *PSTRElement, cchBuffer uint32) (r uint32, err error)
+//sys	GetLongPathNameTransactedA(lpszShortPath *PSTRElement, lpszLongPath *PSTRElement, cchBuffer uint32, hTransaction HANDLE) (r uint32, err error)
+//sys	GetLongPathNameTransactedW(lpszShortPath *PWSTRElement, lpszLongPath *PWSTRElement, cchBuffer uint32, hTransaction HANDLE) (r uint32, err error)
+//sys	SetFileCompletionNotificationModes(FileHandle HANDLE, Flags uint8) (r BOOL, err error)
+//sys	SetFileShortNameA(hFile HANDLE, lpShortName *PSTRElement) (r BOOL, err error)
+//sys	SetFileShortNameW(hFile HANDLE, lpShortName *PWSTRElement) (r BOOL, err error)
+//sys	SetTapePosition(hDevice HANDLE, dwPositionMethod TAPE_POSITION_METHOD, dwPartition uint32, dwOffsetLow uint32, dwOffsetHigh uint32, bImmediate BOOL) (r uint32)
+//sys	GetTapePosition(hDevice HANDLE, dwPositionType TAPE_POSITION_TYPE, lpdwPartition *uint32, lpdwOffsetLow *uint32, lpdwOffsetHigh *uint32) (r uint32)
+//sys	PrepareTape(hDevice HANDLE, dwOperation PREPARE_TAPE_OPERATION, bImmediate BOOL) (r uint32)
+//sys	EraseTape(hDevice HANDLE, dwEraseType ERASE_TAPE_TYPE, bImmediate BOOL) (r uint32)
+//sys	CreateTapePartition(hDevice HANDLE, dwPartitionMethod CREATE_TAPE_PARTITION_METHOD, dwCount uint32, dwSize uint32) (r uint32)
+//sys	WriteTapemark(hDevice HANDLE, dwTapemarkType TAPEMARK_TYPE, dwTapemarkCount uint32, bImmediate BOOL) (r uint32)
+//sys	GetTapeStatus(hDevice HANDLE) (r uint32)
+//sys	GetTapeParameters(hDevice HANDLE, dwOperation GET_TAPE_DRIVE_PARAMETERS_OPERATION, lpdwSize *uint32, lpTapeInformation unsafe.Pointer) (r uint32)
+//sys	SetTapeParameters(hDevice HANDLE, dwOperation TAPE_INFORMATION_TYPE, lpTapeInformation unsafe.Pointer) (r uint32)
+//sys	EncryptFileA(lpFileName *PSTRElement) (r BOOL, err error) = advapi32.EncryptFileA
+//sys	EncryptFileW(lpFileName *PWSTRElement) (r BOOL, err error) = advapi32.EncryptFileW
+//sys	DecryptFileA(lpFileName *PSTRElement, dwReserved uint32) (r BOOL, err error) = advapi32.DecryptFileA
+//sys	DecryptFileW(lpFileName *PWSTRElement, dwReserved uint32) (r BOOL, err error) = advapi32.DecryptFileW
+//sys	FileEncryptionStatusA(lpFileName *PSTRElement, lpStatus *uint32) (r BOOL, err error) = advapi32.FileEncryptionStatusA
+//sys	FileEncryptionStatusW(lpFileName *PWSTRElement, lpStatus *uint32) (r BOOL, err error) = advapi32.FileEncryptionStatusW
+//sys	OpenEncryptedFileRawA(lpFileName *PSTRElement, ulFlags uint32, pvContext *unsafe.Pointer) (r uint32) = advapi32.OpenEncryptedFileRawA
+//sys	OpenEncryptedFileRawW(lpFileName *PWSTRElement, ulFlags uint32, pvContext *unsafe.Pointer) (r uint32) = advapi32.OpenEncryptedFileRawW
+//sys	ReadEncryptedFileRaw(pfExportCallback PFE_EXPORT_FUNC, pvCallbackContext unsafe.Pointer, pvContext unsafe.Pointer) (r uint32) = advapi32.ReadEncryptedFileRaw
+//sys	WriteEncryptedFileRaw(pfImportCallback PFE_IMPORT_FUNC, pvCallbackContext unsafe.Pointer, pvContext unsafe.Pointer) (r uint32) = advapi32.WriteEncryptedFileRaw
+//sys	CloseEncryptedFileRaw(pvContext unsafe.Pointer) = advapi32.CloseEncryptedFileRaw
+//sys	OpenFile(lpFileName *PSTRElement, lpReOpenBuff *OFSTRUCT, uStyle uint32) (r int32, err error)
+//sys	BackupRead(hFile HANDLE, lpBuffer *uint8, nNumberOfBytesToRead uint32, lpNumberOfBytesRead *uint32, bAbort BOOL, bProcessSecurity BOOL, lpContext *unsafe.Pointer) (r BOOL, err error)
+//sys	BackupSeek(hFile HANDLE, dwLowBytesToSeek uint32, dwHighBytesToSeek uint32, lpdwLowByteSeeked *uint32, lpdwHighByteSeeked *uint32, lpContext *unsafe.Pointer) (r BOOL, err error)
+//sys	BackupWrite(hFile HANDLE, lpBuffer *uint8, nNumberOfBytesToWrite uint32, lpNumberOfBytesWritten *uint32, bAbort BOOL, bProcessSecurity BOOL, lpContext *unsafe.Pointer) (r BOOL, err error)
+//sys	GetLogicalDriveStringsA(nBufferLength uint32, lpBuffer *PSTRElement) (r uint32, err error)
+//sys	SetSearchPathMode(Flags uint32) (r BOOL, err error)
+//sys	CreateDirectoryExA(lpTemplateDirectory *PSTRElement, lpNewDirectory *PSTRElement, lpSecurityAttributes *SECURITY_ATTRIBUTES) (r BOOL, err error)
+//sys	CreateDirectoryExW(lpTemplateDirectory *PWSTRElement, lpNewDirectory *PWSTRElement, lpSecurityAttributes *SECURITY_ATTRIBUTES) (r BOOL, err error)
+//sys	CreateDirectoryTransactedA(lpTemplateDirectory *PSTRElement, lpNewDirectory *PSTRElement, lpSecurityAttributes *SECURITY_ATTRIBUTES, hTransaction HANDLE) (r BOOL, err error)
+//sys	CreateDirectoryTransactedW(lpTemplateDirectory *PWSTRElement, lpNewDirectory *PWSTRElement, lpSecurityAttributes *SECURITY_ATTRIBUTES, hTransaction HANDLE) (r BOOL, err error)
+//sys	RemoveDirectoryTransactedA(lpPathName *PSTRElement, hTransaction HANDLE) (r BOOL, err error)
+//sys	RemoveDirectoryTransactedW(lpPathName *PWSTRElement, hTransaction HANDLE) (r BOOL, err error)
+//sys	GetFullPathNameTransactedA(lpFileName *PSTRElement, nBufferLength uint32, lpBuffer *PSTRElement, lpFilePart **PSTRElement, hTransaction HANDLE) (r uint32, err error)
+//sys	GetFullPathNameTransactedW(lpFileName *PWSTRElement, nBufferLength uint32, lpBuffer *PWSTRElement, lpFilePart **PWSTRElement, hTransaction HANDLE) (r uint32, err error)
+//sys	DefineDosDeviceA(dwFlags DEFINE_DOS_DEVICE_FLAGS, lpDeviceName *PSTRElement, lpTargetPath *PSTRElement) (r BOOL, err error)
+//sys	QueryDosDeviceA(lpDeviceName *PSTRElement, lpTargetPath *PSTRElement, ucchMax uint32) (r uint32, err error)
+//sys	CreateFileTransactedA(lpFileName *PSTRElement, dwDesiredAccess uint32, dwShareMode FILE_SHARE_MODE, lpSecurityAttributes *SECURITY_ATTRIBUTES, dwCreationDisposition FILE_CREATION_DISPOSITION, dwFlagsAndAttributes FILE_FLAGS_AND_ATTRIBUTES, hTemplateFile HANDLE, hTransaction HANDLE, pusMiniVersion *TXFS_MINIVERSION, lpExtendedParameter unsafe.Pointer) (r HANDLE, err error)
+//sys	CreateFileTransactedW(lpFileName *PWSTRElement, dwDesiredAccess uint32, dwShareMode FILE_SHARE_MODE, lpSecurityAttributes *SECURITY_ATTRIBUTES, dwCreationDisposition FILE_CREATION_DISPOSITION, dwFlagsAndAttributes FILE_FLAGS_AND_ATTRIBUTES, hTemplateFile HANDLE, hTransaction HANDLE, pusMiniVersion *TXFS_MINIVERSION, lpExtendedParameter unsafe.Pointer) (r HANDLE, err error)
+//sys	ReOpenFile(hOriginalFile HANDLE, dwDesiredAccess uint32, dwShareMode FILE_SHARE_MODE, dwFlagsAndAttributes FILE_FLAGS_AND_ATTRIBUTES) (r HANDLE, err error)
+//sys	SetFileAttributesTransactedA(lpFileName *PSTRElement, dwFileAttributes uint32, hTransaction HANDLE) (r BOOL, err error)
+//sys	SetFileAttributesTransactedW(lpFileName *PWSTRElement, dwFileAttributes uint32, hTransaction HANDLE) (r BOOL, err error)
+//sys	GetFileAttributesTransactedA(lpFileName *PSTRElement, fInfoLevelId GET_FILEEX_INFO_LEVELS, lpFileInformation unsafe.Pointer, hTransaction HANDLE) (r BOOL, err error)
+//sys	GetFileAttributesTransactedW(lpFileName *PWSTRElement, fInfoLevelId GET_FILEEX_INFO_LEVELS, lpFileInformation unsafe.Pointer, hTransaction HANDLE) (r BOOL, err error)
+//sys	GetCompressedFileSizeTransactedA(lpFileName *PSTRElement, lpFileSizeHigh *uint32, hTransaction HANDLE) (r uint32, err error)
+//sys	GetCompressedFileSizeTransactedW(lpFileName *PWSTRElement, lpFileSizeHigh *uint32, hTransaction HANDLE) (r uint32, err error)
+//sys	DeleteFileTransactedA(lpFileName *PSTRElement, hTransaction HANDLE) (r BOOL, err error)
+//sys	DeleteFileTransactedW(lpFileName *PWSTRElement, hTransaction HANDLE) (r BOOL, err error)
+//sys	CheckNameLegalDOS8Dot3A(lpName *PSTRElement, lpOemName *PSTRElement, OemNameSize uint32, pbNameContainsSpaces *BOOL, pbNameLegal *BOOL) (r BOOL, err error)
+//sys	CheckNameLegalDOS8Dot3W(lpName *PWSTRElement, lpOemName *PSTRElement, OemNameSize uint32, pbNameContainsSpaces *BOOL, pbNameLegal *BOOL) (r BOOL, err error)
+//sys	FindFirstFileTransactedA(lpFileName *PSTRElement, fInfoLevelId FINDEX_INFO_LEVELS, lpFindFileData unsafe.Pointer, fSearchOp FINDEX_SEARCH_OPS, lpSearchFilter unsafe.Pointer, dwAdditionalFlags uint32, hTransaction HANDLE) (r HANDLE, err error)
+//sys	FindFirstFileTransactedW(lpFileName *PWSTRElement, fInfoLevelId FINDEX_INFO_LEVELS, lpFindFileData unsafe.Pointer, fSearchOp FINDEX_SEARCH_OPS, lpSearchFilter unsafe.Pointer, dwAdditionalFlags uint32, hTransaction HANDLE) (r HANDLE, err error)
+//sys	CopyFileA(lpExistingFileName *PSTRElement, lpNewFileName *PSTRElement, bFailIfExists BOOL) (r BOOL, err error)
+//sys	CopyFileW(lpExistingFileName *PWSTRElement, lpNewFileName *PWSTRElement, bFailIfExists BOOL) (r BOOL, err error)
+//sys	CopyFileExA(lpExistingFileName *PSTRElement, lpNewFileName *PSTRElement, lpProgressRoutine LPPROGRESS_ROUTINE, lpData unsafe.Pointer, pbCancel *BOOL, dwCopyFlags COPYFILE_FLAGS) (r BOOL, err error)
+//sys	CopyFileExW(lpExistingFileName *PWSTRElement, lpNewFileName *PWSTRElement, lpProgressRoutine LPPROGRESS_ROUTINE, lpData unsafe.Pointer, pbCancel *BOOL, dwCopyFlags COPYFILE_FLAGS) (r BOOL, err error)
+//sys	CopyFileTransactedA(lpExistingFileName *PSTRElement, lpNewFileName *PSTRElement, lpProgressRoutine LPPROGRESS_ROUTINE, lpData unsafe.Pointer, pbCancel *BOOL, dwCopyFlags uint32, hTransaction HANDLE) (r BOOL, err error)
+//sys	CopyFileTransactedW(lpExistingFileName *PWSTRElement, lpNewFileName *PWSTRElement, lpProgressRoutine LPPROGRESS_ROUTINE, lpData unsafe.Pointer, pbCancel *BOOL, dwCopyFlags uint32, hTransaction HANDLE) (r BOOL, err error)
+//sys	CopyFile2(pwszExistingFileName *PWSTRElement, pwszNewFileName *PWSTRElement, pExtendedParameters *COPYFILE2_EXTENDED_PARAMETERS) (r HRESULT)
+//sys	MoveFileA(lpExistingFileName *PSTRElement, lpNewFileName *PSTRElement) (r BOOL, err error)
+//sys	MoveFileW(lpExistingFileName *PWSTRElement, lpNewFileName *PWSTRElement) (r BOOL, err error)
+//sys	MoveFileExA(lpExistingFileName *PSTRElement, lpNewFileName *PSTRElement, dwFlags MOVE_FILE_FLAGS) (r BOOL, err error)
+//sys	MoveFileExW(lpExistingFileName *PWSTRElement, lpNewFileName *PWSTRElement, dwFlags MOVE_FILE_FLAGS) (r BOOL, err error)
+//sys	MoveFileWithProgressA(lpExistingFileName *PSTRElement, lpNewFileName *PSTRElement, lpProgressRoutine LPPROGRESS_ROUTINE, lpData unsafe.Pointer, dwFlags MOVE_FILE_FLAGS) (r BOOL, err error)
+//sys	MoveFileWithProgressW(lpExistingFileName *PWSTRElement, lpNewFileName *PWSTRElement, lpProgressRoutine LPPROGRESS_ROUTINE, lpData unsafe.Pointer, dwFlags MOVE_FILE_FLAGS) (r BOOL, err error)
+//sys	MoveFileTransactedA(lpExistingFileName *PSTRElement, lpNewFileName *PSTRElement, lpProgressRoutine LPPROGRESS_ROUTINE, lpData unsafe.Pointer, dwFlags MOVE_FILE_FLAGS, hTransaction HANDLE) (r BOOL, err error)
+//sys	MoveFileTransactedW(lpExistingFileName *PWSTRElement, lpNewFileName *PWSTRElement, lpProgressRoutine LPPROGRESS_ROUTINE, lpData unsafe.Pointer, dwFlags MOVE_FILE_FLAGS, hTransaction HANDLE) (r BOOL, err error)
+//sys	ReplaceFileA(lpReplacedFileName *PSTRElement, lpReplacementFileName *PSTRElement, lpBackupFileName *PSTRElement, dwReplaceFlags REPLACE_FILE_FLAGS, lpExclude unsafe.Pointer, lpReserved unsafe.Pointer) (r BOOL, err error)
+//sys	ReplaceFileW(lpReplacedFileName *PWSTRElement, lpReplacementFileName *PWSTRElement, lpBackupFileName *PWSTRElement, dwReplaceFlags REPLACE_FILE_FLAGS, lpExclude unsafe.Pointer, lpReserved unsafe.Pointer) (r BOOL, err error)
+//sys	CreateHardLinkA(lpFileName *PSTRElement, lpExistingFileName *PSTRElement, lpSecurityAttributes *SECURITY_ATTRIBUTES) (r BOOL, err error)
+//sys	CreateHardLinkW(lpFileName *PWSTRElement, lpExistingFileName *PWSTRElement, lpSecurityAttributes *SECURITY_ATTRIBUTES) (r BOOL, err error)
+//sys	CreateHardLinkTransactedA(lpFileName *PSTRElement, lpExistingFileName *PSTRElement, lpSecurityAttributes *SECURITY_ATTRIBUTES, hTransaction HANDLE) (r BOOL, err error)
+//sys	CreateHardLinkTransactedW(lpFileName *PWSTRElement, lpExistingFileName *PWSTRElement, lpSecurityAttributes *SECURITY_ATTRIBUTES, hTransaction HANDLE) (r BOOL, err error)
+//sys	FindFirstStreamTransactedW(lpFileName *PWSTRElement, InfoLevel STREAM_INFO_LEVELS, lpFindStreamData unsafe.Pointer, dwFlags uint32, hTransaction HANDLE) (r HANDLE, err error)
+//sys	FindFirstFileNameTransactedW(lpFileName *PWSTRElement, dwFlags uint32, StringLength *uint32, LinkName *PWSTRElement, hTransaction HANDLE) (r HANDLE, err error)
+//sys	SetVolumeLabelA(lpRootPathName *PSTRElement, lpVolumeName *PSTRElement) (r BOOL, err error)
+//sys	SetVolumeLabelW(lpRootPathName *PWSTRElement, lpVolumeName *PWSTRElement) (r BOOL, err error)
+//sys	SetFileBandwidthReservation(hFile HANDLE, nPeriodMilliseconds uint32, nBytesPerPeriod uint32, bDiscardable BOOL, lpTransferSize *uint32, lpNumOutstandingRequests *uint32) (r BOOL, err error)
+//sys	GetFileBandwidthReservation(hFile HANDLE, lpPeriodMilliseconds *uint32, lpBytesPerPeriod *uint32, pDiscardable *BOOL, lpTransferSize *uint32, lpNumOutstandingRequests *uint32) (r BOOL, err error)
+//sys	ReadDirectoryChangesW(hDirectory HANDLE, lpBuffer unsafe.Pointer, nBufferLength uint32, bWatchSubtree BOOL, dwNotifyFilter FILE_NOTIFY_CHANGE, lpBytesReturned *uint32, lpOverlapped *OVERLAPPED, lpCompletionRoutine LPOVERLAPPED_COMPLETION_ROUTINE) (r BOOL, err error)
+//sys	ReadDirectoryChangesExW(hDirectory HANDLE, lpBuffer unsafe.Pointer, nBufferLength uint32, bWatchSubtree BOOL, dwNotifyFilter FILE_NOTIFY_CHANGE, lpBytesReturned *uint32, lpOverlapped *OVERLAPPED, lpCompletionRoutine LPOVERLAPPED_COMPLETION_ROUTINE, ReadDirectoryNotifyInformationClass READ_DIRECTORY_NOTIFY_INFORMATION_CLASS) (r BOOL, err error)
+//sys	FindFirstVolumeA(lpszVolumeName *PSTRElement, cchBufferLength uint32) (r HANDLE, err error)
+//sys	FindNextVolumeA(hFindVolume HANDLE, lpszVolumeName *PSTRElement, cchBufferLength uint32) (r BOOL, err error)
+//sys	FindFirstVolumeMountPointA(lpszRootPathName *PSTRElement, lpszVolumeMountPoint *PSTRElement, cchBufferLength uint32) (r HANDLE, err error)
+//sys	FindFirstVolumeMountPointW(lpszRootPathName *PWSTRElement, lpszVolumeMountPoint *PWSTRElement, cchBufferLength uint32) (r HANDLE, err error)
+//sys	FindNextVolumeMountPointA(hFindVolumeMountPoint HANDLE, lpszVolumeMountPoint *PSTRElement, cchBufferLength uint32) (r BOOL, err error)
+//sys	FindNextVolumeMountPointW(hFindVolumeMountPoint HANDLE, lpszVolumeMountPoint *PWSTRElement, cchBufferLength uint32) (r BOOL, err error)
+//sys	FindVolumeMountPointClose(hFindVolumeMountPoint HANDLE) (r BOOL, err error)
+//sys	SetVolumeMountPointA(lpszVolumeMountPoint *PSTRElement, lpszVolumeName *PSTRElement) (r BOOL, err error)
+//sys	SetVolumeMountPointW(lpszVolumeMountPoint *PWSTRElement, lpszVolumeName *PWSTRElement) (r BOOL, err error)
+//sys	DeleteVolumeMountPointA(lpszVolumeMountPoint *PSTRElement) (r BOOL, err error)
+//sys	GetVolumeNameForVolumeMountPointA(lpszVolumeMountPoint *PSTRElement, lpszVolumeName *PSTRElement, cchBufferLength uint32) (r BOOL, err error)
+//sys	GetVolumePathNameA(lpszFileName *PSTRElement, lpszVolumePathName *PSTRElement, cchBufferLength uint32) (r BOOL, err error)
+//sys	GetVolumePathNamesForVolumeNameA(lpszVolumeName *PSTRElement, lpszVolumePathNames *PSTRElement, cchBufferLength uint32, lpcchReturnLength *uint32) (r BOOL, err error)
+//sys	GetFileInformationByHandleEx(hFile HANDLE, FileInformationClass FILE_INFO_BY_HANDLE_CLASS, lpFileInformation unsafe.Pointer, dwBufferSize uint32) (r BOOL, err error)
+//sys	GetFileInformationByName(FileName *PWSTRElement, FileInformationClass FILE_INFO_BY_NAME_CLASS, FileInfoBuffer unsafe.Pointer, FileInfoBufferSize uint32) (r BOOL)
+//sys	OpenFileById(hVolumeHint HANDLE, lpFileId *FILE_ID_DESCRIPTOR, dwDesiredAccess uint32, dwShareMode FILE_SHARE_MODE, lpSecurityAttributes *SECURITY_ATTRIBUTES, dwFlagsAndAttributes FILE_FLAGS_AND_ATTRIBUTES) (r HANDLE, err error)
+//sys	CreateSymbolicLinkA(lpSymlinkFileName *PSTRElement, lpTargetFileName *PSTRElement, dwFlags SYMBOLIC_LINK_FLAGS) (r BOOLEAN, err error)
+//sys	CreateSymbolicLinkW(lpSymlinkFileName *PWSTRElement, lpTargetFileName *PWSTRElement, dwFlags SYMBOLIC_LINK_FLAGS) (r BOOLEAN, err error)
+//sys	CreateSymbolicLinkTransactedA(lpSymlinkFileName *PSTRElement, lpTargetFileName *PSTRElement, dwFlags SYMBOLIC_LINK_FLAGS, hTransaction HANDLE) (r BOOLEAN, err error)
+//sys	CreateSymbolicLinkTransactedW(lpSymlinkFileName *PWSTRElement, lpTargetFileName *PWSTRElement, dwFlags SYMBOLIC_LINK_FLAGS, hTransaction HANDLE) (r BOOLEAN, err error)
 
 // Types used in generated APIs for
 

--- a/cmd/gowinmd/testdata/prototypes.golden_386.go
+++ b/cmd/gowinmd/testdata/prototypes.golden_386.go
@@ -1,34 +1,34 @@
 
 
 // APIs for Windows.Win32.System.Diagnostics.Debug
-//sys	CheckSumMappedFile(BaseAddress unsafe.Pointer, FileLength uint32, HeaderSum *uint32, CheckSum *uint32) (r *IMAGE_NT_HEADERS32, err error) = imagehlp.dll.CheckSumMappedFile
-//sys	GetImageConfigInformation(LoadedImage *LOADED_IMAGE, ImageConfigInformation *IMAGE_LOAD_CONFIG_DIRECTORY32) (r BOOL, err error) = imagehlp.dll.GetImageConfigInformation
-//sys	SetImageConfigInformation(LoadedImage *LOADED_IMAGE, ImageConfigInformation *IMAGE_LOAD_CONFIG_DIRECTORY32) (r BOOL, err error) = imagehlp.dll.SetImageConfigInformation
-//sys	ImageNtHeader(Base unsafe.Pointer) (r *IMAGE_NT_HEADERS32, err error) = dbghelp.dll.ImageNtHeader
-//sys	ImageRvaToSection(NtHeaders *IMAGE_NT_HEADERS32, Base unsafe.Pointer, Rva uint32) (r *IMAGE_SECTION_HEADER, err error) = dbghelp.dll.ImageRvaToSection
-//sys	ImageRvaToVa(NtHeaders *IMAGE_NT_HEADERS32, Base unsafe.Pointer, Rva uint32, LastRvaSection **IMAGE_SECTION_HEADER) (r unsafe.Pointer, err error) = dbghelp.dll.ImageRvaToVa
-//sys	StackWalk(MachineType uint32, hProcess HANDLE, hThread HANDLE, StackFrame *STACKFRAME, ContextRecord unsafe.Pointer, ReadMemoryRoutine PREAD_PROCESS_MEMORY_ROUTINE, FunctionTableAccessRoutine PFUNCTION_TABLE_ACCESS_ROUTINE, GetModuleBaseRoutine PGET_MODULE_BASE_ROUTINE, TranslateAddress PTRANSLATE_ADDRESS_ROUTINE) (r BOOL) = dbghelp.dll.StackWalk
-//sys	SymEnumerateModules(hProcess HANDLE, EnumModulesCallback PSYM_ENUMMODULES_CALLBACK, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.dll.SymEnumerateModules
-//sys	EnumerateLoadedModules(hProcess HANDLE, EnumLoadedModulesCallback PENUMLOADED_MODULES_CALLBACK, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.dll.EnumerateLoadedModules
-//sys	SymFunctionTableAccess(hProcess HANDLE, AddrBase uint32) (r unsafe.Pointer, err error) = dbghelp.dll.SymFunctionTableAccess
-//sys	SymGetModuleInfo(hProcess HANDLE, dwAddr uint32, ModuleInfo *IMAGEHLP_MODULE) (r BOOL, err error) = dbghelp.dll.SymGetModuleInfo
-//sys	SymGetModuleInfoW(hProcess HANDLE, dwAddr uint32, ModuleInfo *IMAGEHLP_MODULEW) (r BOOL, err error) = dbghelp.dll.SymGetModuleInfoW
-//sys	SymGetModuleBase(hProcess HANDLE, dwAddr uint32) (r uint32, err error) = dbghelp.dll.SymGetModuleBase
-//sys	SymGetLineFromAddr(hProcess HANDLE, dwAddr uint32, pdwDisplacement *uint32, Line *IMAGEHLP_LINE) (r BOOL, err error) = dbghelp.dll.SymGetLineFromAddr
-//sys	SymGetLineFromName(hProcess HANDLE, ModuleName *PSTRElement, FileName *PSTRElement, dwLineNumber uint32, plDisplacement *int32, Line *IMAGEHLP_LINE) (r BOOL, err error) = dbghelp.dll.SymGetLineFromName
-//sys	SymGetLineNext(hProcess HANDLE, Line *IMAGEHLP_LINE) (r BOOL, err error) = dbghelp.dll.SymGetLineNext
-//sys	SymGetLinePrev(hProcess HANDLE, Line *IMAGEHLP_LINE) (r BOOL, err error) = dbghelp.dll.SymGetLinePrev
-//sys	SymUnloadModule(hProcess HANDLE, BaseOfDll uint32) (r BOOL, err error) = dbghelp.dll.SymUnloadModule
-//sys	SymUnDName(sym *IMAGEHLP_SYMBOL, UnDecName *PSTRElement, UnDecNameLength uint32) (r BOOL, err error) = dbghelp.dll.SymUnDName
-//sys	SymRegisterCallback(hProcess HANDLE, CallbackFunction PSYMBOL_REGISTERED_CALLBACK, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.dll.SymRegisterCallback
-//sys	SymRegisterFunctionEntryCallback(hProcess HANDLE, CallbackFunction PSYMBOL_FUNCENTRY_CALLBACK, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.dll.SymRegisterFunctionEntryCallback
-//sys	SymGetSymFromAddr(hProcess HANDLE, dwAddr uint32, pdwDisplacement *uint32, Symbol *IMAGEHLP_SYMBOL) (r BOOL, err error) = dbghelp.dll.SymGetSymFromAddr
-//sys	SymGetSymFromName(hProcess HANDLE, Name *PSTRElement, Symbol *IMAGEHLP_SYMBOL) (r BOOL, err error) = dbghelp.dll.SymGetSymFromName
-//sys	SymEnumerateSymbols(hProcess HANDLE, BaseOfDll uint32, EnumSymbolsCallback PSYM_ENUMSYMBOLS_CALLBACK, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.dll.SymEnumerateSymbols
-//sys	SymEnumerateSymbolsW(hProcess HANDLE, BaseOfDll uint32, EnumSymbolsCallback PSYM_ENUMSYMBOLS_CALLBACKW, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.dll.SymEnumerateSymbolsW
-//sys	SymLoadModule(hProcess HANDLE, hFile HANDLE, ImageName *PSTRElement, ModuleName *PSTRElement, BaseOfDll uint32, SizeOfDll uint32) (r uint32, err error) = dbghelp.dll.SymLoadModule
-//sys	SymGetSymNext(hProcess HANDLE, Symbol *IMAGEHLP_SYMBOL) (r BOOL, err error) = dbghelp.dll.SymGetSymNext
-//sys	SymGetSymPrev(hProcess HANDLE, Symbol *IMAGEHLP_SYMBOL) (r BOOL, err error) = dbghelp.dll.SymGetSymPrev
+//sys	CheckSumMappedFile(BaseAddress unsafe.Pointer, FileLength uint32, HeaderSum *uint32, CheckSum *uint32) (r *IMAGE_NT_HEADERS32, err error) = imagehlp.CheckSumMappedFile
+//sys	GetImageConfigInformation(LoadedImage *LOADED_IMAGE, ImageConfigInformation *IMAGE_LOAD_CONFIG_DIRECTORY32) (r BOOL, err error) = imagehlp.GetImageConfigInformation
+//sys	SetImageConfigInformation(LoadedImage *LOADED_IMAGE, ImageConfigInformation *IMAGE_LOAD_CONFIG_DIRECTORY32) (r BOOL, err error) = imagehlp.SetImageConfigInformation
+//sys	ImageNtHeader(Base unsafe.Pointer) (r *IMAGE_NT_HEADERS32, err error) = dbghelp.ImageNtHeader
+//sys	ImageRvaToSection(NtHeaders *IMAGE_NT_HEADERS32, Base unsafe.Pointer, Rva uint32) (r *IMAGE_SECTION_HEADER, err error) = dbghelp.ImageRvaToSection
+//sys	ImageRvaToVa(NtHeaders *IMAGE_NT_HEADERS32, Base unsafe.Pointer, Rva uint32, LastRvaSection **IMAGE_SECTION_HEADER) (r unsafe.Pointer, err error) = dbghelp.ImageRvaToVa
+//sys	StackWalk(MachineType uint32, hProcess HANDLE, hThread HANDLE, StackFrame *STACKFRAME, ContextRecord unsafe.Pointer, ReadMemoryRoutine PREAD_PROCESS_MEMORY_ROUTINE, FunctionTableAccessRoutine PFUNCTION_TABLE_ACCESS_ROUTINE, GetModuleBaseRoutine PGET_MODULE_BASE_ROUTINE, TranslateAddress PTRANSLATE_ADDRESS_ROUTINE) (r BOOL) = dbghelp.StackWalk
+//sys	SymEnumerateModules(hProcess HANDLE, EnumModulesCallback PSYM_ENUMMODULES_CALLBACK, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.SymEnumerateModules
+//sys	EnumerateLoadedModules(hProcess HANDLE, EnumLoadedModulesCallback PENUMLOADED_MODULES_CALLBACK, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.EnumerateLoadedModules
+//sys	SymFunctionTableAccess(hProcess HANDLE, AddrBase uint32) (r unsafe.Pointer, err error) = dbghelp.SymFunctionTableAccess
+//sys	SymGetModuleInfo(hProcess HANDLE, dwAddr uint32, ModuleInfo *IMAGEHLP_MODULE) (r BOOL, err error) = dbghelp.SymGetModuleInfo
+//sys	SymGetModuleInfoW(hProcess HANDLE, dwAddr uint32, ModuleInfo *IMAGEHLP_MODULEW) (r BOOL, err error) = dbghelp.SymGetModuleInfoW
+//sys	SymGetModuleBase(hProcess HANDLE, dwAddr uint32) (r uint32, err error) = dbghelp.SymGetModuleBase
+//sys	SymGetLineFromAddr(hProcess HANDLE, dwAddr uint32, pdwDisplacement *uint32, Line *IMAGEHLP_LINE) (r BOOL, err error) = dbghelp.SymGetLineFromAddr
+//sys	SymGetLineFromName(hProcess HANDLE, ModuleName *PSTRElement, FileName *PSTRElement, dwLineNumber uint32, plDisplacement *int32, Line *IMAGEHLP_LINE) (r BOOL, err error) = dbghelp.SymGetLineFromName
+//sys	SymGetLineNext(hProcess HANDLE, Line *IMAGEHLP_LINE) (r BOOL, err error) = dbghelp.SymGetLineNext
+//sys	SymGetLinePrev(hProcess HANDLE, Line *IMAGEHLP_LINE) (r BOOL, err error) = dbghelp.SymGetLinePrev
+//sys	SymUnloadModule(hProcess HANDLE, BaseOfDll uint32) (r BOOL, err error) = dbghelp.SymUnloadModule
+//sys	SymUnDName(sym *IMAGEHLP_SYMBOL, UnDecName *PSTRElement, UnDecNameLength uint32) (r BOOL, err error) = dbghelp.SymUnDName
+//sys	SymRegisterCallback(hProcess HANDLE, CallbackFunction PSYMBOL_REGISTERED_CALLBACK, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.SymRegisterCallback
+//sys	SymRegisterFunctionEntryCallback(hProcess HANDLE, CallbackFunction PSYMBOL_FUNCENTRY_CALLBACK, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.SymRegisterFunctionEntryCallback
+//sys	SymGetSymFromAddr(hProcess HANDLE, dwAddr uint32, pdwDisplacement *uint32, Symbol *IMAGEHLP_SYMBOL) (r BOOL, err error) = dbghelp.SymGetSymFromAddr
+//sys	SymGetSymFromName(hProcess HANDLE, Name *PSTRElement, Symbol *IMAGEHLP_SYMBOL) (r BOOL, err error) = dbghelp.SymGetSymFromName
+//sys	SymEnumerateSymbols(hProcess HANDLE, BaseOfDll uint32, EnumSymbolsCallback PSYM_ENUMSYMBOLS_CALLBACK, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.SymEnumerateSymbols
+//sys	SymEnumerateSymbolsW(hProcess HANDLE, BaseOfDll uint32, EnumSymbolsCallback PSYM_ENUMSYMBOLS_CALLBACKW, UserContext unsafe.Pointer) (r BOOL, err error) = dbghelp.SymEnumerateSymbolsW
+//sys	SymLoadModule(hProcess HANDLE, hFile HANDLE, ImageName *PSTRElement, ModuleName *PSTRElement, BaseOfDll uint32, SizeOfDll uint32) (r uint32, err error) = dbghelp.SymLoadModule
+//sys	SymGetSymNext(hProcess HANDLE, Symbol *IMAGEHLP_SYMBOL) (r BOOL, err error) = dbghelp.SymGetSymNext
+//sys	SymGetSymPrev(hProcess HANDLE, Symbol *IMAGEHLP_SYMBOL) (r BOOL, err error) = dbghelp.SymGetSymPrev
 
 // Types used in generated APIs for
 

--- a/cmd/gowinmd/testdata/prototypes.golden_amd64.go
+++ b/cmd/gowinmd/testdata/prototypes.golden_amd64.go
@@ -1,22 +1,22 @@
 
 
 // APIs for Windows.Win32.System.Diagnostics.Debug
-//sys	RtlCaptureContext2(ContextRecord *CONTEXT) = kernel32.dll.RtlCaptureContext2
-//sys	RtlAddFunctionTable(FunctionTable *IMAGE_RUNTIME_FUNCTION_ENTRY, EntryCount uint32, BaseAddress uint64) (r BOOLEAN) = kernel32.dll.RtlAddFunctionTable
-//sys	RtlDeleteFunctionTable(FunctionTable *IMAGE_RUNTIME_FUNCTION_ENTRY) (r BOOLEAN) = kernel32.dll.RtlDeleteFunctionTable
-//sys	RtlInstallFunctionTableCallback(TableIdentifier uint64, BaseAddress uint64, Length uint32, Callback PGET_RUNTIME_FUNCTION_CALLBACK, Context unsafe.Pointer, OutOfProcessCallbackDll *PWSTRElement) (r BOOLEAN) = kernel32.dll.RtlInstallFunctionTableCallback
-//sys	RtlAddGrowableFunctionTable(DynamicTable *unsafe.Pointer, FunctionTable *IMAGE_RUNTIME_FUNCTION_ENTRY, EntryCount uint32, MaximumEntryCount uint32, RangeBase uintptr, RangeEnd uintptr) (r uint32) = ntdll.dll.RtlAddGrowableFunctionTable
-//sys	RtlGrowFunctionTable(DynamicTable unsafe.Pointer, NewEntryCount uint32) = ntdll.dll.RtlGrowFunctionTable
-//sys	RtlDeleteGrowableFunctionTable(DynamicTable unsafe.Pointer) = ntdll.dll.RtlDeleteGrowableFunctionTable
-//sys	RtlLookupFunctionEntry(ControlPc uint64, ImageBase *uint64, HistoryTable *UNWIND_HISTORY_TABLE) (r *IMAGE_RUNTIME_FUNCTION_ENTRY) = kernel32.dll.RtlLookupFunctionEntry
-//sys	RtlUnwindEx(TargetFrame unsafe.Pointer, TargetIp unsafe.Pointer, ExceptionRecord *EXCEPTION_RECORD, ReturnValue unsafe.Pointer, ContextRecord *CONTEXT, HistoryTable *UNWIND_HISTORY_TABLE) = kernel32.dll.RtlUnwindEx
-//sys	RtlVirtualUnwind(HandlerType RTL_VIRTUAL_UNWIND_HANDLER_TYPE, ImageBase uint64, ControlPc uint64, FunctionEntry *IMAGE_RUNTIME_FUNCTION_ENTRY, ContextRecord *CONTEXT, HandlerData *unsafe.Pointer, EstablisherFrame *uint64, ContextPointers *KNONVOLATILE_CONTEXT_POINTERS) (r EXCEPTION_ROUTINE) = kernel32.dll.RtlVirtualUnwind
-//sys	CheckSumMappedFile(BaseAddress unsafe.Pointer, FileLength uint32, HeaderSum *uint32, CheckSum *uint32) (r *IMAGE_NT_HEADERS64, err error) = imagehlp.dll.CheckSumMappedFile
-//sys	GetImageConfigInformation(LoadedImage *LOADED_IMAGE, ImageConfigInformation *IMAGE_LOAD_CONFIG_DIRECTORY64) (r BOOL, err error) = imagehlp.dll.GetImageConfigInformation
-//sys	SetImageConfigInformation(LoadedImage *LOADED_IMAGE, ImageConfigInformation *IMAGE_LOAD_CONFIG_DIRECTORY64) (r BOOL, err error) = imagehlp.dll.SetImageConfigInformation
-//sys	ImageNtHeader(Base unsafe.Pointer) (r *IMAGE_NT_HEADERS64, err error) = dbghelp.dll.ImageNtHeader
-//sys	ImageRvaToSection(NtHeaders *IMAGE_NT_HEADERS64, Base unsafe.Pointer, Rva uint32) (r *IMAGE_SECTION_HEADER, err error) = dbghelp.dll.ImageRvaToSection
-//sys	ImageRvaToVa(NtHeaders *IMAGE_NT_HEADERS64, Base unsafe.Pointer, Rva uint32, LastRvaSection **IMAGE_SECTION_HEADER) (r unsafe.Pointer, err error) = dbghelp.dll.ImageRvaToVa
+//sys	RtlCaptureContext2(ContextRecord *CONTEXT)
+//sys	RtlAddFunctionTable(FunctionTable *IMAGE_RUNTIME_FUNCTION_ENTRY, EntryCount uint32, BaseAddress uint64) (r BOOLEAN)
+//sys	RtlDeleteFunctionTable(FunctionTable *IMAGE_RUNTIME_FUNCTION_ENTRY) (r BOOLEAN)
+//sys	RtlInstallFunctionTableCallback(TableIdentifier uint64, BaseAddress uint64, Length uint32, Callback PGET_RUNTIME_FUNCTION_CALLBACK, Context unsafe.Pointer, OutOfProcessCallbackDll *PWSTRElement) (r BOOLEAN)
+//sys	RtlAddGrowableFunctionTable(DynamicTable *unsafe.Pointer, FunctionTable *IMAGE_RUNTIME_FUNCTION_ENTRY, EntryCount uint32, MaximumEntryCount uint32, RangeBase uintptr, RangeEnd uintptr) (r uint32) = ntdll.RtlAddGrowableFunctionTable
+//sys	RtlGrowFunctionTable(DynamicTable unsafe.Pointer, NewEntryCount uint32) = ntdll.RtlGrowFunctionTable
+//sys	RtlDeleteGrowableFunctionTable(DynamicTable unsafe.Pointer) = ntdll.RtlDeleteGrowableFunctionTable
+//sys	RtlLookupFunctionEntry(ControlPc uint64, ImageBase *uint64, HistoryTable *UNWIND_HISTORY_TABLE) (r *IMAGE_RUNTIME_FUNCTION_ENTRY)
+//sys	RtlUnwindEx(TargetFrame unsafe.Pointer, TargetIp unsafe.Pointer, ExceptionRecord *EXCEPTION_RECORD, ReturnValue unsafe.Pointer, ContextRecord *CONTEXT, HistoryTable *UNWIND_HISTORY_TABLE)
+//sys	RtlVirtualUnwind(HandlerType RTL_VIRTUAL_UNWIND_HANDLER_TYPE, ImageBase uint64, ControlPc uint64, FunctionEntry *IMAGE_RUNTIME_FUNCTION_ENTRY, ContextRecord *CONTEXT, HandlerData *unsafe.Pointer, EstablisherFrame *uint64, ContextPointers *KNONVOLATILE_CONTEXT_POINTERS) (r EXCEPTION_ROUTINE)
+//sys	CheckSumMappedFile(BaseAddress unsafe.Pointer, FileLength uint32, HeaderSum *uint32, CheckSum *uint32) (r *IMAGE_NT_HEADERS64, err error) = imagehlp.CheckSumMappedFile
+//sys	GetImageConfigInformation(LoadedImage *LOADED_IMAGE, ImageConfigInformation *IMAGE_LOAD_CONFIG_DIRECTORY64) (r BOOL, err error) = imagehlp.GetImageConfigInformation
+//sys	SetImageConfigInformation(LoadedImage *LOADED_IMAGE, ImageConfigInformation *IMAGE_LOAD_CONFIG_DIRECTORY64) (r BOOL, err error) = imagehlp.SetImageConfigInformation
+//sys	ImageNtHeader(Base unsafe.Pointer) (r *IMAGE_NT_HEADERS64, err error) = dbghelp.ImageNtHeader
+//sys	ImageRvaToSection(NtHeaders *IMAGE_NT_HEADERS64, Base unsafe.Pointer, Rva uint32) (r *IMAGE_SECTION_HEADER, err error) = dbghelp.ImageRvaToSection
+//sys	ImageRvaToVa(NtHeaders *IMAGE_NT_HEADERS64, Base unsafe.Pointer, Rva uint32, LastRvaSection **IMAGE_SECTION_HEADER) (r unsafe.Pointer, err error) = dbghelp.ImageRvaToVa
 
 // Types used in generated APIs for
 

--- a/cmd/gowinmd/testdata/prototypes.golden_arm64.go
+++ b/cmd/gowinmd/testdata/prototypes.golden_arm64.go
@@ -1,21 +1,21 @@
 
 
 // APIs for Windows.Win32.System.Diagnostics.Debug
-//sys	RtlAddFunctionTable(FunctionTable *IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY, EntryCount uint32, BaseAddress uintptr) (r BOOLEAN) = kernel32.dll.RtlAddFunctionTable
-//sys	RtlDeleteFunctionTable(FunctionTable *IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY) (r BOOLEAN) = kernel32.dll.RtlDeleteFunctionTable
-//sys	RtlInstallFunctionTableCallback(TableIdentifier uint64, BaseAddress uint64, Length uint32, Callback PGET_RUNTIME_FUNCTION_CALLBACK, Context unsafe.Pointer, OutOfProcessCallbackDll *PWSTRElement) (r BOOLEAN) = kernel32.dll.RtlInstallFunctionTableCallback
-//sys	RtlAddGrowableFunctionTable(DynamicTable *unsafe.Pointer, FunctionTable *IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY, EntryCount uint32, MaximumEntryCount uint32, RangeBase uintptr, RangeEnd uintptr) (r uint32) = ntdll.dll.RtlAddGrowableFunctionTable
-//sys	RtlLookupFunctionEntry(ControlPc uintptr, ImageBase *uintptr, HistoryTable *UNWIND_HISTORY_TABLE) (r *IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY) = kernel32.dll.RtlLookupFunctionEntry
-//sys	RtlVirtualUnwind(HandlerType RTL_VIRTUAL_UNWIND_HANDLER_TYPE, ImageBase uintptr, ControlPc uintptr, FunctionEntry *IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY, ContextRecord *CONTEXT, HandlerData *unsafe.Pointer, EstablisherFrame *uintptr, ContextPointers *KNONVOLATILE_CONTEXT_POINTERS) (r EXCEPTION_ROUTINE) = kernel32.dll.RtlVirtualUnwind
-//sys	RtlGrowFunctionTable(DynamicTable unsafe.Pointer, NewEntryCount uint32) = ntdll.dll.RtlGrowFunctionTable
-//sys	RtlDeleteGrowableFunctionTable(DynamicTable unsafe.Pointer) = ntdll.dll.RtlDeleteGrowableFunctionTable
-//sys	RtlUnwindEx(TargetFrame unsafe.Pointer, TargetIp unsafe.Pointer, ExceptionRecord *EXCEPTION_RECORD, ReturnValue unsafe.Pointer, ContextRecord *CONTEXT, HistoryTable *UNWIND_HISTORY_TABLE) = kernel32.dll.RtlUnwindEx
-//sys	CheckSumMappedFile(BaseAddress unsafe.Pointer, FileLength uint32, HeaderSum *uint32, CheckSum *uint32) (r *IMAGE_NT_HEADERS64, err error) = imagehlp.dll.CheckSumMappedFile
-//sys	GetImageConfigInformation(LoadedImage *LOADED_IMAGE, ImageConfigInformation *IMAGE_LOAD_CONFIG_DIRECTORY64) (r BOOL, err error) = imagehlp.dll.GetImageConfigInformation
-//sys	SetImageConfigInformation(LoadedImage *LOADED_IMAGE, ImageConfigInformation *IMAGE_LOAD_CONFIG_DIRECTORY64) (r BOOL, err error) = imagehlp.dll.SetImageConfigInformation
-//sys	ImageNtHeader(Base unsafe.Pointer) (r *IMAGE_NT_HEADERS64, err error) = dbghelp.dll.ImageNtHeader
-//sys	ImageRvaToSection(NtHeaders *IMAGE_NT_HEADERS64, Base unsafe.Pointer, Rva uint32) (r *IMAGE_SECTION_HEADER, err error) = dbghelp.dll.ImageRvaToSection
-//sys	ImageRvaToVa(NtHeaders *IMAGE_NT_HEADERS64, Base unsafe.Pointer, Rva uint32, LastRvaSection **IMAGE_SECTION_HEADER) (r unsafe.Pointer, err error) = dbghelp.dll.ImageRvaToVa
+//sys	RtlAddFunctionTable(FunctionTable *IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY, EntryCount uint32, BaseAddress uintptr) (r BOOLEAN)
+//sys	RtlDeleteFunctionTable(FunctionTable *IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY) (r BOOLEAN)
+//sys	RtlInstallFunctionTableCallback(TableIdentifier uint64, BaseAddress uint64, Length uint32, Callback PGET_RUNTIME_FUNCTION_CALLBACK, Context unsafe.Pointer, OutOfProcessCallbackDll *PWSTRElement) (r BOOLEAN)
+//sys	RtlAddGrowableFunctionTable(DynamicTable *unsafe.Pointer, FunctionTable *IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY, EntryCount uint32, MaximumEntryCount uint32, RangeBase uintptr, RangeEnd uintptr) (r uint32) = ntdll.RtlAddGrowableFunctionTable
+//sys	RtlLookupFunctionEntry(ControlPc uintptr, ImageBase *uintptr, HistoryTable *UNWIND_HISTORY_TABLE) (r *IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY)
+//sys	RtlVirtualUnwind(HandlerType RTL_VIRTUAL_UNWIND_HANDLER_TYPE, ImageBase uintptr, ControlPc uintptr, FunctionEntry *IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY, ContextRecord *CONTEXT, HandlerData *unsafe.Pointer, EstablisherFrame *uintptr, ContextPointers *KNONVOLATILE_CONTEXT_POINTERS) (r EXCEPTION_ROUTINE)
+//sys	RtlGrowFunctionTable(DynamicTable unsafe.Pointer, NewEntryCount uint32) = ntdll.RtlGrowFunctionTable
+//sys	RtlDeleteGrowableFunctionTable(DynamicTable unsafe.Pointer) = ntdll.RtlDeleteGrowableFunctionTable
+//sys	RtlUnwindEx(TargetFrame unsafe.Pointer, TargetIp unsafe.Pointer, ExceptionRecord *EXCEPTION_RECORD, ReturnValue unsafe.Pointer, ContextRecord *CONTEXT, HistoryTable *UNWIND_HISTORY_TABLE)
+//sys	CheckSumMappedFile(BaseAddress unsafe.Pointer, FileLength uint32, HeaderSum *uint32, CheckSum *uint32) (r *IMAGE_NT_HEADERS64, err error) = imagehlp.CheckSumMappedFile
+//sys	GetImageConfigInformation(LoadedImage *LOADED_IMAGE, ImageConfigInformation *IMAGE_LOAD_CONFIG_DIRECTORY64) (r BOOL, err error) = imagehlp.GetImageConfigInformation
+//sys	SetImageConfigInformation(LoadedImage *LOADED_IMAGE, ImageConfigInformation *IMAGE_LOAD_CONFIG_DIRECTORY64) (r BOOL, err error) = imagehlp.SetImageConfigInformation
+//sys	ImageNtHeader(Base unsafe.Pointer) (r *IMAGE_NT_HEADERS64, err error) = dbghelp.ImageNtHeader
+//sys	ImageRvaToSection(NtHeaders *IMAGE_NT_HEADERS64, Base unsafe.Pointer, Rva uint32) (r *IMAGE_SECTION_HEADER, err error) = dbghelp.ImageRvaToSection
+//sys	ImageRvaToVa(NtHeaders *IMAGE_NT_HEADERS64, Base unsafe.Pointer, Rva uint32, LastRvaSection **IMAGE_SECTION_HEADER) (r unsafe.Pointer, err error) = dbghelp.ImageRvaToVa
 
 // Types used in generated APIs for
 


### PR DESCRIPTION
## Summary

- add an opt-in `-projection idiomatic` mode while retaining raw ABI output by default
- normalize mkwinsyscall DLL targets, project metadata-backed pointer/count pairs to slices, map `NTSTATUS` to the supported error convention, and emit normal UTF-16 element pointers
- preserve exact function naming, duplicate metadata constants, transitive types, and architecture-specific layouts
- document projection behavior and regenerate raw golden output

## Compatibility

The default remains `-projection raw`. Idiomatic slice projection is limited to explicit `NativeArrayInfoAttribute` or `MemorySizeAttribute` associations that mkwinsyscall can reproduce without changing ABI argument order. APIs requiring a non-nil pointer for an empty buffer can continue using raw declarations and handwritten wrappers.

## Validation

- `go test ./...`
- `go test ./cmd/gowinmd -update`
- `git diff --check`
- generated the BCrypt integration fixture through `golang.org/x/sys/windows/mkwinsyscall v0.47.0` and verified pointer/length argument order, nil-on-empty slices, UTF-16 pointers, and NTSTATUS conversion