### PR TITLE
Add getwinmd metadata downloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 
 A Windows Metadata (a.k.a. winmd) parser written in Go and based on the ECMA-335 6th edition standard.
 
+## Commands
+
+- [`gowinmd`](cmd/gowinmd) generates Go declarations from WinMD metadata.
+- [`getwinmd`](cmd/getwinmd) downloads `Windows.Win32.winmd` from the
+  `Microsoft.Windows.SDK.Win32Metadata` NuGet package.
+
 ## Development References
 
 These resources are useful as reference while working on the go-winmd module:

--- a/cmd/getwinmd/README.md
+++ b/cmd/getwinmd/README.md
@@ -1,0 +1,34 @@
+# getwinmd
+
+`getwinmd` downloads `Windows.Win32.winmd` from the
+[`Microsoft.Windows.SDK.Win32Metadata`](https://www.nuget.org/packages/Microsoft.Windows.SDK.Win32Metadata)
+NuGet package.
+
+## Usage
+
+```text
+getwinmd [-version <NuGet version>] [-output <path>]
+```
+
+- `-version` selects an exact NuGet package version. When omitted, the latest version in NuGet's
+  package feed is used, including prerelease versions.
+- `-output` selects the destination file. The default is `Windows.Win32.winmd` in the current
+  directory.
+
+Download the latest metadata:
+
+```sh
+go run github.com/microsoft/go-winmd/cmd/getwinmd@latest
+```
+
+Download a specific version:
+
+```sh
+go run github.com/microsoft/go-winmd/cmd/getwinmd@latest \
+  -version 71.0.20-preview \
+  -output Windows.Win32.winmd
+```
+
+The command downloads the NuGet archive, locates `Windows.Win32.winmd` inside it, and extracts only
+that file. It does not validate the package against a separately maintained checksum; selecting an
+exact package version provides reproducible metadata content.

--- a/cmd/getwinmd/main.go
+++ b/cmd/getwinmd/main.go
@@ -1,0 +1,249 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Command getwinmd downloads Windows.Win32.winmd from NuGet.
+package main
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/xml"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	packageID             = "Microsoft.Windows.SDK.Win32Metadata"
+	metadataFileName      = "Windows.Win32.winmd"
+	defaultVersionFeedURL = "https://www.nuget.org/packages/" + packageID + "/atom.xml"
+	defaultPackageBaseURL = "https://www.nuget.org/api/v2/package/" + packageID
+	maxPackageSize        = int64(128 << 20)
+	maxMetadataSize       = int64(256 << 20)
+)
+
+func main() {
+	client := &http.Client{Timeout: 5 * time.Minute}
+	if err := run(context.Background(), os.Args[1:], os.Stdout, os.Stderr, client, nugetEndpoints{
+		versionFeedURL: defaultVersionFeedURL,
+		packageBaseURL: defaultPackageBaseURL,
+	}); err != nil {
+		log.Fatal(err)
+	}
+}
+
+type nugetEndpoints struct {
+	versionFeedURL string
+	packageBaseURL string
+}
+
+func run(ctx context.Context, args []string, stdout, stderr io.Writer, client *http.Client, endpoints nugetEndpoints) error {
+	flags := flag.NewFlagSet("getwinmd", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	version := flags.String("version", "", "NuGet package version (latest if omitted)")
+	output := flags.String("output", metadataFileName, "output WinMD file")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("unexpected arguments: %s", strings.Join(flags.Args(), " "))
+	}
+	if strings.TrimSpace(*output) == "" {
+		return errors.New("output path must not be empty")
+	}
+
+	resolvedVersion := strings.TrimSpace(*version)
+	if resolvedVersion == "" {
+		var err error
+		resolvedVersion, err = latestVersion(ctx, client, endpoints.versionFeedURL)
+		if err != nil {
+			return err
+		}
+	}
+	if strings.ContainsAny(resolvedVersion, `/\\`) {
+		return fmt.Errorf("invalid package version %q", resolvedVersion)
+	}
+
+	packageData, err := downloadPackage(ctx, client, endpoints.packageBaseURL, resolvedVersion)
+	if err != nil {
+		return err
+	}
+	if err := extractMetadata(packageData, *output); err != nil {
+		return err
+	}
+	fmt.Fprintf(stdout, "Downloaded %s %s to %s\n", packageID, resolvedVersion, *output)
+	return nil
+}
+
+type atomFeed struct {
+	Entries []atomEntry `xml:"entry"`
+}
+
+type atomEntry struct {
+	ID string `xml:"id"`
+}
+
+func latestVersion(ctx context.Context, client *http.Client, versionFeedURL string) (string, error) {
+	response, err := get(ctx, client, versionFeedURL)
+	if err != nil {
+		return "", fmt.Errorf("resolve latest %s version: %w", packageID, err)
+	}
+	defer response.Body.Close()
+
+	var feed atomFeed
+	if err := xml.NewDecoder(response.Body).Decode(&feed); err != nil {
+		return "", fmt.Errorf("decode %s version feed: %w", packageID, err)
+	}
+	// NuGet's package Atom feed is ordered from newest to oldest.
+	for _, entry := range feed.Entries {
+		entryURL, err := url.Parse(strings.TrimSpace(entry.ID))
+		if err != nil {
+			continue
+		}
+		version, err := url.PathUnescape(path.Base(strings.TrimSuffix(entryURL.Path, "/")))
+		if err == nil && version != "" && version != "." {
+			return version, nil
+		}
+	}
+	return "", fmt.Errorf("NuGet returned no versions for %s", packageID)
+}
+
+func downloadPackage(ctx context.Context, client *http.Client, packageBaseURL, version string) ([]byte, error) {
+	normalizedVersion := strings.ToLower(version)
+	escapedVersion := url.PathEscape(normalizedVersion)
+	packageURL := strings.TrimRight(packageBaseURL, "/") + "/" + escapedVersion
+	response, err := get(ctx, client, packageURL)
+	if err != nil {
+		return nil, fmt.Errorf("download %s %s: %w", packageID, version, err)
+	}
+	defer response.Body.Close()
+
+	data, err := io.ReadAll(io.LimitReader(response.Body, maxPackageSize+1))
+	if err != nil {
+		return nil, fmt.Errorf("read %s %s: %w", packageID, version, err)
+	}
+	if int64(len(data)) > maxPackageSize {
+		return nil, fmt.Errorf("%s %s exceeds the %d-byte download limit", packageID, version, maxPackageSize)
+	}
+	return data, nil
+}
+
+func get(ctx context.Context, client *http.Client, address string) (*http.Response, error) {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, address, nil)
+	if err != nil {
+		return nil, err
+	}
+	request.Header.Set("User-Agent", "go-winmd/getwinmd")
+	response, err := client.Do(request)
+	if err != nil {
+		return nil, err
+	}
+	if response.StatusCode != http.StatusOK {
+		defer response.Body.Close()
+		message, _ := io.ReadAll(io.LimitReader(response.Body, 4<<10))
+		return nil, fmt.Errorf("GET %s: %s%s", address, response.Status, formatResponseMessage(message))
+	}
+	return response, nil
+}
+
+func formatResponseMessage(message []byte) string {
+	trimmed := strings.TrimSpace(string(message))
+	if trimmed == "" {
+		return ""
+	}
+	return ": " + trimmed
+}
+
+func extractMetadata(packageData []byte, output string) error {
+	archive, err := zip.NewReader(bytes.NewReader(packageData), int64(len(packageData)))
+	if err != nil {
+		return fmt.Errorf("open NuGet package: %w", err)
+	}
+	metadata, err := findMetadata(archive.File)
+	if err != nil {
+		return err
+	}
+	if metadata.UncompressedSize64 > uint64(maxMetadataSize) {
+		return fmt.Errorf("%s exceeds the %d-byte extraction limit", metadata.Name, maxMetadataSize)
+	}
+
+	reader, err := metadata.Open()
+	if err != nil {
+		return fmt.Errorf("open %s in NuGet package: %w", metadata.Name, err)
+	}
+	defer reader.Close()
+
+	directory := filepath.Dir(output)
+	if err := os.MkdirAll(directory, 0o755); err != nil {
+		return fmt.Errorf("create output directory: %w", err)
+	}
+	temporary, err := os.CreateTemp(directory, "."+filepath.Base(output)+"-*")
+	if err != nil {
+		return fmt.Errorf("create temporary output: %w", err)
+	}
+	temporaryName := temporary.Name()
+	defer os.Remove(temporaryName)
+
+	written, copyErr := io.Copy(temporary, io.LimitReader(reader, maxMetadataSize+1))
+	if copyErr != nil {
+		temporary.Close()
+		return fmt.Errorf("extract %s: %w", metadata.Name, copyErr)
+	}
+	if written > maxMetadataSize {
+		temporary.Close()
+		return fmt.Errorf("%s exceeds the %d-byte extraction limit", metadata.Name, maxMetadataSize)
+	}
+	if err := temporary.Chmod(0o644); err != nil {
+		temporary.Close()
+		return fmt.Errorf("set output permissions: %w", err)
+	}
+	if err := temporary.Close(); err != nil {
+		return fmt.Errorf("close temporary output: %w", err)
+	}
+	if err := replaceFile(temporaryName, output); err != nil {
+		return fmt.Errorf("write %s: %w", output, err)
+	}
+	return nil
+}
+
+func findMetadata(files []*zip.File) (*zip.File, error) {
+	var matches []*zip.File
+	for _, file := range files {
+		if file.FileInfo().IsDir() || !strings.EqualFold(path.Base(file.Name), metadataFileName) {
+			continue
+		}
+		matches = append(matches, file)
+	}
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("%s not found in %s package", metadataFileName, packageID)
+	}
+	if len(matches) == 1 {
+		return matches[0], nil
+	}
+	for _, file := range matches {
+		if file.Name == metadataFileName {
+			return file, nil
+		}
+	}
+	return nil, fmt.Errorf("multiple %s files found in %s package", metadataFileName, packageID)
+}
+
+func replaceFile(source, destination string) error {
+	if err := os.Rename(source, destination); err == nil {
+		return nil
+	}
+	if err := os.Remove(destination); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return os.Rename(source, destination)
+}

