### PR TITLE
Use Go 1.26 language and library features

### DIFF
--- a/cmd/gowinmd/internal/gowinmd/abilayout.go
+++ b/cmd/gowinmd/internal/gowinmd/abilayout.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"sort"
+	"slices"
 
 	"github.com/microsoft/go-winmd/winmd"
 )
@@ -180,7 +180,7 @@ func (c *Context) discoverABILayoutDependencies() error {
 		if len(indices) == 0 {
 			return nil
 		}
-		sort.Slice(indices, func(i, j int) bool { return indices[i] < indices[j] })
+		slices.Sort(indices)
 		for _, index := range indices {
 			discovered[index] = true
 			def, err := c.resolveTypeDef(index)
@@ -306,7 +306,7 @@ func (c *Context) sigTypeABITypeLayout(sig *winmd.SigType, arch Arch, visiting m
 			return abiTypeLayout{}, err
 		}
 		count := uint64(1)
-		for dimension := 0; dimension < int(array.Rank); dimension++ {
+		for dimension := range int(array.Rank) {
 			if dimension >= len(array.Sizes) {
 				return abiTypeLayout{}, errors.New("variable-length array fields are not representable in Go")
 			}

--- a/cmd/gowinmd/internal/gowinmd/gowinmd.go
+++ b/cmd/gowinmd/internal/gowinmd/gowinmd.go
@@ -6,12 +6,13 @@
 package gowinmd
 
 import (
+	"cmp"
 	"encoding/binary"
 	"errors"
 	"fmt"
 	"go/token"
 	"io"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -807,7 +808,7 @@ func (c *Context) writeType(w io.StringWriter, p *winmd.SigType, arch Arch) erro
 				markVisited(p)
 				return visitType(&v)
 			case winmd.SigArray:
-				for i := 0; i < int(v.Rank); i++ {
+				for i := range int(v.Rank) {
 					if i < len(v.Sizes) {
 						w.WriteString("[" + strconv.Itoa(int(v.Sizes[i])) + "]")
 					} else {
@@ -1287,8 +1288,8 @@ func (c *Context) WriteUsedTypeDefs(b map[Arch]*strings.Builder) error {
 			break
 		}
 		// Order is scrambled due to the map. Put it back in some order.
-		sort.Slice(usedTypeDefs, func(i, j int) bool {
-			return usedTypeDefs[i].Index < usedTypeDefs[j].Index
+		slices.SortFunc(usedTypeDefs, func(a, b *resolvedDef) int {
+			return cmp.Compare(a.Index, b.Index)
 		})
 		for _, r := range usedTypeDefs {
 			// Writing the type def (field types in particular) adds new entries to ResolvedDefs if

--- a/cmd/gowinmd/main.go
+++ b/cmd/gowinmd/main.go
@@ -12,8 +12,9 @@ import (
 	"go/parser"
 	"go/token"
 	"log"
+	"maps"
 	"os"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -280,11 +281,7 @@ func writeSelectionsWithProjection(b map[gowinmd.Arch]*strings.Builder, f *winmd
 	if err != nil {
 		return err
 	}
-	qualifiedNames := make([]string, 0, len(selectedTypes))
-	for qualifiedName := range selectedTypes {
-		qualifiedNames = append(qualifiedNames, qualifiedName)
-	}
-	sort.Strings(qualifiedNames)
+	qualifiedNames := slices.Sorted(maps.Keys(selectedTypes))
 	for _, qualifiedName := range qualifiedNames {
 		selection := selectedTypes[qualifiedName]
 		if err := context.SelectTypeDef(selection.Namespace, selection.Name, selection.GoName); err != nil {

--- a/cmd/gowinmd/main_test.go
+++ b/cmd/gowinmd/main_test.go
@@ -467,14 +467,14 @@ func TestWriteBCryptTypesGolden(t *testing.T) {
 		t.Fatalf("generated %d files; want common, 386, amd64, and arm64 files", len(first))
 	}
 	commonTypeNames := make(map[string]bool)
-	for _, line := range strings.Split(first[gowinmd.ArchAll], "\n") {
+	for line := range strings.SplitSeq(first[gowinmd.ArchAll], "\n") {
 		fields := strings.Fields(line)
 		if len(fields) >= 2 && fields[0] == "type" {
 			commonTypeNames[fields[1]] = true
 		}
 	}
 	for _, arch := range []gowinmd.Arch{gowinmd.Arch386, gowinmd.ArchAMD64, gowinmd.ArchARM64} {
-		for _, line := range strings.Split(first[arch], "\n") {
+		for line := range strings.SplitSeq(first[arch], "\n") {
 			fields := strings.Fields(line)
 			if len(fields) >= 2 && fields[0] == "type" && commonTypeNames[fields[1]] {
 				t.Fatalf("type %s was emitted in both common and %s output", fields[1], arch)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/microsoft/go-winmd
 
-go 1.25.0
+go 1.26
 
 require golang.org/x/tools v0.43.0
 

--- a/winmd/file.go
+++ b/winmd/file.go
@@ -122,7 +122,7 @@ func readMetadataDirectory(pefile *pe.File, pe64 bool) (pe.DataDirectory, error)
 		return pe.DataDirectory{}, fmt.Errorf("failure to seek to the COM descriptor data directory root: %v", err)
 	}
 
-	read := func(data interface{}) bool {
+	read := func(data any) bool {
 		err = binary.Read(r, binary.LittleEndian, data)
 		return err == nil
 	}
@@ -166,7 +166,7 @@ func readMetadata(pefile *pe.File, rva uint32) (string, []*heap, error) {
 		return "", nil, fmt.Errorf("failure to seek to the metadata root: %v", err)
 	}
 
-	read := func(data interface{}) bool {
+	read := func(data any) bool {
 		err = binary.Read(r, binary.LittleEndian, data)
 		return err == nil
 	}
@@ -248,7 +248,7 @@ func readMetadata(pefile *pe.File, rva uint32) (string, []*heap, error) {
 	// common case is to have just 5.
 	streams := make([]*heap, 0, 5)
 	streamNames := make(map[string]struct{}, 5)
-	for i := 0; i < int(streamsCount); i++ {
+	for i := range int(streamsCount) {
 		// the stream header is defined in §II.24.2.2.
 		var s struct {
 			Offset uint32

--- a/winmd/genlayout.go
+++ b/winmd/genlayout.go
@@ -24,6 +24,7 @@ package main
 
 import (
 	"bytes"
+	"cmp"
 	"fmt"
 	"go/ast"
 	"go/format"
@@ -32,7 +33,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -93,16 +94,17 @@ import "fmt"
 func writeTableValues(w io.Writer, tables []tableInfo) {
 	// Sort tables by its code so the table
 	// values are defined in a nice-looking increasing order.
-	sorted := make([]struct {
+	type tableValue struct {
 		name  string
 		value uint8
-	}, len(tables))
+	}
+	sorted := make([]tableValue, len(tables))
 	for i, t := range tables {
 		sorted[i].name = t.tableName
 		sorted[i].value = t.code
 	}
-	sort.Slice(sorted, func(i, j int) bool {
-		return sorted[i].value < sorted[j].value
+	slices.SortFunc(sorted, func(a, b tableValue) int {
+		return cmp.Compare(a.value, b.value)
 	})
 
 	fmt.Fprintf(w, "// Define table enum\n")
@@ -364,7 +366,7 @@ func parseTable(pkg *packages.Package, spec *ast.TypeSpec) (info tableInfo) {
 	info.name = spec.Name.Name
 	info.exported = spec.Name.IsExported()
 	info.fields = make([]columnInfo, 0, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		f := t.Field(i)
 		var col columnInfo
 		tp := f.Type()
@@ -445,8 +447,7 @@ func tableCode(decl *ast.GenDecl) *uint8 {
 			if err != nil {
 				log.Panic(err)
 			}
-			v := uint8(code)
-			return &v
+			return new(uint8(code))
 		}
 	}
 	return nil

--- a/winmd/layout.go
+++ b/winmd/layout.go
@@ -32,18 +32,18 @@ func generateLayout(heapSizes uint8, tableRowCounts [tableMax]uint32) *layout {
 	la.stringSize, la.guidSize, la.blobSize = heapIndexSize(heapSizes)
 
 	// Simple index column sizes only depend on the number of rows of the referenced table.
-	for e := table(0); e < tableMax; e++ {
+	for e := range tableMax {
 		la.simpleSizes[e] = simpleIndexSize(e, tableRowCounts)
 	}
 
 	// Coded index column sizes depend on the maximum number of rows in the set of allowed tables to reference.
-	for e := codedKind(0); e < codedMax; e++ {
+	for e := range codedMax {
 		la.codedSizes[e] = codedIndexSize(e, tableRowCounts)
 	}
 
 	// We now have all the static and dynamic information to calculate the size of each table column.
 	var offset int
-	for t := table(0); t < tableMax; t++ {
+	for t := range tableMax {
 		rowCount := tableRowCounts[t]
 		if rowCount == 0 {
 			continue
@@ -272,7 +272,7 @@ func (r *sigReader) methodDefSig() (v SigMethodDef) {
 	if r.err != nil {
 		return
 	}
-	for i := uint32(0); i < paramCount; i++ {
+	for range paramCount {
 		v.Param = append(v.Param, r.param())
 		if r.err != nil {
 			return
@@ -418,14 +418,14 @@ func (r *sigReader) array() (a SigArray) {
 		return
 	}
 	a.Sizes = make([]uint32, r.compressedUint32())
-	for i := 0; i < len(a.Sizes); i++ {
+	for i := range a.Sizes {
 		a.Sizes[i] = r.compressedUint32()
 	}
 	if r.err != nil {
 		return
 	}
 	a.LowerBounds = make([]int32, r.compressedUint32())
-	for i := 0; i < len(a.LowerBounds); i++ {
+	for i := range a.LowerBounds {
 		a.LowerBounds[i] = r.compressedInt32()
 	}
 	return

--- a/winmd/saferio.go
+++ b/winmd/saferio.go
@@ -36,10 +36,7 @@ func readData(r io.Reader, n uint64) ([]byte, error) {
 	var buf []byte
 	buf1 := make([]byte, chunk)
 	for n > 0 {
-		next := n
-		if next > chunk {
-			next = chunk
-		}
+		next := min(n, chunk)
 		_, err := io.ReadFull(r, buf1[:next])
 		if err != nil {
 			if len(buf) > 0 && err == io.EOF {


### PR DESCRIPTION
## Summary
- update the module to Go 1.26
- apply Go modernizers and adopt type-safe maps/slices APIs
- use iterator and range syntax plus initialized new expressions where they simplify existing code

## Testing
- go test ./...
- go run genlayout.go from winmd