--- a/cmd/getwinmd/main_test.go
+++ b/cmd/getwinmd/main_test.go
@@ -1,0 +1,179 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunDownloadsExplicitVersion(t *testing.T) {
+	packageData := makePackage(t, map[string][]byte{
+		"metadata/Windows.Win32.winmd": []byte("explicit metadata"),
+	})
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/package/1.2.3-preview" {
+			t.Errorf("request path = %q; want explicit package path", request.URL.Path)
+			http.NotFound(response, request)
+			return
+		}
+		response.Write(packageData)
+	}))
+	defer server.Close()
+
+	output := filepath.Join(t.TempDir(), "metadata", metadataFileName)
+	if err := os.MkdirAll(filepath.Dir(output), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(output, []byte("old metadata"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr strings.Builder
+	err := run(context.Background(), []string{"-version", "1.2.3-Preview", "-output", output}, &stdout, &stderr, server.Client(), nugetEndpoints{
+		versionFeedURL: server.URL + "/atom.xml",
+		packageBaseURL: server.URL + "/package",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q; want empty", stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "1.2.3-Preview") {
+		t.Fatalf("stdout = %q; want resolved version", stdout.String())
+	}
+	got, err := os.ReadFile(output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "explicit metadata" {
+		t.Fatalf("output = %q; want explicit metadata", got)
+	}
+}
+
+func TestRunDownloadsLatestVersion(t *testing.T) {
+	packageData := makePackage(t, map[string][]byte{
+		metadataFileName: []byte("latest metadata"),
+	})
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/atom.xml":
+			io.WriteString(response, `<feed xmlns="http://www.w3.org/2005/Atom"><entry><id>https://www.nuget.org/packages/`+packageID+`/2.0.0-preview</id></entry><entry><id>https://www.nuget.org/packages/`+packageID+`/1.0.0</id></entry></feed>`)
+		case "/package/2.0.0-preview":
+			response.Write(packageData)
+		default:
+			http.NotFound(response, request)
+		}
+	}))
+	defer server.Close()
+
+	output := filepath.Join(t.TempDir(), metadataFileName)
+	var stdout, stderr strings.Builder
+	if err := run(context.Background(), []string{"-output", output}, &stdout, &stderr, server.Client(), nugetEndpoints{
+		versionFeedURL: server.URL + "/atom.xml",
+		packageBaseURL: server.URL + "/package",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout.String(), "2.0.0-preview") {
+		t.Fatalf("stdout = %q; want latest version", stdout.String())
+	}
+	got, err := os.ReadFile(output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "latest metadata" {
+		t.Fatalf("output = %q; want latest metadata", got)
+	}
+}
+
+func TestLatestVersionRejectsEmptyIndex(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		io.WriteString(response, `<feed xmlns="http://www.w3.org/2005/Atom"></feed>`)
+	}))
+	defer server.Close()
+
+	_, err := latestVersion(context.Background(), server.Client(), server.URL)
+	if err == nil || !strings.Contains(err.Error(), "no versions") {
+		t.Fatalf("latestVersion() error = %v; want no versions error", err)
+	}
+}
+
+func TestRunReportsHTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		http.Error(response, "not available", http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	err := run(context.Background(), []string{"-version", "1.0.0"}, io.Discard, io.Discard, server.Client(), nugetEndpoints{
+		versionFeedURL: server.URL + "/atom.xml",
+		packageBaseURL: server.URL + "/package",
+	})
+	if err == nil || !strings.Contains(err.Error(), "404 Not Found") || !strings.Contains(err.Error(), "not available") {
+		t.Fatalf("run() error = %v; want HTTP status and response", err)
+	}
+}
+
+func TestExtractMetadataRejectsMissingFile(t *testing.T) {
+	packageData := makePackage(t, map[string][]byte{"README.md": []byte("no metadata")})
+	err := extractMetadata(packageData, filepath.Join(t.TempDir(), metadataFileName))
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("extractMetadata() error = %v; want not found error", err)
+	}
+}
+
+func TestFindMetadataPrefersArchiveRoot(t *testing.T) {
+	packageData := makePackage(t, map[string][]byte{
+		metadataFileName:                []byte("root"),
+		"duplicate/Windows.Win32.winmd": []byte("duplicate"),
+	})
+	archive, err := zip.NewReader(bytes.NewReader(packageData), int64(len(packageData)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	file, err := findMetadata(archive.File)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if file.Name != metadataFileName {
+		t.Fatalf("findMetadata() = %q; want root file", file.Name)
+	}
+}
+
+func TestRunRejectsUnexpectedArguments(t *testing.T) {
+	err := run(context.Background(), []string{"unexpected"}, io.Discard, io.Discard, http.DefaultClient, nugetEndpoints{
+		versionFeedURL: "https://example.invalid/atom.xml",
+		packageBaseURL: "https://example.invalid/package",
+	})
+	if err == nil || !strings.Contains(err.Error(), "unexpected arguments") {
+		t.Fatalf("run() error = %v; want unexpected arguments error", err)
+	}
+}
+
+func makePackage(t *testing.T, files map[string][]byte) []byte {
+	t.Helper()
+	var buffer bytes.Buffer
+	archive := zip.NewWriter(&buffer)
+	for name, contents := range files {
+		file, err := archive.Create(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := file.Write(contents); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := archive.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buffer.Bytes()
+}


### PR DESCRIPTION
## Summary

- add `cmd/getwinmd` to download `Windows.Win32.winmd` from the Microsoft Win32Metadata NuGet package
- resolve the latest package from NuGet when `-version` is omitted, while supporting exact version selection
- search and extract only the WinMD payload without maintaining a separate checksum
- document the command and cover latest, explicit-version, extraction, overwrite, and error behavior

## Validation

- `go test -race -count=1 ./cmd/getwinmd`
- `go test -count=1 ./...`
- `go vet ./...`
- cross-compiled getwinmd tests for Windows 386, amd64, and arm64
- downloaded the real latest NuGet package (`71.0.20-preview`) and parsed the result with `gowinmd`
- downloaded `71.0.20-preview` explicitly and byte-compared it with the latest result